### PR TITLE
Update integrate-with-inference-sdks.md to fix broken links

### DIFF
--- a/docs/how-to/integrate-with-inference-sdks.md
+++ b/docs/how-to/integrate-with-inference-sdks.md
@@ -42,7 +42,7 @@ response = client.chat.completions.create(
 
 print(response.choices[0].message.content)
 ```
-Check out the streaming example [here](./includes/integrate-examples/python.md).
+Check out the streaming example [here](../includes/integrate-examples/python.md).
 
 ### REST API
 
@@ -65,7 +65,7 @@ curl http://localhost:5272/v1/chat/completions \
   }'
 ```
 
-Check out the streaming example [here](./includes/integrate-examples/rest.md).
+Check out the streaming example [here](../includes/integrate-examples/rest.md).
 
 ### JavaScript
 
@@ -94,7 +94,7 @@ async function generateText() {
 generateText();
 ```
 
-Check out the streaming example [here](./includes/integrate-examples/javascript.md).
+Check out the streaming example [here](../includes/integrate-examples/javascript.md).
 
 ### C#
 
@@ -127,7 +127,7 @@ Response<ChatCompletions> response = await client.GetChatCompletionsAsync(
 Console.WriteLine(response.Value.Choices[0].Message.Content);
 ```
 
-Check out the streaming example [here](./includes/integrate-examples/csharp.md).
+Check out the streaming example [here](../includes/integrate-examples/csharp.md).
 
 ## Best Practices
 


### PR DESCRIPTION
Links to streaming examples mapped to a path that didn't exist