### PR TITLE
Fixup workflow so it runs cargo fmts in the sub directories.

### DIFF
--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,4 +1,4 @@
-name: rustfmt
+name: Rust-fmt
 
 on:
   pull_request:
@@ -21,5 +21,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Update toolchain
         run: rustup update --no-self-update stable && rustup default stable
-      - name: Check
+      - name: Check SDK
+        working-directory: sdk/rust
+        run: cargo fmt --all -- --check
+      - name: Check Samples
+        working-directory: samples
         run: cargo fmt --all -- --check

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -10,7 +10,7 @@ on:
       - 'sdk/rust/**'
       - 'samples/rust/**'
     branches:
-      - main
+      - user/chendrixson/rust-workflows
 
 jobs:
   check:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -10,7 +10,8 @@ on:
       - 'sdk/rust/**'
       - 'samples/rust/**'
     branches:
-      - user/chendrixson/rust-workflows
+      - main
+  workflow_dispatch:
 
 jobs:
   check:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,0 +1,24 @@
+name: rustfmt
+
+on:
+  pull_request:
+    paths:
+      - 'sdk/rust/**'
+      - 'samples/rust/**'
+  push:
+    paths:
+      - 'sdk/rust/**'
+      - 'samples/rust/**'
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Update toolchain
+        run: rustup update --no-self-update stable && rustup default stable
+      - name: Check
+        run: cargo fmt --all -- --check

--- a/samples/rust/Cargo.toml
+++ b/samples/rust/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = [
+    "hello-foundry-local"
+]
+resolver = "2"

--- a/samples/rust/hello-foundry-local/src/main.rs
+++ b/samples/rust/hello-foundry-local/src/main.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<()> {
     // Create a FoundryLocalManager instance using the builder pattern
     println!("\nInitializing Foundry Local manager...");
     let mut manager = FoundryLocalManager::builder()
-        .bootstrap(true)  // Start the service if not running
+        .bootstrap(true) // Start the service if not running
         .build()
         .await?;
 


### PR DESCRIPTION
Chose to add a cargo.toml file in the samples directory and cargo fmt in both places rather than having a top level cargo.toml workspace file.  Better to keep the root cleaner.