### PR TITLE
Improving error handling in download progress

### DIFF
--- a/sdk/cs/src/FoundryLocalManager.cs
+++ b/sdk/cs/src/FoundryLocalManager.cs
@@ -289,7 +289,13 @@ public partial class FoundryLocalManager : IDisposable, IAsyncDisposable
             yield break;
         }
 
-        var modelInfo = await GetModelInfoAsync(aliasOrModelId, ct) ?? throw new InvalidOperationException($"Model {aliasOrModelId} not found in catalog.");
+        var modelInfo = await GetModelInfoAsync(aliasOrModelId, ct).ConfigureAwait(false);
+        if (modelInfo is null)
+        {
+            yield return ModelDownloadProgress.Error($"Model '{aliasOrModelId}' was not found in the catalogue");
+            yield break;
+        }
+
         var localModels = await ListCachedModelsAsync(ct);
         if (localModels.Any(m => m.ModelId == aliasOrModelId || m.Alias == aliasOrModelId) && !force.GetValueOrDefault(false))
         {


### PR DESCRIPTION
Rather than throwing an exception it will yield an error status, which means that you can handle it in the consistent control flow of the app
