### PR TITLE
Add C# sample projects using MEAI and Semantic Kernel for chat completions with foundry local

### DIFF
--- a/samples/cs/FoundryLocal-01-MEAI-Chat/FoundryLocal-02-MEAI-Chat.csproj
+++ b/samples/cs/FoundryLocal-01-MEAI-Chat/FoundryLocal-02-MEAI-Chat.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net9.0</TargetFramework>
+		<RootNamespace>AIFoundryLocal_01_MEAI_Chat</RootNamespace>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.AI" Version="9.5.0" />
+		<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.5.0-preview.1.25265.7" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.5" />
+	</ItemGroup>
+</Project>

--- a/samples/cs/FoundryLocal-01-MEAI-Chat/Program.cs
+++ b/samples/cs/FoundryLocal-01-MEAI-Chat/Program.cs
@@ -1,0 +1,28 @@
+﻿using OpenAI;
+using OpenAI.Chat;
+using System.ClientModel;
+using System.Text;
+
+var model = "Phi-3.5-mini-instruct-cuda-gpu";
+var baseUrl = "http://localhost:5273/v1";
+var apiKey = "unused";
+
+OpenAIClientOptions options = new OpenAIClientOptions();
+options.Endpoint = new Uri(baseUrl);
+ApiKeyCredential credential = new ApiKeyCredential(apiKey);
+
+ChatClient client = new OpenAIClient(credential, options).GetChatClient(model);
+
+// here we're building the prompt
+StringBuilder prompt = new StringBuilder();
+prompt.AppendLine("You will analyze the sentiment of the following product reviews. Each line is its own review. Output the sentiment of each review in a bulleted list and then provide a generate sentiment of all reviews. ");
+prompt.AppendLine("I bought this product and it's amazing. I love it!");
+prompt.AppendLine("This product is terrible. I hate it.");
+prompt.AppendLine("I'm not sure about this product. It's okay.");
+prompt.AppendLine("I found this product based on the other reviews. It worked for a bit, and then it didn't.");
+
+// send the prompt to the model and wait for the text completion
+var response = await client.CompleteChatAsync(prompt.ToString());
+
+// display the response
+Console.WriteLine(response.Value.Content[0].Text);

--- a/samples/cs/FoundryLocal-01-SK-Chat/FoundryLocal-01-SK-Chat.csproj
+++ b/samples/cs/FoundryLocal-01-SK-Chat/FoundryLocal-01-SK-Chat.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net9.0</TargetFramework>
+		<RootNamespace>AIFoundryLocal_01_SK_Chat</RootNamespace>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.5" />
+		<PackageReference Include="Microsoft.SemanticKernel" Version="1.55.0" />
+	</ItemGroup>
+
+</Project>

--- a/samples/cs/FoundryLocal-01-SK-Chat/Program.cs
+++ b/samples/cs/FoundryLocal-01-SK-Chat/Program.cs
@@ -1,0 +1,46 @@
+﻿#pragma warning disable SKEXP0001, SKEXP0003, SKEXP0010, SKEXP0011, SKEXP0050, SKEXP0052
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using System.Text;
+
+var model = "Phi-3.5-mini-instruct-cuda-gpu";
+var baseUrl = "http://localhost:5273/v1";
+var apiKey = "unused";
+
+// Create a chat completion service
+var kernel = Kernel.CreateBuilder()
+    .AddOpenAIChatCompletion(modelId: model, apiKey: apiKey, endpoint: new Uri(baseUrl))
+    .Build();
+
+var chat = kernel.GetRequiredService<IChatCompletionService>();
+var history = new ChatHistory();
+history.AddSystemMessage("You are a useful chatbot. Always reply in a funny way with short answers.");
+
+var settings = new OpenAIPromptExecutionSettings
+{
+    MaxTokens = 50000,
+    Temperature = 1
+};
+
+while (true)
+{
+    Console.Write("Q: ");
+    var userQuestion = Console.ReadLine();
+    if (string.IsNullOrWhiteSpace(userQuestion))
+    {
+        break;
+    }
+    history.AddUserMessage(userQuestion);
+
+    var responseBuilder = new StringBuilder();
+    Console.Write("AI: ");
+    await foreach (var message in chat.GetStreamingChatMessageContentsAsync(history, settings, kernel))
+    {
+        responseBuilder.Append(message.Content);
+        Console.Write(message.Content);
+    }
+    Console.WriteLine();
+
+    history.AddAssistantMessage(responseBuilder.ToString());
+}

--- a/samples/cs/csharp_samples.sln
+++ b/samples/cs/csharp_samples.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35514.174
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FoundryLocal-02-MEAI-Chat", "FoundryLocal-01-MEAI-Chat\FoundryLocal-02-MEAI-Chat.csproj", "{414BA593-8F67-4B48-C9BD-B5941B8D26D8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FoundryLocal-01-SK-Chat", "FoundryLocal-01-SK-Chat\FoundryLocal-01-SK-Chat.csproj", "{46EAA046-C8D9-94DF-40D6-920B3A68162C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{414BA593-8F67-4B48-C9BD-B5941B8D26D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{414BA593-8F67-4B48-C9BD-B5941B8D26D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{414BA593-8F67-4B48-C9BD-B5941B8D26D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{414BA593-8F67-4B48-C9BD-B5941B8D26D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{46EAA046-C8D9-94DF-40D6-920B3A68162C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{46EAA046-C8D9-94DF-40D6-920B3A68162C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{46EAA046-C8D9-94DF-40D6-920B3A68162C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{46EAA046-C8D9-94DF-40D6-920B3A68162C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {961EEBAB-4149-4AA4-BEE7-9DAAE4C94133}
+	EndGlobalSection
+EndGlobal

--- a/samples/cs/readme.md
+++ b/samples/cs/readme.md
@@ -1,0 +1,48 @@
+# Foundry Local .NET Samples
+
+This folder contains sample projects demonstrating how to use [Foundry Local](https://github.com/microsoft/foundry-local) with .NET.
+
+## Projects in this Solution
+
+- **FoundryLocal-01-MEAI-Chat**
+  - Demonstrates chat completion using Foundry Local and the MEAI SDK.
+  - Project file: `FoundryLocal-01-MEAI-Chat/FoundryLocal-02-MEAI-Chat.csproj`
+
+- **FoundryLocal-01-SK-Chat**
+  - Demonstrates chat completion using Foundry Local and Semantic Kernel.
+  - Project file: `FoundryLocal-01-SK-Chat/FoundryLocal-01-SK-Chat.csproj`
+
+## Prerequisites
+
+To run these samples, you need:
+
+- [.NET 8 SDK or higher](https://dotnet.microsoft.com/en-us/download/dotnet)
+- **Foundry Local** installed and running on your machine
+- A downloaded local model, such as Phi-3.5
+
+### Installing Foundry Local
+
+Follow the [Foundry Local installation guide](../../README.md#installing) to set up Foundry Local on your machine. After installation, download a supported model (e.g., phi-3.5) and configure Foundry Local to use it.
+
+## How to Run the Samples
+
+1. Ensure Foundry Local is running and a model is loaded (e.g., phi-3.5).
+
+1. Open one of the sample project's folder in your terminal.
+
+1. Run a sample project. For example, to run the MEAI Chat sample:
+
+   ```bash
+   dotnet run --project FoundryLocal-01-MEAI-Chat/FoundryLocal-02-MEAI-Chat.csproj
+   ```
+
+   Or to run the Semantic Kernel Chat sample:
+
+   ```bash
+   dotnet run --project FoundryLocal-01-SK-Chat/FoundryLocal-01-SK-Chat.csproj
+   ```
+
+## References
+
+- [Sample code using Foundry Local with .NET](https://aka.ms/genainet)
+- [Foundry Local GitHub](https://github.com/microsoft/foundry-local)


### PR DESCRIPTION
This pull request introduces two new C# sample projects demonstrating chat completion functionality using Foundry Local with different SDKs, updates the solution file to include these projects, and provides documentation for running the samples. Below are the most important changes grouped by theme:

### New Sample Projects

* Added `FoundryLocal-01-MEAI-Chat` project to demonstrate chat completion using Foundry Local and the MEAI SDK. Includes project file `FoundryLocal-01-MEAI-Chat/FoundryLocal-02-MEAI-Chat.csproj` and implementation in `Program.cs`. [[1]](diffhunk://#diff-8a4f8c2dfea26094d72e991225d88c31b15561e7029a7709a27d90ff1efd081aR1-R17) [[2]](diffhunk://#diff-83dab8cb78c7a07241aa31793729945fb5b83e11ae8ec2199eb8e3fb6bfd4b92R1-R28)
* Added `FoundryLocal-01-SK-Chat` project to demonstrate chat completion using Foundry Local and Semantic Kernel. Includes project file `FoundryLocal-01-SK-Chat/FoundryLocal-01-SK-Chat.csproj` and implementation in `Program.cs`. [[1]](diffhunk://#diff-f8126c7a6d844da3238c519173b0100a84443e8efde54f56616939d031b225a0R1-R16) [[2]](diffhunk://#diff-70dfd0f00661fbb2c9cfc54430e6c188817858dff8f36fa73a865e9dcad2dbe1R1-R46)

### Solution File Updates

* Updated `csharp_samples.sln` to include the new sample projects, enabling them to be built and run as part of the solution.

### Documentation Updates

* Added a `readme.md` file in the `samples/cs/` directory to provide an overview of the sample projects, prerequisites, and instructions for running them.