### PR TITLE
[WIP] Add  upgrade and upgradeable APIs to JS and Python SDKs

### DIFF
--- a/sdk/js/src/base.ts
+++ b/sdk/js/src/base.ts
@@ -278,7 +278,9 @@ export class FoundryLocalManager {
    * @returns {Promise<boolean>} True if a newer version is available, otherwise false.
    */
   async isModelUpgradable(aliasOrModelId: string): Promise<boolean> {
-    const response = await client.get(this.fetch, `${this.serviceUrl}/openai/upgradable/${aliasOrModelId}`)
+    const modelInfo = (await this.getModelInfo(aliasOrModelId, true)) as FoundryModelInfo
+
+    const response = await client.get(this.fetch, `${this.serviceUrl}/openai/upgradable/${modelInfo.id}`)
     const data = await response.json()
     return data.upgradable
   }
@@ -301,7 +303,7 @@ export class FoundryLocalManager {
       Name: modelInfo.id,
       Uri: modelInfo.uri,
       Publisher: modelInfo.publisher,
-      ProviderType: modelInfo.provider === 'AzureFoundry' ? `${modelInfo.provider}Local` : modelInfo.provider,
+      ProviderType: modelInfo.provider === 'AzureFoundry' ? `AzureFoundryLocal` : modelInfo.provider,
       PromptTemplate: modelInfo.promptTemplate,
     }
 

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -219,3 +219,33 @@ export interface DownloadBody {
    */
   PromptTemplate: Record<string, string>
 }
+
+/**
+ * Interface representing the body of an upgrade request.
+ */
+export interface UpgradeBody {
+  /**
+   * The name of the model.
+   */
+  Name: string
+
+  /**
+   * The URI of the model.
+   */
+  Uri: string
+
+  /**
+   * The publisher of the model.
+   */
+  Publisher: string
+
+  /**
+   * The provider type of the model.
+   */
+  ProviderType: string
+
+  /**
+   * The prompt template associated with the model.
+   */
+  PromptTemplate: Record<string, string>
+}


### PR DESCRIPTION
This depends on the `/openai/upgradable/` and `/openai/upgrade` endpoints being available in FL.