### PR TITLE
SDK: Remove open ai from dev dependencies

### DIFF
--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -21,7 +21,6 @@
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-jsdoc": "^46.8.2",
         "genversion": "^3.2.0",
-        "openai": "^5.22.1",
         "prettier": "^3.2.4",
         "typescript": "^5.2.2",
         "unbuild": "^3.5.0",
@@ -4829,28 +4828,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/openai": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.22.1.tgz",
-      "integrity": "sha512-nzjcbqcSKxMAkTzNbtqKxrAq1jrG2txRshLZEflL3uZsgzGb22nVjbJscqTOSHGxbUWlYbISKHaUudA5Z1eutg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/optionator": {

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -44,7 +44,6 @@
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-jsdoc": "^46.8.2",
     "genversion": "^3.2.0",
-    "openai": "^5.22.1",
     "prettier": "^3.2.4",
     "typescript": "^5.2.2",
     "unbuild": "^3.5.0",

--- a/sdk/python/requirements-dev.txt
+++ b/sdk/python/requirements-dev.txt
@@ -1,5 +1,4 @@
 -r requirements.txt
 build
 coverage
-openai
 pytest


### PR DESCRIPTION
openai package is only required for integration testing. 