### PR TITLE
Fix README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,18 @@ Foundry Local brings the power of Azure AI Foundry to your local device **withou
 
 1. **Install Foundry Local:**
 
-   - **Windows**: Install Foundry Local for your architecture (x64 or arm64):
+- **Windows**: Install Foundry Local for your architecture (x64 or arm64):
 
-     ```bash
-       winget install Microsoft.FoundryLocal
-     ```
+  ```bash
+  winget install Microsoft.FoundryLocal
+  ```
 
 - **MacOS**: Open a terminal and run the following command:
-  `bash
-    brew install microsoft/foundrylocal/foundrylocal
-    `
+  
+  ```bash
+  brew install microsoft/foundrylocal/foundrylocal
+  ```
+  
   Alternatively, you can download the installers from the [releases page](https://github.com/microsoft/Foundry-Local/releases) and follow the on-screen installation instructions.
 
 > [!TIP]


### PR DESCRIPTION
This PR fixes some formatting issues related to the MacOS install instructions. At the same time, it tidies up the Windows instructions that come just before.

The current README looks like this. Notice that the MacOS instructions are poorly formatted and start with `bash`:

<img width="866" height="295" alt="image" src="https://github.com/user-attachments/assets/d7e496f8-0dbc-4f2f-98c5-f2d1c5bb11ff" />

The PR fixes this and the result is as follows:

<img width="1036" height="362" alt="image" src="https://github.com/user-attachments/assets/e4c01e71-96df-4fc9-9970-4879c70a94a0" />
