### PR TITLE
Fix ModelManagementExample: use MaxTokens (not N) to limit output length

### DIFF
--- a/samples/cs/GettingStarted/src/ModelManagementExample/Program.cs
+++ b/samples/cs/GettingStarted/src/ModelManagementExample/Program.cs
@@ -124,7 +124,7 @@ List<ChatMessage> messages = new()
 
 // You can adjust settings on the chat client
 chatClient.Settings.Temperature = 0.7f;
-chatClient.Settings.N = 512;
+chatClient.Settings.MaxTokens = 512;
 
 Console.WriteLine("Chat completion response:");
 var streamingResponse = chatClient.CompleteChatStreamingAsync(messages, ct);


### PR DESCRIPTION
This PR corrects a likely configuration error. The SDK documentation for `OpenAIChatClient.ChatSettings` defines `N` as “Number of parallel completions to request” and `MaxTokens` as “Maximum number of output tokens to generate”, so `MaxTokens` is the correct control for output length.

issue #353 

### Background
`OpenAIChatClient.ChatSettings` exposes both:
- `MaxTokens`: maximum number of output tokens to generate
- `N`: number of parallel completions (choices) to request

The current sample sets:
- `chatClient.Settings.N = 512;`

### Problem
Setting `N = 512` requests 512 parallel completions, which is not an output-length limit. In this sample, the streaming loop only prints `chunk.Choices[0]`, meaning the additional requested completions are unused. This can:
- dramatically increase compute/memory/time requirements,
- increase the chance of backend rejection/limits being hit,
- mislead readers into thinking `N` controls output token budget.