### PR TITLE
feat(www): unhide whisper models and display as SDK-only

### DIFF
--- a/www/src/routes/models/components/ModelCard.svelte
+++ b/www/src/routes/models/components/ModelCard.svelte
@@ -88,6 +88,10 @@
 	$: uniqueVariants = sortVariantsByDevice(getUniqueVariants());
 	$: displayDescription = generateModelDescription(model);
 	$: genericModelName = getGenericModelName();
+	$: isSpeechToText = model.taskType?.toLowerCase().includes('automatic-speech-recognition') || 
+		model.taskType?.toLowerCase().includes('speech-to-text') ||
+		model.alias?.toLowerCase().includes('whisper') ||
+		model.displayName?.toLowerCase().includes('whisper');
 </script>
 
 <div use:animate={{ delay: 0, duration: 600, animation: 'fade-in', once: true }} class="flex">
@@ -189,7 +193,37 @@
 
 			<!-- Copy Run Command Section -->
 			<div class="border-border/40 border-t pt-3">
-				{#if uniqueVariants.length > 0}
+				{#if isSpeechToText}
+					<!-- SDK Only Notice for Speech-to-Text Models -->
+					<div class="space-y-2">
+						<div class="bg-gradient-to-r from-violet-500/10 to-purple-500/10 rounded-lg p-3 border border-violet-500/20">
+							<div class="flex items-center gap-2 mb-2">
+								<svg class="size-4 text-violet-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+								</svg>
+								<span class="text-xs font-semibold text-violet-600 dark:text-violet-400">SDK Only</span>
+							</div>
+							<div class="font-mono text-xs text-muted-foreground mb-2">
+								Model ID: <span class="text-foreground font-medium">{genericModelName}</span>
+							</div>
+							<a
+								href="https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-local/how-to/how-to-transcribe-audio?view=foundry-classic&tabs=windows"
+								target="_blank"
+								rel="noopener noreferrer"
+								onclick={(e) => e.stopPropagation()}
+								class="inline-flex items-center gap-1.5 text-xs font-medium text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 transition-colors"
+							>
+								<svg class="size-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+								</svg>
+								View SDK Documentation
+								<svg class="size-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+								</svg>
+							</a>
+						</div>
+					</div>
+				{:else if uniqueVariants.length > 0}
 					<div class="space-y-1.5">
 						<div class="text-xs font-medium text-gray-600 dark:text-gray-400">
 							Copy Run Command:


### PR DESCRIPTION
- Remove filter that hid automatic-speech-recognition models
- Add whisper model detection by name/alias in addition to taskType
- Group all whisper variants (tiny, base, large, turbo) into single card
- Display SDK-only notice with documentation link for speech-to-text models
- Update deduplication logic to preserve different whisper sizes as variants