### PR TITLE
feat(www): unhide whisper models and display as SDK-only with code cleanup

### DIFF
--- a/www/src/lib/utils/model-helpers.ts
+++ b/www/src/lib/utils/model-helpers.ts
@@ -1,163 +1,111 @@
+// Device icon mapping
+const DEVICE_ICONS: Record<string, string> = {
+    npu: '🧠',
+    gpu: '🎮',
+    cpu: '💻'
+};
+
 export function getDeviceIcon(device: string): string {
-    const icons: Record<string, string> = {
-        npu: '🧠',
-        gpu: '🎮',
-        cpu: '💻'
-    };
-    return icons[device.toLowerCase()] || '🔧';
+    return DEVICE_ICONS[device.toLowerCase()] || '🔧';
 }
+
+// Accelerator logo patterns and paths
+const ACCELERATOR_LOGO_PATTERNS: Array<{ patterns: string[]; logo: string }> = [
+    { patterns: ['-cuda-', '-cuda', '-tensorrt-', '-tensorrt', '-trt-rtx-', '-trt-rtx', '-trtrtx'], logo: '/logos/nvidia-logo.svg' },
+    { patterns: ['-qnn-', '-qnn'], logo: '/logos/qualcomm-logo.svg' },
+    { patterns: ['-vitis-', '-vitis', '-vitisai'], logo: '/logos/amd-logo.svg' },
+    { patterns: ['-openvino-', '-openvino'], logo: '/logos/intel-logo.svg' },
+    { patterns: ['-webgpu-', '-webgpu', 'webgpu', '-generic-gpu'], logo: '/logos/webgpu-logo.svg' }
+];
 
 export function getAcceleratorLogo(variantName: string): string | null {
     const name = variantName.toLowerCase();
-
-    // NVIDIA (CUDA, TensorRT)
-    if (
-        name.includes('-cuda-') ||
-        name.includes('-cuda') ||
-        name.includes('-tensorrt-') ||
-        name.includes('-tensorrt') ||
-        name.includes('-trt-rtx-') ||
-        name.includes('-trt-rtx') ||
-        name.includes('-trtrtx')
-    ) {
-        return '/logos/nvidia-logo.svg';
+    for (const { patterns, logo } of ACCELERATOR_LOGO_PATTERNS) {
+        if (patterns.some(pattern => name.includes(pattern))) {
+            return logo;
+        }
     }
-
-    // Qualcomm (QNN)
-    if (name.includes('-qnn-') || name.includes('-qnn')) {
-        return '/logos/qualcomm-logo.svg';
-    }
-
-    // AMD (Vitis)
-    if (name.includes('-vitis-') || name.includes('-vitis') || name.includes('-vitisai')) {
-        return '/logos/amd-logo.svg';
-    }
-
-    // Intel (OpenVINO)
-    if (name.includes('-openvino-') || name.includes('-openvino')) {
-        return '/logos/intel-logo.svg';
-    }
-
-    // WebGPU (check for webgpu OR generic-gpu)
-    if (
-        name.includes('-webgpu-') ||
-        name.includes('-webgpu') ||
-        name.includes('webgpu') ||
-        name.includes('-generic-gpu')
-    ) {
-        return '/logos/webgpu-logo.svg';
-    }
-
     return null;
 }
 
+// Accelerator color patterns
+const ACCELERATOR_COLOR_PATTERNS: Array<{ patterns: string[]; color: string }> = [
+    { patterns: ['-cuda-', '-cuda', '-tensorrt-', '-tensorrt', '-trt-rtx-', '-trt-rtx', '-trtrtx'], color: '#76B900' },
+    { patterns: ['-qnn-', '-qnn'], color: '#3253DC' },
+    { patterns: ['-vitis-', '-vitis', '-vitisai'], color: 'var(--amd-color, #000000)' },
+    { patterns: ['-openvino-', '-openvino'], color: '#0071C5' },
+    { patterns: ['-webgpu-', '-webgpu', 'webgpu', '-generic-gpu'], color: '#005A9C' }
+];
+
 export function getAcceleratorColor(variantName: string): string {
     const name = variantName.toLowerCase();
-
-    if (
-        name.includes('-cuda-') ||
-        name.includes('-cuda') ||
-        name.includes('-tensorrt-') ||
-        name.includes('-tensorrt') ||
-        name.includes('-trt-rtx-') ||
-        name.includes('-trt-rtx') ||
-        name.includes('-trtrtx')
-    ) {
-        return '#76B900';
+    for (const { patterns, color } of ACCELERATOR_COLOR_PATTERNS) {
+        if (patterns.some(pattern => name.includes(pattern))) {
+            return color;
+        }
     }
-    if (name.includes('-qnn-') || name.includes('-qnn')) {
-        return '#3253DC';
-    }
-    if (name.includes('-vitis-') || name.includes('-vitis') || name.includes('-vitisai')) {
-        return 'var(--amd-color, #000000)'; // Black in light mode, white in dark mode
-    }
-    if (name.includes('-openvino-') || name.includes('-openvino')) {
-        return '#0071C5';
-    }
-    if (
-        name.includes('-webgpu-') ||
-        name.includes('-webgpu') ||
-        name.includes('webgpu') ||
-        name.includes('-generic-gpu')
-    ) {
-        return '#005A9C';
-    }
-
     return 'currentColor';
 }
+
+// Variant label patterns - ordered by specificity (most specific first)
+const VARIANT_LABEL_PATTERNS: Array<{ patterns: string[]; label: string; requiresAll?: boolean }> = [
+    { patterns: ['-cuda-', '-trt-rtx-'], label: 'CUDA + TensorRT', requiresAll: true },
+    { patterns: ['-cuda-', '-tensorrt-'], label: 'CUDA + TensorRT', requiresAll: true },
+    { patterns: ['-cuda-', '-trtrtx'], label: 'CUDA + TensorRT', requiresAll: true },
+    { patterns: ['-cuda-gpu', '-cuda-'], label: 'CUDA' },
+    { patterns: ['-generic-gpu', 'webgpu'], label: 'WebGPU' },
+    { patterns: ['-qnn-'], label: 'QNN' },
+    { patterns: ['-vitis-'], label: 'Vitis' },
+    { patterns: ['-openvino-'], label: 'OpenVINO' },
+    { patterns: ['-trt-rtx-', '-tensorrt-', '-trtrtx-', '-trtrtx'], label: 'TensorRT' },
+    { patterns: ['-generic-cpu'], label: 'Generic' }
+];
 
 export function getVariantLabel(variant: { name: string; deviceSupport: string[] }): string {
     const modelName = variant.name.toLowerCase();
     const device = variant.deviceSupport[0]?.toUpperCase() || '';
 
-    if (modelName.includes('-cuda-gpu') || modelName.includes('-cuda-')) {
-        if (
-            modelName.includes('-trt-rtx-') ||
-            modelName.includes('-tensorrt-') ||
-            modelName.includes('-trtrtx-') ||
-            modelName.includes('-trtrtx')
-        ) {
-            return `${device} (CUDA + TensorRT)`;
+    for (const { patterns, label, requiresAll } of VARIANT_LABEL_PATTERNS) {
+        if (requiresAll) {
+            if (patterns.every(pattern => modelName.includes(pattern))) {
+                return `${device} (${label})`;
+            }
+        } else {
+            if (patterns.some(pattern => modelName.includes(pattern))) {
+                return `${device} (${label})`;
+            }
         }
-        return `${device} (CUDA)`;
-    } else if (modelName.includes('-generic-gpu') || modelName.includes('webgpu')) {
-        return `${device} (WebGPU)`;
-    }
-
-    if (modelName.includes('-qnn-')) {
-        return `${device} (QNN)`;
-    } else if (modelName.includes('-vitis-')) {
-        return `${device} (Vitis)`;
-    } else if (modelName.includes('-openvino-')) {
-        return `${device} (OpenVINO)`;
-    } else if (
-        modelName.includes('-trt-rtx-') ||
-        modelName.includes('-tensorrt-') ||
-        modelName.includes('-trtrtx-') ||
-        modelName.includes('-trtrtx')
-    ) {
-        return `${device} (TensorRT)`;
-    }
-
-    if (modelName.includes('-generic-cpu')) {
-        return `${device} (Generic)`;
     }
 
     return device;
 }
 
+// Acceleration to logo mapping
+const ACCELERATION_LOGOS: Record<string, string> = {
+    cuda: '/logos/nvidia-logo.svg',
+    'trt-rtx': '/logos/nvidia-logo.svg',
+    trtrtx: '/logos/nvidia-logo.svg',
+    qnn: '/logos/qualcomm-logo.svg',
+    vitis: '/logos/amd-logo.svg',
+    openvino: '/logos/intel-logo.svg',
+    webgpu: '/logos/webgpu-logo.svg'
+};
+
 export function getAcceleratorLogoFromAcceleration(acceleration: string): string | null {
-    const accel = acceleration.toLowerCase();
-
-    if (accel === 'cuda' || accel === 'trt-rtx' || accel === 'trtrtx') {
-        return '/logos/nvidia-logo.svg';
-    }
-    if (accel === 'qnn') {
-        return '/logos/qualcomm-logo.svg';
-    }
-    if (accel === 'vitis') {
-        return '/logos/amd-logo.svg';
-    }
-    if (accel === 'openvino') {
-        return '/logos/intel-logo.svg';
-    }
-    if (accel === 'webgpu') {
-        return '/logos/webgpu-logo.svg';
-    }
-
-    return null;
+    return ACCELERATION_LOGOS[acceleration.toLowerCase()] || null;
 }
 
+// Acceleration to color mapping
+const ACCELERATION_COLORS: Record<string, string> = {
+    cuda: '#76B900',
+    'trt-rtx': '#76B900',
+    trtrtx: '#76B900',
+    qnn: '#3253DC',
+    vitis: 'var(--amd-color, #000000)',
+    openvino: '#0071C5',
+    webgpu: '#005A9C'
+};
+
 export function getAcceleratorColorFromAcceleration(acceleration: string): string {
-    const accel = acceleration.toLowerCase();
-    const colors: Record<string, string> = {
-        cuda: '#76B900',
-        'trt-rtx': '#76B900',
-        trtrtx: '#76B900',
-        qnn: '#3253DC',
-        vitis: 'var(--amd-color, #000000)',
-        openvino: '#0071C5',
-        webgpu: '#005A9C'
-    };
-    return colors[accel] || 'currentColor';
+    return ACCELERATION_COLORS[acceleration.toLowerCase()] || 'currentColor';
 }

--- a/www/src/routes/models/components/ModelDetailsModal.svelte
+++ b/www/src/routes/models/components/ModelDetailsModal.svelte
@@ -179,39 +179,28 @@
 		return html;
 	}
 
+	// Device suffix pattern for cleaning model names
+	const DEVICE_SUFFIX_PATTERN = /-(generic|cuda|qnn|openvino|vitis)-(cpu|gpu|npu)$|-(cpu|gpu|npu)$/i;
+
 	// Get the generic model name for auto-selection
 	function getGenericModelName(model: GroupedFoundryModel): string {
 		const baseName = model.alias || model.variants[0]?.name || model.displayName;
 		const withoutVersion = baseName.split(':')[0];
-		const genericName = withoutVersion
-			.replace(/-generic-(cpu|gpu|npu)$/i, '')
-			.replace(/-cuda-(cpu|gpu|npu)$/i, '')
-			.replace(/-qnn-(cpu|gpu|npu)$/i, '')
-			.replace(/-openvino-(cpu|gpu|npu)$/i, '')
-			.replace(/-vitis-(cpu|gpu|npu)$/i, '')
-			.replace(/-(cpu|gpu|npu)$/i, '');
-		return genericName;
+		return withoutVersion.replace(DEVICE_SUFFIX_PATTERN, '');
 	}
 
 	// Check if model is a speech-to-text model
 	function isSpeechToTextModel(model: GroupedFoundryModel | null): boolean {
 		if (!model) return false;
 		
-		// Check by task type
-		if (model.taskType) {
-			const taskType = model.taskType.toLowerCase();
-			if (taskType.includes('automatic-speech-recognition') || taskType.includes('speech-to-text')) {
-				return true;
-			}
-		}
+		const taskType = model.taskType?.toLowerCase() || '';
+		const alias = model.alias?.toLowerCase() || '';
+		const displayName = model.displayName?.toLowerCase() || '';
 		
-		// Check by alias/name (for whisper models)
-		if (model.alias?.toLowerCase().includes('whisper') || 
-			model.displayName?.toLowerCase().includes('whisper')) {
-			return true;
-		}
-		
-		return false;
+		return taskType.includes('automatic-speech-recognition') || 
+			taskType.includes('speech-to-text') ||
+			alias.includes('whisper') || 
+			displayName.includes('whisper');
 	}
 </script>
 

--- a/www/src/routes/models/components/ModelFilters.svelte
+++ b/www/src/routes/models/components/ModelFilters.svelte
@@ -6,6 +6,11 @@
 	import * as Card from '$lib/components/ui/card';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { foundryModelService } from '../service';
+	import {
+		getDeviceIcon,
+		getAcceleratorLogoFromAcceleration,
+		getAcceleratorColorFromAcceleration
+	} from '$lib/utils/model-helpers';
 
 	export let searchTerm = '';
 	export let selectedDevices: string[] = [];
@@ -29,60 +34,6 @@
 		} else {
 			selectedDevices = [...selectedDevices, device];
 		}
-	}
-
-	function getDeviceIcon(device: string): string {
-		const icons: Record<string, string> = {
-			npu: '🧠',
-			gpu: '🎮',
-			cpu: '💻'
-		};
-		return icons[device.toLowerCase()] || '🔧';
-	}
-
-	function getAcceleratorLogo(acceleration: string): string | null {
-		const accel = acceleration.toLowerCase();
-
-		// NVIDIA (CUDA, TensorRT)
-		if (accel === 'cuda' || accel === 'trt-rtx' || accel === 'trtrtx') {
-			return '/logos/nvidia-logo.svg';
-		}
-
-		// Qualcomm (QNN)
-		if (accel === 'qnn') {
-			return '/logos/qualcomm-logo.svg';
-		}
-
-		// AMD (Vitis)
-		if (accel === 'vitis') {
-			return '/logos/amd-logo.svg';
-		}
-
-		// Intel (OpenVINO)
-		if (accel === 'openvino') {
-			return '/logos/intel-logo.svg';
-		}
-
-		// WebGPU
-		if (accel === 'webgpu') {
-			return '/logos/webgpu-logo.svg';
-		}
-
-		return null;
-	}
-
-	function getAcceleratorColor(acceleration: string): string {
-		const accel = acceleration.toLowerCase();
-		const colors: Record<string, string> = {
-			cuda: '#76B900',
-			'trt-rtx': '#76B900',
-			trtrtx: '#76B900',
-			qnn: '#3253DC',
-			vitis: 'var(--amd-color, #000000)',
-			openvino: '#0071C5',
-			webgpu: '#005A9C'
-		};
-		return colors[accel] || 'currentColor';
 	}
 
 	$: hasActiveFilters =
@@ -258,8 +209,8 @@
 						<DropdownMenu.Separator />
 						{#each availableAccelerations as acceleration}
 							<DropdownMenu.Item onclick={() => (selectedAcceleration = acceleration)}>
-								{@const acceleratorLogo = getAcceleratorLogo(acceleration)}
-								{@const acceleratorColor = getAcceleratorColor(acceleration)}
+								{@const acceleratorLogo = getAcceleratorLogoFromAcceleration(acceleration)}
+								{@const acceleratorColor = getAcceleratorColorFromAcceleration(acceleration)}
 								{#if acceleratorLogo && selectedAcceleration === acceleration}
 									<span
 										class="accelerator-logo-mask mr-2 size-4"

--- a/www/src/routes/models/components/ModelGrid.svelte
+++ b/www/src/routes/models/components/ModelGrid.svelte
@@ -10,7 +10,6 @@
 	export let copiedModelId: string | null = null;
 	export let onCardClick: (model: GroupedFoundryModel) => void;
 	export let onCopyCommand: (modelId: string) => void;
-	export let onCopyModelId: (modelId: string) => void;
 	export let onClearFilters: () => void;
 
 	$: totalPages = Math.ceil(models.length / itemsPerPage);
@@ -24,7 +23,7 @@
 {#if models.length > 0}
 	<div class="mt-6 grid auto-rows-fr gap-4 sm:grid-cols-2 lg:grid-cols-3">
 		{#each paginatedModels as model (model.id)}
-			<ModelCard {model} {copiedModelId} {onCardClick} {onCopyCommand} {onCopyModelId} />
+			<ModelCard {model} {copiedModelId} {onCardClick} {onCopyCommand} />
 		{/each}
 	</div>
 


### PR DESCRIPTION
## Summary
This PR makes Whisper (speech-to-text) models visible in the model catalog and displays them with a special "SDK Only" treatment, along with code simplification improvements.

## Changes

### Unhide Whisper Models
- Whisper models are now visible in the model catalog
- Speech-to-text models display with a distinct "SDK Only" badge and styling
- Added link to SDK documentation for audio transcription
- Detection based on task type (`automatic-speech-recognition`, `speech-to-text`) and model name patterns

### Code Simplification & Formatting
- Simplified utility functions in `utils.ts` and `model-helpers.ts`
- Improved code formatting across model components
- Reduced code duplication and improved readability
- Applied consistent formatting per project style guidelines

## Files Changed
- `src/lib/utils.ts` - Simplified utility functions
- `src/lib/utils/model-helpers.ts` - Consolidated model helper functions
- `src/routes/models/+page.svelte` - Formatting improvements
- `src/routes/models/components/ModelCard.svelte` - SDK-only treatment for whisper
- `src/routes/models/components/ModelDetailsModal.svelte` - SDK-only details view
- `src/routes/models/components/ModelFilters.svelte` - Formatting cleanup
- `src/routes/models/components/ModelGrid.svelte` - Minor cleanup
- `src/routes/models/service.ts` - Service simplification