### PR TITLE
feat(www): Split Whisper models by size variant

### DIFF
--- a/www/src/routes/models/+page.svelte
+++ b/www/src/routes/models/+page.svelte
@@ -34,7 +34,7 @@
 
 	// Available filter options
 	let availableDevices: string[] = [];
-	let availableFamilies: string[] = ['deepseek', 'mistral', 'qwen', 'phi'];
+	let availableFamilies: string[] = ['deepseek', 'mistral', 'qwen', 'phi', 'whisper'];
 	let availableAccelerations: string[] = [];
 
 	// Pagination

--- a/www/src/routes/models/components/ModelDetailsModal.svelte
+++ b/www/src/routes/models/components/ModelDetailsModal.svelte
@@ -22,7 +22,8 @@
 		'toolregisterstart',
 		'toolresponsestart',
 		'toolresponseend',
-		'directorypath'
+		'directorypath',
+		'invisiblelatest'
 	];
 
 	// Compute generic model name reactively


### PR DESCRIPTION
## Summary

This PR updates the Whisper model display to be more consistent with other models in the catalog, showing each size variant as a separate model card.

## Changes

- **Split Whisper models by size**: Each Whisper size (large-v3, medium, small, base, tiny) now displays as a separate model card instead of being grouped together
- **Updated display names**: Names now show as "Whisper Large V3", "Whisper Medium", etc. (removed "OpenAI" prefix for cleaner presentation)
- **Added Whisper to family filter**: Users can now filter by "Whisper" in the model family dropdown
- **Hidden internal tags**: Added `invisiblelatest` to the list of hidden tags in model details
- **Simplified code**: Removed whisper-specific grouping logic in favor of the standard variant handling

## Visual Changes

- Before: Single "OpenAI Whisper" card with all size variants listed inside
- After: Separate cards for "Whisper Large V3", "Whisper Medium", "Whisper Small", "Whisper Base", "Whisper Tiny"

## Notes

- SDK-only behavior is preserved for all Whisper models (uses existing `isSpeechToTextModel()` detection)
- Device variants (CPU, GPU, CUDA) are still grouped within each size card