### PR TITLE
[sdk_v2] bug fix for MacOS not finding onnxruntime/onnxruntime-genai binaries

### DIFF
--- a/sdk_v2/js/src/detail/coreInterop.ts
+++ b/sdk_v2/js/src/detail/coreInterop.ts
@@ -37,7 +37,7 @@ export class CoreInterop {
         throw new Error(`Unsupported platform: ${platform}`);
     }
 
-    private static _resolveDefaultCorePath(): string | null {
+    private static _resolveDefaultCorePath(config: Configuration): string | null {
         const require = createRequire(import.meta.url);
         const platform = process.platform;
         const arch = process.arch;
@@ -51,14 +51,15 @@ export class CoreInterop {
         
         const corePath = path.join(packageDir, `Microsoft.AI.Foundry.Local.Core${ext}`);
             if (fs.existsSync(corePath)) {
-            return corePath;
-        }
+                config.params['FoundryLocalCorePath'] = corePath;
+                return corePath;
+            }
 
         return null;
     }
 
     constructor(config: Configuration) {
-        const corePath = config.params['FoundryLocalCorePath'] || CoreInterop._resolveDefaultCorePath();
+        const corePath = config.params['FoundryLocalCorePath'] || CoreInterop._resolveDefaultCorePath(config);
         
         if (!corePath) {
             throw new Error("FoundryLocalCorePath not specified in configuration and could not auto-discover binaries. Please run 'npm install' to download native libraries.");


### PR DESCRIPTION
paired with this fix in Foundry Local Core https://dev.azure.com/microsoft/windows.ai.toolkit/_git/neutron-server/pullrequest/14640827

if we auto-discover binaries, need to pass the found location to foundry local core so it can resolve them with the above fix