### PR TITLE
[sdk_v2] removes winml scenario from js sdk

### DIFF
--- a/.github/workflows/build-js-steps.yml
+++ b/.github/workflows/build-js-steps.yml
@@ -6,10 +6,6 @@ on:
       version:
         required: true
         type: string
-      useWinML:
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -80,15 +76,9 @@ jobs:
           Get-ChildItem -Recurse -Depth 2 | ForEach-Object { Write-Host "  $($_.FullName)" }
 
 
-      - name: npm install (WinML)
-        if: ${{ inputs.useWinML == true }}
-        working-directory: sdk_v2\js
-        run: npm install --winml
-
       - name: npm install (Standard)
-        if: ${{ inputs.useWinML == false }}
         working-directory: sdk_v2\js
-        run: npm install --nightly
+        run: npm install
 
       # Verify that installing new packages doesn't strip custom native binary folders
       - name: npm install openai (verify persistence)
@@ -110,18 +100,6 @@ jobs:
       - name: Pack npm package
         working-directory: sdk_v2\js
         run: npm pack
-
-      - name: Rename WinML artifact
-        if: ${{ inputs.useWinML == true }}
-        shell: pwsh
-        working-directory: sdk_v2\js
-        run: |
-          $tgz = Get-ChildItem *.tgz | Select-Object -First 1
-          if ($tgz) {
-              $newName = $tgz.Name -replace '^foundry-local-sdk-', 'foundry-local-sdk-winml-'
-              Rename-Item -Path $tgz.FullName -NewName $newName
-              Write-Host "Renamed $($tgz.Name) to $newName"
-          }
 
       - name: Upload npm packages
         uses: actions/upload-artifact@v4

--- a/sdk_v2/js/script/install.cjs
+++ b/sdk_v2/js/script/install.cjs
@@ -36,12 +36,9 @@ const REQUIRED_FILES = [
   'onnxruntime-genai.dll',
 ].map(f => f.replace('.dll', os.platform() === 'win32' ? '.dll' : os.platform() === 'darwin' ? '.dylib' : '.so'));
 
-// When you run npm install --winml, npm does not pass --winml as a command-line argument to your script. 
-// Instead, it sets an environment variable named npm_config_winml to 'true'.
-const useWinML = process.env.npm_config_winml === 'true';
+// If npm_config_nightly is set (npm install --nightly), use nightly builds
 const useNightly = process.env.npm_config_nightly === 'true';
 
-console.log(`[foundry-local] WinML enabled: ${useWinML}`);
 console.log(`[foundry-local] Nightly enabled: ${useNightly}`);
 
 const NUGET_FEED = 'https://api.nuget.org/v3/index.json';
@@ -54,7 +51,7 @@ const CORE_FEED = useNightly ? ORT_NIGHTLY_FEED : NUGET_FEED;
 
 const ARTIFACTS = [
   { 
-    name: useWinML ? 'Microsoft.AI.Foundry.Local.Core.WinML' : 'Microsoft.AI.Foundry.Local.Core', 
+    name: 'Microsoft.AI.Foundry.Local.Core', 
     version: useNightly ? undefined : '0.8.2.2', // Set later using resolveLatestVersion if undefined
     files: ['Microsoft.AI.Foundry.Local.Core'],
     feed: CORE_FEED
@@ -66,7 +63,7 @@ const ARTIFACTS = [
     feed: ORT_NIGHTLY_FEED
   },
   { 
-    name: useWinML ? 'Microsoft.ML.OnnxRuntimeGenAI.WinML' : 'Microsoft.ML.OnnxRuntimeGenAI.Foundry', 
+    name: 'Microsoft.ML.OnnxRuntimeGenAI.Foundry', 
     version: '0.11.2', // Hardcoded stable version
     files: ['onnxruntime-genai'],
     feed: NUGET_FEED


### PR DESCRIPTION
WinML scenario only uses C# SDK, removing WinML flow from JS SDK to reduce complexity