### PR TITLE
[sdk_v2] removed 0.8.2 hardcoded in preinstall.js

### DIFF
--- a/sdk_v2/js/script/install.cjs
+++ b/sdk_v2/js/script/install.cjs
@@ -257,6 +257,21 @@ async function installPackage(artifact, tempDir) {
              console.warn(`    ⚠ File ${fileName} not found for RID ${RID} in package.`);
         }
     }
+
+    // After extracting, update the packages/@foundry-local-core/RID/package.json version to match the downloaded artifact
+    if (found && pkgName.startsWith('Microsoft.AI.Foundry.Local.Core')) {
+        const pkgJsonPath = path.join(BIN_DIR, 'package.json');
+        try {
+            if (fs.existsSync(pkgJsonPath)) {
+                const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+                pkgJson.version = pkgVer;
+                fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
+                console.log(`    Updated package.json version to ${pkgVer}`);
+            }
+        } catch (e) {
+            console.warn(`    Failed to update package.json version: ${e.message}`);
+        }
+    }
 }
 
 async function main() {

--- a/sdk_v2/js/script/preinstall.cjs
+++ b/sdk_v2/js/script/preinstall.cjs
@@ -18,7 +18,7 @@ const pkgJsonPath = path.join(dir, 'package.json');
 if (!fs.existsSync(pkgJsonPath)) {
   const pkgContent = {
     name: `@foundry-local-core/${platformKey}`,
-    version: "0.8.2",
+    version: "0.0.0", // Placeholder version, will be replaced during install.cjs
     description: `Native binaries for Foundry Local SDK (${platformKey})`,
     os: [os.platform()],
     cpu: [os.arch()],


### PR DESCRIPTION
dynamically sets version based on which foundry local core was downloaded