### PR TITLE
[sdk_v2] print variants in js sdk example

### DIFF
--- a/sdk_v2/js/examples/chat-completion.ts
+++ b/sdk_v2/js/examples/chat-completion.ts
@@ -25,7 +25,8 @@ async function main() {
         
         console.log(`Found ${models.length} models:`);
         for (const model of models) {
-            console.log(`  - ${model.alias}`);
+            const variants = model.variants.map((v: any) => v.id).join(', ');
+            console.log(`  - ${model.alias} (variants: ${variants})`);
         }
 
         // Explore cached models


### PR DESCRIPTION
Defaults the example to printing the model variants so we can confirm if EPs have been loaded correctly across platforms