### PR TITLE
[sdk_v2] target net9.0 in samples

### DIFF
--- a/samples/cs/GettingStarted/windows/AudioTranscriptionExample/AudioTranscriptionExample.csproj
+++ b/samples/cs/GettingStarted/windows/AudioTranscriptionExample/AudioTranscriptionExample.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- For Windows use the following -->
-    <TargetFramework>net10.0-windows10.0.26100</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.26100</TargetFramework>
     <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <Platforms>ARM64;x64</Platforms>
     <WindowsPackageType>None</WindowsPackageType>

--- a/samples/cs/GettingStarted/windows/FoundryLocalWebServer/FoundryLocalWebServer.csproj
+++ b/samples/cs/GettingStarted/windows/FoundryLocalWebServer/FoundryLocalWebServer.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- For Windows use the following -->
-    <TargetFramework>net10.0-windows10.0.26100</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.26100</TargetFramework>
     <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <Platforms>ARM64;x64</Platforms>
     <WindowsPackageType>None</WindowsPackageType>

--- a/samples/cs/GettingStarted/windows/HelloFoundryLocalSdk/HelloFoundryLocalSdk.csproj
+++ b/samples/cs/GettingStarted/windows/HelloFoundryLocalSdk/HelloFoundryLocalSdk.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- For Windows use the following -->
-    <TargetFramework>net10.0-windows10.0.26100</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.26100</TargetFramework>
     <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <Platforms>ARM64;x64</Platforms>
     <WindowsPackageType>None</WindowsPackageType>

--- a/samples/cs/GettingStarted/windows/ModelManagementExample/ModelManagementExample.csproj
+++ b/samples/cs/GettingStarted/windows/ModelManagementExample/ModelManagementExample.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- For Windows use the following -->
-    <TargetFramework>net10.0-windows10.0.26100</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.26100</TargetFramework>
     <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <Platforms>ARM64;x64</Platforms>
     <WindowsPackageType>None</WindowsPackageType>


### PR DESCRIPTION
Resolves the below error by targetting net9.0 (consistent with what we target in our official build pipeline) 

Error (active)	NETSDK1209	The current Visual Studio version does not support targeting .NET 10.0.  Either target .NET 9.0 or lower, or use Visual Studio version 17.16 or higher	HelloFoundryLocalSdk	C:\Program Files\dotnet\sdk\9.0.306\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets	171		
