### PR TITLE
docs: document dynamic port assignment and remove hardcoded 5272 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ This will show you a list of all models that can be run locally, including their
 
 Foundry Local has an easy-to-use SDK (C#, Python, JavaScript) to get you started with existing applications:
 
+> [!IMPORTANT]
+> Foundry Local assigns a **dynamic port** each time the service starts -- do not hardcode `localhost:5272` or any other port. Use the SDK's `manager.endpoint` property to obtain the correct URL at runtime. For CLI or `curl` usage, run `foundry service status` to discover the current endpoint.
+
 ### C#
 
 The C# SDK is available as a package on NuGet. You can install it using the .NET CLI:

--- a/docs/copilot-sdk-integration.md
+++ b/docs/copilot-sdk-integration.md
@@ -17,7 +17,7 @@ Your Application
               |
               ├─ JSON-RPC ──→ Copilot CLI (agent orchestration, tool execution)
               |
-              └─ BYOK provider: { type: "openai", baseUrl: "http://localhost:5272/v1" }
+              └─ BYOK provider: { type: "openai", baseUrl: manager.endpoint }
                        |
                        └─ POST /v1/chat/completions ──→ Foundry Local (on-device inference)
                                                               |
@@ -64,7 +64,7 @@ const session = await client.createSession({
     model: modelInfo.id,
     provider: {
         type: "openai",
-        baseUrl: manager.endpoint,     // e.g., "http://localhost:5272/v1"
+        baseUrl: manager.endpoint,     // Dynamically assigned; never hardcode the port
         apiKey: manager.apiKey,
         wireApi: "completions",        // Foundry Local uses Chat Completions API
     },
@@ -231,7 +231,7 @@ The `provider` object in `createSession()` configures where Copilot SDK sends in
 | Field | Type | Description |
 |-------|------|-------------|
 | `type` | `"openai"` | Provider type. Use `"openai"` for Foundry Local (OpenAI-compatible) |
-| `baseUrl` | string | Foundry Local endpoint, e.g., `"http://localhost:5272/v1"` |
+| `baseUrl` | string | Foundry Local endpoint (port is dynamically assigned). Use `manager.endpoint` from the SDK, or run `foundry service status` to discover the URL. |
 | `apiKey` | string | API key (optional for local endpoints) |
 | `wireApi` | `"completions"` \| `"responses"` | API format. Use `"completions"` for Foundry Local |
 

--- a/samples/js/copilot-sdk-foundry-local/README.md
+++ b/samples/js/copilot-sdk-foundry-local/README.md
@@ -111,7 +111,7 @@ const session = await client.createSession({
     model: modelInfo.id,
     provider: {
         type: "openai",                // Foundry Local exposes OpenAI-compatible API
-        baseUrl: manager.endpoint,     // e.g., "http://localhost:5272/v1"
+        baseUrl: manager.endpoint,     // Dynamically assigned; never hardcode the port
         apiKey: manager.apiKey,
         wireApi: "completions",        // Chat Completions API format
     },


### PR DESCRIPTION
## Summary

Foundry Local assigns a dynamic port each time the service starts, but several docs and examples hardcode `localhost:5272`, which misleads users into thinking the port is fixed.

This PR:
- **`docs/copilot-sdk-integration.md`**: Replaces hardcoded `localhost:5272` in the architecture diagram, Quick Start code comment, and BYOK reference table with dynamic port guidance
- **`samples/js/copilot-sdk-foundry-local/README.md`**: Updates BYOK code comment to note the port is dynamically assigned
- **`README.md`**: Adds an `[!IMPORTANT]` callout in the SDK integration section explaining that the port is dynamic and how to discover it (`manager.endpoint` or `foundry service status`)

Related to #424