### PR TITLE
[sdk_v2] remove 'latest' AnalysisLevel to rely on stable analysis rules

### DIFF
--- a/sdk_v2/cs/src/Microsoft.AI.Foundry.Local.csproj
+++ b/sdk_v2/cs/src/Microsoft.AI.Foundry.Local.csproj
@@ -55,7 +55,6 @@
         <DefineConstants Condition="('$(IsWindows)'=='true')">$(DefineConstants);IS_WINDOWS</DefineConstants>
         <DefineConstants Condition="('$(IsOSX)'=='true')">$(DefineConstants);IS_OSX</DefineConstants>
         <DefineConstants Condition="('$(IsLinux)'=='true')">$(DefineConstants);IS_LINUX</DefineConstants>
-        <AnalysisLevel>latest-recommended</AnalysisLevel>
     </PropertyGroup>
 
     <Target Name="DumpValues" BeforeTargets="Build">
@@ -94,13 +93,6 @@
       
       <!-- we don't pass any types across the WinRT ABI -->
       <NoWarn>$(NoWarn);CsWinRT1028</NoWarn>
-    </PropertyGroup>
-    
-    <PropertyGroup>
-      <!-- Suppress CA1873: Logging argument evaluation is not expensive in this codebase.
-           Most logs use simple string interpolation or existing variables without expensive operations
-           like database queries, complex computations, or large allocations. Performance impact is negligible. -->
-      <NoWarn>$(NoWarn);CA1873</NoWarn>
     </PropertyGroup>
     
     <PropertyGroup>


### PR DESCRIPTION
```
Error: D:\a\Foundry-Local\Foundry-Local\sdk_v2\cs\src\Detail\ModelLoadManager.cs(60,9): error CA1873: 
 Evaluation of this argument may be expensive and unnecessary if logging is disabled
 (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1873) 
```