### PR TITLE
Feature/js sdk responses api

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,27 +215,111 @@ Explore complete working examples in the [`samples/`](samples/) folder:
 
 The SDK also supports audio transcription via Whisper models. Use `model.createAudioClient()` to transcribe audio files on-device:
 
+> [!TIP]
+> The JavaScript SDK does not require end users to have the Foundry Local CLI installed. It is a completely self-contained SDK that includes native in-process Chat Completions and Audio Transcription APIs — no HTTP calls or external services needed.
+
+#### Chat Completions
+
 ```javascript
-import { FoundryLocalManager } from 'foundry-local-sdk';
+import { FoundryLocalManager } from "foundry-local-sdk";
 
-const manager = FoundryLocalManager.create({ appName: 'MyApp' });
+// Initialize the SDK
+const manager = FoundryLocalManager.create({ appName: "MyApp" });
 
-// Download and load the Whisper model
-const whisperModel = await manager.catalog.getModel('whisper-tiny');
+// Get and load a chat model
+const model = await manager.catalog.getModel("phi-3.5-mini");
+await model.download();
+await model.load();
+
+// Create a chat client and generate a response
+const chatClient = model.createChatClient();
+chatClient.settings.temperature = 0.7;
+chatClient.settings.maxTokens = 800;
+
+const response = await chatClient.completeChat([
+  { role: "user", content: "What is the golden ratio?" },
+]);
+console.log(response.choices[0].message.content);
+
+// Stream responses in real-time
+for await (const chunk of chatClient.completeStreamingChat([
+  { role: "user", content: "Explain quantum computing simply." },
+])) {
+  const content = chunk.choices?.[0]?.message?.content;
+  if (content) process.stdout.write(content);
+}
+
+// Clean up
+await model.unload();
+```
+
+#### Audio Transcription (Speech-to-Text)
+
+```javascript
+import { FoundryLocalManager } from "foundry-local-sdk";
+
+// Initialize the SDK (reuses the same singleton if already created)
+const manager = FoundryLocalManager.create({ appName: "MyApp" });
+
+// Get and load the Whisper model for audio transcription
+const whisperModel = await manager.catalog.getModel("whisper-tiny");
 await whisperModel.download();
 await whisperModel.load();
 
-// Transcribe an audio file
+// Create an audio client and transcribe
 const audioClient = whisperModel.createAudioClient();
-audioClient.settings.language = 'en';
-const result = await audioClient.transcribe('recording.wav');
-console.log('Transcription:', result.text);
+audioClient.settings.language = "en";
 
-// Or stream in real-time
-for await (const chunk of audioClient.transcribeStreaming('recording.wav')) {
-    process.stdout.write(chunk.text);
+// Transcribe an audio file
+const result = await audioClient.transcribe("recording.wav");
+console.log("Transcription:", result.text);
+
+// Or stream the transcription in real-time
+for await (const chunk of audioClient.transcribeStreaming("recording.wav")) {
+  process.stdout.write(chunk.text);
 }
 
+// Clean up
+await whisperModel.unload();
+```
+
+#### Chat + Audio Together
+
+A single `FoundryLocalManager` can manage both chat and audio models simultaneously — no need for separate runtimes:
+
+```javascript
+import { FoundryLocalManager } from "foundry-local-sdk";
+
+const manager = FoundryLocalManager.create({ appName: "VoiceJournal" });
+
+// Load both models
+const chatModel = await manager.catalog.getModel("phi-3.5-mini");
+await chatModel.download();
+await chatModel.load();
+
+const whisperModel = await manager.catalog.getModel("whisper-tiny");
+await whisperModel.download();
+await whisperModel.load();
+
+// Step 1: Transcribe audio
+const audioClient = whisperModel.createAudioClient();
+audioClient.settings.language = "en";
+const transcription = await audioClient.transcribe("journal-entry.wav");
+console.log("You said:", transcription.text);
+
+// Step 2: Analyze the transcription with the chat model
+const chatClient = chatModel.createChatClient();
+const analysis = await chatClient.completeChat([
+  {
+    role: "system",
+    content: "Summarize this journal entry and extract key themes.",
+  },
+  { role: "user", content: transcription.text },
+]);
+console.log("Summary:", analysis.choices[0].message.content);
+
+// Clean up
+await chatModel.unload();
 await whisperModel.unload();
 ```
 

--- a/samples/js/audio-transcription-foundry-local/README.md
+++ b/samples/js/audio-transcription-foundry-local/README.md
@@ -16,10 +16,10 @@ This sample demonstrates how to use Foundry Local for **speech-to-text (audio tr
 
 ## Getting Started
 
-Install the Foundry Local SDK:
+From this sample's directory, install dependencies:
 
 ```bash
-npm install foundry-local-sdk
+npm install
 ```
 
 Place an audio file (e.g., `recording.wav` or `recording.mp3`) in the project directory, then run:

--- a/samples/js/audio-transcription-foundry-local/README.md
+++ b/samples/js/audio-transcription-foundry-local/README.md
@@ -1,0 +1,39 @@
+# Sample: Audio Transcription with Foundry Local
+
+This sample demonstrates how to use Foundry Local for **speech-to-text (audio transcription)** using the Whisper model — entirely on-device, with no cloud services required.
+
+## What This Shows
+
+- Loading the `whisper-tiny` model via the Foundry Local SDK
+- Transcribing an audio file (`.wav`, `.mp3`, etc.) to text
+- Both standard and streaming transcription modes
+- Automatic hardware acceleration (NPU > GPU > CPU)
+
+## Prerequisites
+
+- [Foundry Local](https://github.com/microsoft/Foundry-Local) installed on your machine
+- Node.js 18+
+
+## Getting Started
+
+Install the Foundry Local SDK:
+
+```bash
+npm install foundry-local-sdk
+```
+
+Place an audio file (e.g., `recording.wav` or `recording.mp3`) in the project directory, then run:
+
+```bash
+node src/app.js
+```
+
+## How It Works
+
+The Foundry Local SDK handles everything:
+1. **Model discovery** — finds the best `whisper-tiny` variant for your hardware
+2. **Model download** — downloads the model if not already cached
+3. **Model loading** — loads the model into memory with optimized hardware acceleration
+4. **Transcription** — runs Whisper inference entirely on-device
+
+No need for `whisper.cpp`, `@huggingface/transformers`, or any other separate STT tool.

--- a/samples/js/audio-transcription-foundry-local/package.json
+++ b/samples/js/audio-transcription-foundry-local/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "audio-transcription-foundry-local",
+  "type": "module",
+  "description": "Audio transcription (speech-to-text) sample using Foundry Local",
+  "scripts": {
+    "start": "node src/app.js"
+  },
+  "dependencies": {
+    "foundry-local-sdk": "latest"
+  }
+}

--- a/samples/js/audio-transcription-foundry-local/package.json
+++ b/samples/js/audio-transcription-foundry-local/package.json
@@ -6,6 +6,6 @@
     "start": "node src/app.js"
   },
   "dependencies": {
-    "foundry-local-sdk": "latest"
+    "foundry-local-sdk": "^0.9.0"
   }
 }

--- a/samples/js/audio-transcription-foundry-local/src/app.js
+++ b/samples/js/audio-transcription-foundry-local/src/app.js
@@ -51,9 +51,9 @@ async function main() {
 
   // --- Streaming transcription ---
   console.log("\n=== Streaming Transcription ===");
-  await audioClient.transcribeStreaming(audioFilePath, (chunk) => {
+  for await (const chunk of audioClient.transcribeStreaming(audioFilePath)) {
     process.stdout.write(chunk.text);
-  });
+  }
   console.log("\n");
 
   // Clean up

--- a/samples/js/audio-transcription-foundry-local/src/app.js
+++ b/samples/js/audio-transcription-foundry-local/src/app.js
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { FoundryLocalManager } from "foundry-local-sdk";
+import path from "path";
+
+// The Whisper model alias for audio transcription
+const alias = "whisper-tiny";
+
+async function main() {
+  console.log("Initializing Foundry Local SDK...");
+  const manager = FoundryLocalManager.create({
+    appName: "AudioTranscriptionSample",
+    logLevel: "info",
+  });
+
+  // Get the Whisper model from the catalog
+  const catalog = manager.catalog;
+  const model = await catalog.getModel(alias);
+  if (!model) {
+    throw new Error(
+      `Model "${alias}" not found. Run "foundry model list" to see available models.`
+    );
+  }
+
+  // Download the model if not already cached
+  if (!model.isCached) {
+    console.log(`Downloading model "${alias}"...`);
+    await model.download((progress) => {
+      process.stdout.write(`\rDownload progress: ${progress.toFixed(1)}%`);
+    });
+    console.log("\nDownload complete.");
+  }
+
+  // Load the model into memory
+  console.log(`Loading model "${model.id}"...`);
+  await model.load();
+  console.log("Model loaded.\n");
+
+  // Create an audio client for transcription
+  const audioClient = model.createAudioClient();
+  audioClient.settings.language = "en";
+
+  // Update this path to point to your audio file
+  const audioFilePath = path.resolve("recording.mp3");
+
+  // --- Standard transcription ---
+  console.log("=== Standard Transcription ===");
+  const result = await audioClient.transcribe(audioFilePath);
+  console.log("Transcription:", result.text);
+
+  // --- Streaming transcription ---
+  console.log("\n=== Streaming Transcription ===");
+  await audioClient.transcribeStreaming(audioFilePath, (chunk) => {
+    process.stdout.write(chunk.text);
+  });
+  console.log("\n");
+
+  // Clean up
+  await model.unload();
+  console.log("Done.");
+}
+
+main().catch(console.error);


### PR DESCRIPTION
This pull request introduces comprehensive support for audio transcription (speech-to-text) using Whisper models in the Foundry Local SDK, alongside unified chat and audio capabilities. It adds new documentation, sample apps, and code examples demonstrating how to use both chat and audio features through a single SDK, highlighting automatic hardware acceleration and simplified integration. The updates make it easier for developers to build applications that combine text generation and speech-to-text without needing separate runtimes or hardware detection code.

**Documentation and SDK feature updates:**

* Updated `README.md` and `docs/README.md` to clarify that Foundry Local now supports both chat (text generation) and audio transcription (speech-to-text) in a single runtime, with automatic hardware acceleration and unified APIs. Added tables listing supported tasks, model aliases, and API usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26-R44) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R10-R26)
* Expanded sample listings in documentation to include new JavaScript samples for chat, audio transcription, tool calling, and combined chat+audio apps. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L199-R244) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R10-R26)

**New sample applications and examples:**

* Added `samples/js/audio-transcription-foundry-local` sample, including a detailed README, `package.json`, and implementation in `src/app.js`, showing how to load Whisper models and transcribe audio files (standard and streaming modes). [[1]](diffhunk://#diff-e486946336386d04aee6ea7c49808e6a31f568e565db3a44921ce003fe24ca3aR1-R39) [[2]](diffhunk://#diff-217fffad0151430ebe576fdd0a1d215db8c35fdbdba55d92c9d2cfdb65f23ec3R1-R11) [[3]](diffhunk://#diff-cfa23c653388868ae03c7f2306db6fda76f6d7611e7de530d2535c38fc9f5c0cR1-R64)
* Added `samples/js/chat-and-audio-foundry-local` sample, with README, `package.json`, and implementation in `src/app.js`, demonstrating unified management of chat and audio models, transcribing audio, and analyzing the transcription with a chat model. [[1]](diffhunk://#diff-70d0f3672b3dc457b3db1e35d65e7a4ec3a8fecb722b001f99fe30bc7764eea5R1-R39) [[2]](diffhunk://#diff-3babfe16bdd0e588109b9c435cc25a7d944049c20013a8a7d3b24ddbcc350bf5R1-R11) [[3]](diffhunk://#diff-431bc1d357dd953e19545dff272b1f38c65ff4d01a38e1d223955823f5785be6R1-R103)

**SDK example enhancements:**

* Introduced a new TypeScript example `audio-transcription.ts` in `sdk_v2/js/examples`, showcasing programmatic use of Whisper models for audio transcription, including model discovery, download, loading, and both standard and streaming transcription.
* Added `responses.ts` example to `sdk_v2/js/examples`, demonstrating the Responses API for text generation, streaming, multi-turn conversations, tool calling, and response management.