### PR TITLE
streamline js examples

### DIFF
--- a/samples/js/audio-transcription-example/README.md
+++ b/samples/js/audio-transcription-example/README.md
@@ -5,34 +5,12 @@ This sample demonstrates how to use the audio transcription capabilities of the 
 ## Prerequisites
 - Ensure you have Node.js installed (version 20 or higher is recommended).
 
-## Setup project
+## Setup and run
 
-Navigate to the sample directory, setup the project, and install the Foundry Local SDK package.
-
-1. Navigate to the sample directory and setup the project:
-    ```bash
-    cd samples/js/audio-transcription-example
-    npm init -y
-    npm pkg set type=module
-    ```
-
-1. Install the Foundry Local package:
-
-    **macOS / Linux:**
-    ```bash
-    npm install --foreground-scripts foundry-local-sdk
-    ```
-
-    **Windows:**
-    ```bash
-    npm install --foreground-scripts --winml foundry-local-sdk
-    ```
-
-## Run the sample
-
-Run the sample script using Node.js:
+Navigate to the sample directory, install the dependencies, and run the sample:
 
 ```bash
 cd samples/js/audio-transcription-example
+npm run setup
 node app.js
 ```

--- a/samples/js/audio-transcription-example/package.json
+++ b/samples/js/audio-transcription-example/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "audio-transcription-example",
+  "private": true,
+  "type": "module",
+  "description": "Audio transcription sample using Foundry Local SDK",
+  "scripts": {
+    "setup": "node setup.cjs",
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "foundry-local-sdk": "latest"
+  }
+}

--- a/samples/js/audio-transcription-example/setup.cjs
+++ b/samples/js/audio-transcription-example/setup.cjs
@@ -1,0 +1,11 @@
+// Cross-platform dependency installer
+// Automatically uses --winml on Windows for hardware-accelerated inference
+const { execSync } = require('child_process');
+
+const isWindows = process.platform === 'win32';
+const cmd = isWindows
+  ? 'npm install --foreground-scripts --winml'
+  : 'npm install --foreground-scripts';
+
+console.log(`Running: ${cmd}`);
+execSync(cmd, { stdio: 'inherit' });

--- a/samples/js/chat-and-audio-foundry-local/README.md
+++ b/samples/js/chat-and-audio-foundry-local/README.md
@@ -26,10 +26,9 @@ With Foundry Local, you get **one SDK, one service, both capabilities** — and 
 
 ## Getting Started
 
-Install the Foundry Local SDK:
-
 ```bash
-npm install foundry-local-sdk
+cd samples/js/chat-and-audio-foundry-local
+npm run setup
 ```
 
 Place an audio file (`recording.mp3`) in the project directory, then run:

--- a/samples/js/chat-and-audio-foundry-local/package.json
+++ b/samples/js/chat-and-audio-foundry-local/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "description": "Unified chat + audio transcription sample using Foundry Local",
   "scripts": {
+    "setup": "node setup.cjs",
     "start": "node src/app.js"
   },
   "dependencies": {

--- a/samples/js/chat-and-audio-foundry-local/setup.cjs
+++ b/samples/js/chat-and-audio-foundry-local/setup.cjs
@@ -1,0 +1,11 @@
+// Cross-platform dependency installer
+// Automatically uses --winml on Windows for hardware-accelerated inference
+const { execSync } = require('child_process');
+
+const isWindows = process.platform === 'win32';
+const cmd = isWindows
+  ? 'npm install --foreground-scripts --winml'
+  : 'npm install --foreground-scripts';
+
+console.log(`Running: ${cmd}`);
+execSync(cmd, { stdio: 'inherit' });

--- a/samples/js/chat-and-audio-foundry-local/src/app.js
+++ b/samples/js/chat-and-audio-foundry-local/src/app.js
@@ -11,7 +11,7 @@ const WHISPER_MODEL = "whisper-tiny";
 async function main() {
   console.log("Initializing Foundry Local SDK...");
   const manager = FoundryLocalManager.create({
-    appName: "ChatAndAudioSample",
+    appName: "foundry_local_samples",
     logLevel: "info",
   });
 

--- a/samples/js/copilot-sdk-foundry-local/README.md
+++ b/samples/js/copilot-sdk-foundry-local/README.md
@@ -32,7 +32,7 @@ node --version
 
 ```bash
 cd samples/js/copilot-sdk-foundry-local
-npm install
+npm run setup
 ```
 
 ### `app.ts` — Self-reading app (`npm start`)

--- a/samples/js/copilot-sdk-foundry-local/package.json
+++ b/samples/js/copilot-sdk-foundry-local/package.json
@@ -4,6 +4,7 @@
   "description": "Sample: Using GitHub Copilot SDK with Foundry Local for agentic workflows",
   "type": "module",
   "scripts": {
+    "setup": "node setup.cjs",
     "start": "npx tsx src/app.ts",
     "tools": "npx tsx src/tool-calling.ts"
   },

--- a/samples/js/copilot-sdk-foundry-local/setup.cjs
+++ b/samples/js/copilot-sdk-foundry-local/setup.cjs
@@ -1,0 +1,11 @@
+// Cross-platform dependency installer
+// Automatically uses --winml on Windows for hardware-accelerated inference
+const { execSync } = require('child_process');
+
+const isWindows = process.platform === 'win32';
+const cmd = isWindows
+  ? 'npm install --foreground-scripts --winml'
+  : 'npm install --foreground-scripts';
+
+console.log(`Running: ${cmd}`);
+execSync(cmd, { stdio: 'inherit' });

--- a/samples/js/electron-chat-application/README.md
+++ b/samples/js/electron-chat-application/README.md
@@ -49,21 +49,11 @@ You can also change and/or delete the model for transcription using the *Voice s
 
 ## Installation
 
-To set up and run the Electron Chat Application, follow these steps:
+To set up and run the Electron Chat Application:
 
-**macOS / Linux:**
 ```bash
 cd samples/js/electron-chat-application
-npm install
-npm install --foreground-scripts foundry-local-sdk
-npm start
-```
-
-**Windows:**
-```bash
-cd samples/js/electron-chat-application
-npm install
-npm install --foreground-scripts --winml foundry-local-sdk
+npm run setup
 npm start
 ```
 

--- a/samples/js/electron-chat-application/package.json
+++ b/samples/js/electron-chat-application/package.json
@@ -4,6 +4,7 @@
   "description": "A modern chat application using Foundry Local SDK",
   "main": "main.js",
   "scripts": {
+    "setup": "node setup.cjs",
     "start": "electron .",
     "dev": "electron . --enable-logging"
   },
@@ -19,6 +20,7 @@
     "electron": "^34.5.8"
   },
   "dependencies": {
+    "foundry-local-sdk": "latest",
     "highlight.js": "^11.11.1",
     "marked": "^15.0.6"
   }

--- a/samples/js/electron-chat-application/setup.cjs
+++ b/samples/js/electron-chat-application/setup.cjs
@@ -1,0 +1,11 @@
+// Cross-platform dependency installer
+// Automatically uses --winml on Windows for hardware-accelerated inference
+const { execSync } = require('child_process');
+
+const isWindows = process.platform === 'win32';
+const cmd = isWindows
+  ? 'npm install --foreground-scripts --winml'
+  : 'npm install --foreground-scripts';
+
+console.log(`Running: ${cmd}`);
+execSync(cmd, { stdio: 'inherit' });

--- a/samples/js/langchain-integration-example/README.md
+++ b/samples/js/langchain-integration-example/README.md
@@ -5,35 +5,12 @@ This sample demonstrates how to integrate the Foundry Local SDK with LangChain.j
 ## Prerequisites
 - Ensure you have Node.js installed (version 20 or higher is recommended).
 
-## Setup project
+## Setup and run
 
-Navigate to the sample directory, setup the project, and install the Foundry Local and LangChain packages.
-
-1. Navigate to the sample directory and setup the project:
-    ```bash
-    cd samples/js/langchain-integration-example
-    npm init -y
-    npm pkg set type=module
-    ```
-1. Install the Foundry Local and LangChain packages:
-
-    **macOS / Linux:**
-    ```bash
-    npm install --foreground-scripts foundry-local-sdk
-    npm install @langchain/openai @langchain/core
-    ```
-
-    **Windows:**
-    ```bash
-    npm install --foreground-scripts --winml foundry-local-sdk
-    npm install @langchain/openai @langchain/core
-    ```
-
-## Run the sample
-
-Run the sample script using Node.js:
+Navigate to the sample directory, install the dependencies, and run the sample:
 
 ```bash
 cd samples/js/langchain-integration-example
+npm run setup
 node app.js
 ```

--- a/samples/js/langchain-integration-example/package.json
+++ b/samples/js/langchain-integration-example/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "langchain-integration-example",
+  "private": true,
+  "type": "module",
+  "description": "LangChain integration sample using Foundry Local SDK",
+  "scripts": {
+    "setup": "node setup.cjs",
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "foundry-local-sdk": "latest",
+    "@langchain/openai": "latest",
+    "@langchain/core": "latest"
+  }
+}

--- a/samples/js/langchain-integration-example/setup.cjs
+++ b/samples/js/langchain-integration-example/setup.cjs
@@ -1,0 +1,11 @@
+// Cross-platform dependency installer
+// Automatically uses --winml on Windows for hardware-accelerated inference
+const { execSync } = require('child_process');
+
+const isWindows = process.platform === 'win32';
+const cmd = isWindows
+  ? 'npm install --foreground-scripts --winml'
+  : 'npm install --foreground-scripts';
+
+console.log(`Running: ${cmd}`);
+execSync(cmd, { stdio: 'inherit' });

--- a/samples/js/native-chat-completions/README.md
+++ b/samples/js/native-chat-completions/README.md
@@ -5,33 +5,12 @@ This sample demonstrates how to use the Foundry Local SDK to perform native chat
 ## Prerequisites
 - Ensure you have Node.js installed (version 20 or higher is recommended).
 
-## Setup project
+## Setup and run
 
-Navigate to the sample directory, setup the project, and install the Foundry Local SDK package.
-
-1. Navigate to the sample directory and setup the project:
-    ```bash
-    cd samples/js/native-chat-completions
-    npm init -y
-    npm pkg set type=module
-    ```
-1. Install the Foundry Local SDK package:
-
-    **macOS / Linux:**
-    ```bash
-    npm install --foreground-scripts foundry-local-sdk
-    ```
-
-    **Windows:**
-    ```bash
-    npm install --foreground-scripts --winml foundry-local-sdk
-    ```
-
-## Run the sample
-
-Run the sample script using Node.js:
+Navigate to the sample directory, install the dependencies, and run the sample:
 
 ```bash
 cd samples/js/native-chat-completions
+npm run setup
 node app.js
 ```

--- a/samples/js/native-chat-completions/package.json
+++ b/samples/js/native-chat-completions/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "native-chat-completions",
+  "private": true,
+  "type": "module",
+  "description": "Native chat completions sample using Foundry Local SDK",
+  "scripts": {
+    "setup": "node setup.cjs",
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "foundry-local-sdk": "latest"
+  }
+}

--- a/samples/js/native-chat-completions/setup.cjs
+++ b/samples/js/native-chat-completions/setup.cjs
@@ -1,0 +1,11 @@
+// Cross-platform dependency installer
+// Automatically uses --winml on Windows for hardware-accelerated inference
+const { execSync } = require('child_process');
+
+const isWindows = process.platform === 'win32';
+const cmd = isWindows
+  ? 'npm install --foreground-scripts --winml'
+  : 'npm install --foreground-scripts';
+
+console.log(`Running: ${cmd}`);
+execSync(cmd, { stdio: 'inherit' });

--- a/samples/js/tool-calling-foundry-local/package.json
+++ b/samples/js/tool-calling-foundry-local/package.json
@@ -1,6 +1,14 @@
 {
+  "name": "tool-calling-foundry-local",
+  "private": true,
   "type": "module",
+  "description": "Tool calling sample using Foundry Local SDK",
+  "scripts": {
+    "setup": "node setup.cjs",
+    "start": "node src/app.js"
+  },
   "dependencies": {
+    "foundry-local-sdk": "latest",
     "openai": "^6.25.0"
   }
 }

--- a/samples/js/tool-calling-foundry-local/setup.cjs
+++ b/samples/js/tool-calling-foundry-local/setup.cjs
@@ -1,0 +1,11 @@
+// Cross-platform dependency installer
+// Automatically uses --winml on Windows for hardware-accelerated inference
+const { execSync } = require('child_process');
+
+const isWindows = process.platform === 'win32';
+const cmd = isWindows
+  ? 'npm install --foreground-scripts --winml'
+  : 'npm install --foreground-scripts';
+
+console.log(`Running: ${cmd}`);
+execSync(cmd, { stdio: 'inherit' });

--- a/samples/js/web-server-example/README.md
+++ b/samples/js/web-server-example/README.md
@@ -5,35 +5,12 @@ This sample demonstrates how to use the Foundry Local SDK to perform chat comple
 ## Prerequisites
 - Ensure you have Node.js installed (version 20 or higher is recommended).
 
-## Setup project
+## Setup and run
 
-Navigate to the sample directory, setup the project, and install the required packages.
-
-1. Navigate to the sample directory and setup the project:
-    ```bash
-    cd samples/js/web-server-example
-    npm init -y
-    npm pkg set type=module
-    ```
-1. Install the Foundry Local and OpenAI packages:
-
-    **macOS / Linux:**
-    ```bash
-    npm install --foreground-scripts foundry-local-sdk
-    npm install openai
-    ```
-
-    **Windows:**
-    ```bash
-    npm install --foreground-scripts --winml foundry-local-sdk
-    npm install openai
-    ```
-
-## Run the sample
-
-Run the sample script using Node.js:
+Navigate to the sample directory, install the dependencies, and run the sample:
 
 ```bash
 cd samples/js/web-server-example
+npm run setup
 node app.js
 ```

--- a/samples/js/web-server-example/package.json
+++ b/samples/js/web-server-example/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "web-server-example",
+  "private": true,
+  "type": "module",
+  "description": "OpenAI-compatible web server sample using Foundry Local SDK",
+  "scripts": {
+    "setup": "node setup.cjs",
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "foundry-local-sdk": "latest",
+    "openai": "latest"
+  }
+}

--- a/samples/js/web-server-example/setup.cjs
+++ b/samples/js/web-server-example/setup.cjs
@@ -1,0 +1,11 @@
+// Cross-platform dependency installer
+// Automatically uses --winml on Windows for hardware-accelerated inference
+const { execSync } = require('child_process');
+
+const isWindows = process.platform === 'win32';
+const cmd = isWindows
+  ? 'npm install --foreground-scripts --winml'
+  : 'npm install --foreground-scripts';
+
+console.log(`Running: ${cmd}`);
+execSync(cmd, { stdio: 'inherit' });


### PR DESCRIPTION
Simplify the samples so that users only need to:

```bash
npm run setup
node app.js
```

The setup script detects if the machine is Windows and installs FLC winml.