### PR TITLE
refactor(www): SDK-first website refresh

### DIFF
--- a/www/src/lib/components/download-dropdown.svelte
+++ b/www/src/lib/components/download-dropdown.svelte
@@ -39,9 +39,13 @@
 		windows: 'winget install Microsoft.FoundryLocal',
 		macos: 'brew install microsoft/foundrylocal/foundrylocal',
 		python: 'pip install foundry-local-sdk',
+		python_winml: 'pip install foundry-local-sdk-winml',
 		javascript: 'npm install foundry-local-sdk',
+		javascript_winml: 'npm install foundry-local-sdk-winml',
 		csharp: 'dotnet add package Microsoft.AI.Foundry.Local',
-		rust: 'cargo add foundry-local'
+		csharp_winml: 'dotnet add package Microsoft.AI.Foundry.Local.WinML',
+		rust: 'cargo add foundry-local-sdk',
+		rust_winml: 'cargo add foundry-local-sdk --features winml'
 	};
 
 	let copiedItem = $state<string | null>(null);
@@ -122,7 +126,7 @@
 
 		<DropdownMenu.Separator />
 		<DropdownMenu.Label class="text-muted-foreground text-xs font-normal">
-			Install SDK
+			Install SDK (Cross-Platform)
 		</DropdownMenu.Label>
 
 		<DropdownMenu.Group>
@@ -195,6 +199,89 @@
 					<code class="text-muted-foreground break-all text-xs">{commands.rust}</code>
 				</div>
 				{#if copiedItem === 'rust'}
+					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
+					<span class="sr-only">Copied</span>
+				{:else}
+					<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
+				{/if}
+			</button>
+		</DropdownMenu.Group>
+
+		<DropdownMenu.Separator />
+		<DropdownMenu.Label class="text-muted-foreground text-xs font-normal">
+			Install SDK (Windows + WinML hardware acceleration)
+		</DropdownMenu.Label>
+
+		<DropdownMenu.Group>
+			<button
+				type="button"
+				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
+				onclick={() => copyToClipboard(commands.python_winml, 'python_winml')}
+				aria-label="Copy Python WinML SDK installation command"
+			>
+				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html PythonIcon}</span>
+				<div class="flex flex-1 flex-col gap-1 px-2">
+					<span class="font-medium">Python SDK <span class="text-xs text-muted-foreground">(WinML)</span></span>
+					<code class="text-muted-foreground break-all text-xs">{commands.python_winml}</code>
+				</div>
+				{#if copiedItem === 'python_winml'}
+					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
+					<span class="sr-only">Copied</span>
+				{:else}
+					<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
+				{/if}
+			</button>
+
+			<button
+				type="button"
+				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
+				onclick={() => copyToClipboard(commands.javascript_winml, 'javascript_winml')}
+				aria-label="Copy JavaScript WinML SDK installation command"
+			>
+				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html JavaScriptIcon}</span>
+				<div class="flex flex-1 flex-col gap-1 px-2">
+					<span class="font-medium">JavaScript SDK <span class="text-xs text-muted-foreground">(WinML)</span></span>
+					<code class="text-muted-foreground break-all text-xs">{commands.javascript_winml}</code>
+				</div>
+				{#if copiedItem === 'javascript_winml'}
+					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
+					<span class="sr-only">Copied</span>
+				{:else}
+					<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
+				{/if}
+			</button>
+
+			<button
+				type="button"
+				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
+				onclick={() => copyToClipboard(commands.csharp_winml, 'csharp_winml')}
+				aria-label="Copy C# WinML SDK installation command"
+			>
+				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html CSharpIcon}</span>
+				<div class="flex flex-1 flex-col gap-1 px-2">
+					<span class="font-medium">C# SDK <span class="text-xs text-muted-foreground">(WinML)</span></span>
+					<code class="text-muted-foreground break-all text-xs">{commands.csharp_winml}</code>
+				</div>
+				{#if copiedItem === 'csharp_winml'}
+					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
+					<span class="sr-only">Copied</span>
+				{:else}
+					<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
+				{/if}
+			</button>
+
+			<button
+				type="button"
+				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
+				onclick={() => copyToClipboard(commands.rust_winml, 'rust_winml')}
+				aria-label="Copy Rust WinML SDK installation command"
+			>
+				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html RustIcon}</span>
+				<div class="flex flex-1 flex-col gap-1 px-2">
+					<span class="font-medium">Rust SDK <span class="text-xs text-muted-foreground">(WinML)</span></span>
+					<code class="text-muted-foreground break-all text-xs">{commands.rust_winml}</code>
+				</div>
+				{#if copiedItem === 'rust_winml'}
 					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
 					<span class="sr-only">Copied</span>
 				{:else}

--- a/www/src/lib/components/download-dropdown.svelte
+++ b/www/src/lib/components/download-dropdown.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Button, buttonVariants } from '$lib/components/ui/button';
+	import { buttonVariants } from '$lib/components/ui/button';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { Download, Copy, Check } from 'lucide-svelte';
 	import { toast } from 'svelte-sonner';
@@ -12,6 +12,20 @@
 		class?: string;
 	}
 
+	type CommandItem = {
+		id: string;
+		label: string;
+		command: string;
+		badge: string;
+		ariaLabel: string;
+	};
+
+	type CommandSection = {
+		title: string;
+		description: string;
+		items: CommandItem[];
+	};
+
 	let {
 		variant = 'ghost',
 		size = 'default',
@@ -21,32 +35,96 @@
 
 	const isMobile = new IsMobile();
 
-	// Platform SVG icons
-	const AppleIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M11.182.008C11.148-.03 9.923.023 8.857 1.18c-1.066 1.156-.902 2.482-.878 2.516.024.034 1.52.087 2.475-1.258.955-1.345.762-2.391.728-2.43zm3.314 11.733c-.048-.096-2.325-1.234-2.113-3.422.212-2.189 1.675-2.789 1.698-2.854.023-.065-.597-.79-1.254-1.157a3.692 3.692 0 0 0-1.563-.434c-.108-.003-.483-.095-1.254.116-.508.139-1.653.589-1.968.607-.316.018-1.256-.522-2.267-.665-.647-.125-1.333.131-1.824.328-.49.196-1.422.754-2.074 2.237-.652 1.482-.311 3.83-.067 4.56.244.729.625 1.924 1.273 2.796.576.984 1.34 1.667 1.659 1.899.319.232 1.219.386 1.843.067.502-.308 1.408-.485 1.766-.472.357.013 1.061.154 1.782.539.571.197 1.111.115 1.652-.105.541-.221 1.324-1.059 2.238-2.758.347-.79.505-1.217.473-1.282z"/></svg>`;
-
-	const WindowsIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M6.555 1.375 0 2.237v5.45h6.555V1.375zM0 13.795l6.555.933V8.313H0v5.482zm7.278-5.4.026 6.378L16 16V8.395H7.278zM16 0 7.33 1.244v6.414H16V0z"/></svg>`;
-
-	const PythonIcon = `<svg role="img" width="16" height="16" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Python</title><path d="M14.25.18l.9.2.73.26.59.3.45.32.34.34.25.34.16.33.1.3.04.26.02.2-.01.13V8.5l-.05.63-.13.55-.21.46-.26.38-.3.31-.33.25-.35.19-.35.14-.33.1-.3.07-.26.04-.21.02H8.77l-.69.05-.59.14-.5.22-.41.27-.33.32-.27.35-.2.36-.15.37-.1.35-.07.32-.04.27-.02.21v3.06H3.17l-.21-.03-.28-.07-.32-.12-.35-.18-.36-.26-.36-.36-.35-.46-.32-.59-.28-.73-.21-.88-.14-1.05-.05-1.23.06-1.22.16-1.04.24-.87.32-.71.36-.57.4-.44.42-.33.42-.24.4-.16.36-.1.32-.05.24-.01h.16l.06.01h8.16v-.83H6.18l-.01-2.75-.02-.37.05-.34.11-.31.17-.28.25-.26.31-.23.38-.2.44-.18.51-.15.58-.12.64-.1.71-.06.77-.04.84-.02 1.27.05zm-6.3 1.98l-.23.33-.08.41.08.41.23.34.33.22.41.09.41-.09.33-.22.23-.34.08-.41-.08-.41-.23-.33-.33-.22-.41-.09-.41.09zm13.09 3.95l.28.06.32.12.35.18.36.27.36.35.35.47.32.59.28.73.21.88.14 1.04.05 1.23-.06 1.23-.16 1.04-.24.86-.32.71-.36.57-.4.45-.42.33-.42.24-.4.16-.36.09-.32.05-.24.02-.16-.01h-8.22v.82h5.84l.01 2.76.02.36-.05.34-.11.31-.17.29-.25.25-.31.24-.38.2-.44.17-.51.15-.58.13-.64.09-.71.07-.77.04-.84.01-1.27-.04-1.07-.14-.9-.2-.73-.25-.59-.3-.45-.33-.34-.34-.25-.34-.16-.33-.1-.3-.04-.25-.02-.2.01-.13v-5.34l.05-.64.13-.54.21-.46.26-.38.3-.32.33-.24.35-.2.35-.14.33-.1.3-.06.26-.04.21-.02.13-.01h5.84l.69-.05.59-.14.5-.21.41-.28.33-.32.27-.35.2-.36.15-.36.1-.35.07-.32.04-.28.02-.21V6.07h2.09l.14.01zm-6.47 14.25l-.23.33-.08.41.08.41.23.33.33.23.41.08.41-.08.33-.23.23-.33.08-.41-.08-.41-.23-.33-.33-.23-.41-.08-.41.08z"/></svg>`;
-
-	const JavaScriptIcon = `<svg role="img" width="16" height="16" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>JavaScript</title><path d="M0 0h24v24H0V0zm22.034 18.276c-.175-1.095-.888-2.015-3.003-2.873-.736-.345-1.554-.585-1.797-1.14-.091-.33-.105-.51-.046-.705.15-.646.915-.84 1.515-.66.39.12.75.42.976.9 1.034-.676 1.034-.676 1.755-1.125-.27-.42-.404-.601-.586-.78-.63-.705-1.469-1.065-2.834-1.034l-.705.089c-.676.165-1.32.525-1.71 1.005-1.14 1.291-.811 3.541.569 4.471 1.365 1.02 3.361 1.244 3.616 2.205.24 1.17-.87 1.545-1.966 1.41-.811-.18-1.26-.586-1.755-1.336l-1.83 1.051c.21.48.45.689.81 1.109 1.74 1.756 6.09 1.666 6.871-1.004.029-.09.24-.705.074-1.65l.046.067zm-8.983-7.245h-2.248c0 1.938-.009 3.864-.009 5.805 0 1.232.063 2.363-.138 2.711-.33.689-1.18.601-1.566.48-.396-.196-.597-.466-.83-.855-.063-.105-.11-.196-.127-.196l-1.825 1.125c.305.63.75 1.172 1.324 1.517.855.51 2.004.675 3.207.405.783-.226 1.458-.691 1.811-1.411.51-.93.402-2.07.397-3.346.012-2.054 0-4.109 0-6.179l.004-.056z"/></svg>`;
-
-	const CSharpIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 50 50" fill="currentColor"><path d="M 25 2 C 24.285156 2 23.570313 2.179688 22.933594 2.539063 L 6.089844 12.003906 C 4.800781 12.726563 4 14.082031 4 15.535156 L 4 34.464844 C 4 35.917969 4.800781 37.273438 6.089844 37.996094 L 22.933594 47.460938 C 23.570313 47.820313 24.285156 48 25 48 C 25.714844 48 26.429688 47.820313 27.066406 47.460938 L 43.910156 38 C 45.199219 37.273438 46 35.917969 46 34.464844 L 46 15.535156 C 46 14.082031 45.199219 12.726563 43.910156 12.003906 L 27.066406 2.539063 C 26.429688 2.179688 25.714844 2 25 2 Z M 25 13 C 28.78125 13 32.277344 14.753906 34.542969 17.738281 L 30.160156 20.277344 C 28.84375 18.835938 26.972656 18 25 18 C 21.140625 18 18 21.140625 18 25 C 18 28.859375 21.140625 32 25 32 C 26.972656 32 28.84375 31.164063 30.160156 29.722656 L 34.542969 32.261719 C 32.277344 35.246094 28.78125 37 25 37 C 18.382813 37 13 31.617188 13 25 C 13 18.382813 18.382813 13 25 13 Z M 35 20 L 37 20 L 37 22 L 39 22 L 39 20 L 41 20 L 41 22 L 43 22 L 43 24 L 41 24 L 41 26 L 43 26 L 43 28 L 41 28 L 41 30 L 39 30 L 39 28 L 37 28 L 37 30 L 35 30 L 35 28 L 33 28 L 33 26 L 35 26 L 35 24 L 33 24 L 33 22 L 35 22 Z M 37 24 L 37 26 L 39 26 L 39 24 Z"/></svg>`;
-
-	const RustIcon = `<svg role="img" width="16" height="16" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M23.8346 11.7033l-1.0073-.6236a13.7268 13.7268 0 00-.0283-.2936l.8656-.8069a.3483.3483 0 00-.1154-.578l-1.1066-.414a8.4958 8.4958 0 00-.087-.2856l.6904-.9587a.3462.3462 0 00-.2257-.5446l-1.1663-.1894a9.3574 9.3574 0 00-.1407-.2622l.49-1.0761a.3437.3437 0 00-.0274-.3361.3486.3486 0 00-.3006-.154l-1.1845.0416a6.7444 6.7444 0 00-.1873-.2268l.2723-1.153a.3472.3472 0 00-.417-.4172l-1.1532.2724a14.0183 14.0183 0 00-.2278-.1873l.0415-1.1845a.3442.3442 0 00-.49-.328l-1.076.491c-.0872-.0476-.1742-.0952-.2623-.1407l-.1903-1.1673A.3483.3483 0 0016.256.955l-.9597.6905a8.4867 8.4867 0 00-.2855-.086l-.414-1.1066a.3483.3483 0 00-.5781-.1154l-.8069.8666a9.2936 9.2936 0 00-.2936-.0284L12.2946.1683a.3462.3462 0 00-.5892 0l-.6236 1.0073a13.7383 13.7383 0 00-.2936.0284L9.9803.3374a.3462.3462 0 00-.578.1154l-.4141 1.1065c-.0962.0274-.1903.0567-.2855.086L7.744.955a.3483.3483 0 00-.5447.2258L7.009 2.348a9.3574 9.3574 0 00-.2622.1407l-1.0762-.491a.3462.3462 0 00-.49.328l.0416 1.1845a7.9826 7.9826 0 00-.2278.1873L3.8413 3.425a.3472.3472 0 00-.4171.4171l.2713 1.1531c-.0628.075-.1255.1509-.1863.2268l-1.1845-.0415a.3462.3462 0 00-.328.49l.491 1.0761a9.167 9.167 0 00-.1407.2622l-1.1662.1894a.3483.3483 0 00-.2258.5446l.6904.9587a13.303 13.303 0 00-.087.2855l-1.1065.414a.3483.3483 0 00-.1155.5781l.8656.807a9.2936 9.2936 0 00-.0283.2935l-1.0073.6236a.3442.3442 0 000 .5892l1.0073.6236c.008.0982.0182.1964.0283.2936l-.8656.8079a.3462.3462 0 00.1155.578l1.1065.4141c.0273.0962.0567.1914.087.2855l-.6904.9587a.3452.3452 0 00.2268.5447l1.1662.1893c.0456.088.0922.1751.1408.2622l-.491 1.0762a.3462.3462 0 00.328.49l1.1834-.0415c.0618.0769.1235.1528.1873.2277l-.2713 1.1541a.3462.3462 0 00.4171.4161l1.153-.2713c.075.0638.151.1255.2279.1863l-.0415 1.1845a.3442.3442 0 00.49.327l1.0761-.49c.087.0486.1741.0951.2622.1407l.1903 1.1662a.3483.3483 0 00.5447.2268l.9587-.6904a9.299 9.299 0 00.2855.087l.414 1.1066a.3452.3452 0 00.5781.1154l.8079-.8656c.0972.0111.1954.0203.2936.0294l.6236 1.0073a.3472.3472 0 00.5892 0l.6236-1.0073c.0982-.0091.1964-.0183.2936-.0294l.8069.8656a.3483.3483 0 00.578-.1154l.4141-1.1066a8.4626 8.4626 0 00.2855-.087l.9587.6904a.3452.3452 0 00.5447-.2268l.1903-1.1662c.088-.0456.1751-.0931.2622-.1407l1.0762.49a.3472.3472 0 00.49-.327l-.0415-1.1845a6.7267 6.7267 0 00.2267-.1863l1.1531.2713a.3472.3472 0 00.4171-.416l-.2713-1.1542c.0628-.0749.1255-.1508.1863-.2278l1.1845.0415a.3442.3442 0 00.328-.49l-.49-1.076c.0475-.0872.0951-.1742.1407-.2623l1.1662-.1893a.3483.3483 0 00.2258-.5447l-.6904-.9587.087-.2855 1.1066-.414a.3462.3462 0 00.1154-.5781l-.8656-.8079c.0101-.0972.0202-.1954.0283-.2936l1.0073-.6236a.3442.3442 0 000-.5892zm-6.7413 8.3551a.7138.7138 0 01.2986-1.396.714.714 0 11-.2997 1.396zm-.3422-2.3142a.649.649 0 00-.7715.5l-.3573 1.6685c-1.1035.501-2.3285.7795-3.6193.7795a8.7368 8.7368 0 01-3.6951-.814l-.3574-1.6684a.648.648 0 00-.7714-.499l-1.473.3158a8.7216 8.7216 0 01-.7613-.898h7.1676c.081 0 .1356-.0141.1356-.088v-2.536c0-.074-.0536-.0881-.1356-.0881h-2.0966v-1.6077h2.2677c.2065 0 1.1065.0587 1.394 1.2088.0901.3533.2875 1.5044.4232 1.8729.1346.413.6833 1.2381 1.2685 1.2381h3.5716a.7492.7492 0 00.1296-.0131 8.7874 8.7874 0 01-.8119.9526zM6.8369 20.024a.714.714 0 11-.2997-1.396.714.714 0 01.2997 1.396zM4.1177 8.9972a.7137.7137 0 11-1.304.5791.7137.7137 0 011.304-.579zm-.8352 1.9813l1.5347-.6824a.65.65 0 00.33-.8585l-.3158-.7147h1.2432v5.6025H3.5669a8.7753 8.7753 0 01-.2834-3.348zm6.7343-.5437V8.7836h2.9601c.153 0 1.0792.1772 1.0792.8697 0 .575-.7107.7815-1.2948.7815zm10.7574 1.4862c0 .2187-.008.4363-.0243.651h-.9c-.09 0-.1265.0586-.1265.1477v.413c0 .973-.5487 1.1846-1.0296 1.2382-.4576.0517-.9648-.1913-1.0275-.4717-.2704-1.5186-.7198-1.8436-1.4305-2.4034.8817-.5599 1.799-1.386 1.799-2.4915 0-1.1936-.819-1.9458-1.3769-2.3153-.7825-.5163-1.6491-.6195-1.883-.6195H5.4682a8.7651 8.7651 0 014.907-2.7699l1.0974 1.151a.648.648 0 00.9182.0213l1.227-1.1743a8.7753 8.7753 0 016.0044 4.2762l-.8403 1.8982a.652.652 0 00.33.8585l1.6178.7188c.0283.2875.0425.577.0425.8717zm-9.3006-9.5993a.7128.7128 0 11.984 1.0316.7137.7137 0 01-.984-1.0316zm8.3389 6.71a.7107.7107 0 01.9395-.3625.7137.7137 0 11-.9405.3635z"/></svg>`;
-
-	// Commands to copy
-	const commands = {
-		windows: 'winget install Microsoft.FoundryLocal',
-		macos: 'brew install microsoft/foundrylocal/foundrylocal',
-		python: 'pip install foundry-local-sdk',
-		python_winml: 'pip install foundry-local-sdk-winml',
-		javascript: 'npm install foundry-local-sdk',
-		javascript_winml: 'npm install foundry-local-sdk-winml',
-		csharp: 'dotnet add package Microsoft.AI.Foundry.Local',
-		csharp_winml: 'dotnet add package Microsoft.AI.Foundry.Local.WinML',
-		rust: 'cargo add foundry-local-sdk',
-		rust_winml: 'cargo add foundry-local-sdk --features winml'
-	};
+	const sections: CommandSection[] = [
+		{
+			title: 'Start with an SDK',
+			description: 'Use this path when you are building an application with local inference.',
+			items: [
+				{
+					id: 'python',
+					label: 'Python SDK',
+					command: 'pip install foundry-local-sdk',
+					badge: 'PY',
+					ariaLabel: 'Copy Python SDK installation command'
+				},
+				{
+					id: 'javascript',
+					label: 'JavaScript SDK',
+					command: 'npm install foundry-local-sdk',
+					badge: 'JS',
+					ariaLabel: 'Copy JavaScript SDK installation command'
+				},
+				{
+					id: 'csharp',
+					label: 'C# SDK',
+					command: 'dotnet add package Microsoft.AI.Foundry.Local',
+					badge: 'C#',
+					ariaLabel: 'Copy C# SDK installation command'
+				},
+				{
+					id: 'rust',
+					label: 'Rust SDK',
+					command: 'cargo add foundry-local-sdk',
+					badge: 'RS',
+					ariaLabel: 'Copy Rust SDK installation command'
+				}
+			]
+		},
+		{
+			title: 'Windows SDK acceleration',
+			description: 'Use WinML packages when you want Windows hardware acceleration from the SDK.',
+			items: [
+				{
+					id: 'python_winml',
+					label: 'Python SDK (WinML)',
+					command: 'pip install foundry-local-sdk-winml',
+					badge: 'PY',
+					ariaLabel: 'Copy Python WinML SDK installation command'
+				},
+				{
+					id: 'javascript_winml',
+					label: 'JavaScript SDK (WinML)',
+					command: 'npm install foundry-local-sdk-winml',
+					badge: 'JS',
+					ariaLabel: 'Copy JavaScript WinML SDK installation command'
+				},
+				{
+					id: 'csharp_winml',
+					label: 'C# SDK (WinML)',
+					command: 'dotnet add package Microsoft.AI.Foundry.Local.WinML',
+					badge: 'C#',
+					ariaLabel: 'Copy C# WinML SDK installation command'
+				},
+				{
+					id: 'rust_winml',
+					label: 'Rust SDK (WinML)',
+					command: 'cargo add foundry-local-sdk --features winml',
+					badge: 'RS',
+					ariaLabel: 'Copy Rust WinML SDK installation command'
+				}
+			]
+		},
+		{
+			title: 'Optional CLI tools',
+			description: 'Use the CLI to explore models or test prompts outside your app.',
+			items: [
+				{
+					id: 'windows',
+					label: 'Windows CLI',
+					command: 'winget install Microsoft.FoundryLocal',
+					badge: 'WIN',
+					ariaLabel: 'Copy Windows CLI installation command'
+				},
+				{
+					id: 'macos',
+					label: 'macOS CLI',
+					command: 'brew install microsoft/foundrylocal/foundrylocal',
+					badge: 'MAC',
+					ariaLabel: 'Copy macOS CLI installation command'
+				}
+			]
+		}
+	];
 
 	let copiedItem = $state<string | null>(null);
 
@@ -54,7 +132,7 @@
 		try {
 			await navigator.clipboard.writeText(text);
 			copiedItem = label;
-			toast.success(`Copied to clipboard!`);
+			toast.success('Copied to clipboard!');
 			setTimeout(() => {
 				copiedItem = null;
 			}, 2000);
@@ -67,231 +145,64 @@
 <DropdownMenu.Root bind:open>
 	<DropdownMenu.Trigger
 		class={`${buttonVariants({ variant, size })} ${className} group`}
-		aria-label="Download Foundry Local for your platform"
+		aria-label="Install Foundry Local SDK or CLI"
 	>
 		<Download
 			class="download-hover-icon mr-2 size-4 transition-transform duration-300"
 			aria-hidden="true"
 		/>
-		<span>Download</span>
+		<span>Install</span>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content
 		align="end"
-		class={isMobile.current ? 'mx-4 w-[calc(100vw-2rem)]' : 'w-[28rem]'}
-		aria-label="Download options"
+		class={isMobile.current ? 'mx-4 w-[calc(100vw-2rem)]' : 'w-[30rem]'}
+		aria-label="Install options"
 	>
-		<DropdownMenu.Label>Download Foundry Local</DropdownMenu.Label>
-		<DropdownMenu.Separator />
+		<DropdownMenu.Label>Install Foundry Local</DropdownMenu.Label>
+		<p class="text-muted-foreground px-2 pb-2 text-xs leading-relaxed">
+			Choose an SDK to embed local AI in your app. The CLI is available as secondary developer
+			tooling.
+		</p>
 
-		<DropdownMenu.Group>
-			<button
-				type="button"
-				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
-				onclick={() => copyToClipboard(commands.windows, 'windows')}
-				aria-label="Copy Windows installation command"
-			>
-				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html WindowsIcon}</span>
-				<div class="flex flex-1 flex-col gap-1 px-2">
-					<span class="font-medium">Windows</span>
-					<code class="text-muted-foreground break-all text-xs">{commands.windows}</code>
-				</div>
-				{#if copiedItem === 'windows'}
-					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
-					<span class="sr-only">Copied</span>
-				{:else}
-					<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
-				{/if}
-			</button>
+		{#each sections as section}
+			<DropdownMenu.Separator />
+			<DropdownMenu.Label class="text-muted-foreground text-xs font-normal">
+				{section.title}
+			</DropdownMenu.Label>
+			<p class="text-muted-foreground px-2 pb-1 text-[11px] leading-relaxed">
+				{section.description}
+			</p>
 
-			<button
-				type="button"
-				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
-				onclick={() => copyToClipboard(commands.macos, 'macos')}
-				aria-label="Copy macOS installation command"
-			>
-				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html AppleIcon}</span>
-				<div class="flex flex-1 flex-col gap-1 px-2">
-					<span class="font-medium">macOS</span>
-					<code class="text-muted-foreground whitespace-pre break-all text-xs"
-						>{commands.macos}</code
+			<DropdownMenu.Group>
+				{#each section.items as item}
+					<button
+						type="button"
+						class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm transition-colors outline-none select-none"
+						onclick={() => copyToClipboard(item.command, item.id)}
+						aria-label={item.ariaLabel}
 					>
-				</div>
-				{#if copiedItem === 'macos'}
-					<Check class="size-4 shrink-0 text-green-600" />
-				{:else}
-					<Copy class="size-4 shrink-0 opacity-50" />
-				{/if}
-			</button>
-		</DropdownMenu.Group>
+						<span
+							class="bg-primary/10 text-primary mt-0.5 inline-flex min-w-8 shrink-0 items-center justify-center rounded-md px-1.5 py-1 font-mono text-[10px] font-bold"
+							aria-hidden="true"
+						>
+							{item.badge}
+						</span>
+						<div class="flex flex-1 flex-col gap-1 px-2">
+							<span class="font-medium">{item.label}</span>
+							<code class="text-muted-foreground text-xs break-all">{item.command}</code>
+						</div>
+						{#if copiedItem === item.id}
+							<Check class="text-primary size-4 shrink-0" aria-hidden="true" />
+							<span class="sr-only">Copied</span>
+						{:else}
+							<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
+						{/if}
+					</button>
+				{/each}
+			</DropdownMenu.Group>
+		{/each}
 
 		<DropdownMenu.Separator />
-		<DropdownMenu.Label class="text-muted-foreground text-xs font-normal">
-			Install SDK (Cross-Platform)
-		</DropdownMenu.Label>
-
-		<DropdownMenu.Group>
-			<button
-				type="button"
-				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
-				onclick={() => copyToClipboard(commands.python, 'python')}
-				aria-label="Copy Python SDK installation command"
-			>
-				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html PythonIcon}</span>
-				<div class="flex flex-1 flex-col gap-1 px-2">
-					<span class="font-medium">Python SDK</span>
-					<code class="text-muted-foreground break-all text-xs">{commands.python}</code>
-				</div>
-				{#if copiedItem === 'python'}
-					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
-					<span class="sr-only">Copied</span>
-				{:else}
-					<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
-				{/if}
-			</button>
-
-			<button
-				type="button"
-				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
-				onclick={() => copyToClipboard(commands.javascript, 'javascript')}
-				aria-label="Copy JavaScript SDK installation command"
-			>
-				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html JavaScriptIcon}</span>
-				<div class="flex flex-1 flex-col gap-1 px-2">
-					<span class="font-medium">JavaScript SDK</span>
-					<code class="text-muted-foreground break-all text-xs">{commands.javascript}</code>
-				</div>
-				{#if copiedItem === 'javascript'}
-					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
-					<span class="sr-only">Copied</span>
-				{:else}
-					<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
-				{/if}
-			</button>
-
-			<button
-				type="button"
-				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
-				onclick={() => copyToClipboard(commands.csharp, 'csharp')}
-				aria-label="Copy C# SDK installation command"
-			>
-				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html CSharpIcon}</span>
-				<div class="flex flex-1 flex-col gap-1 px-2">
-					<span class="font-medium">C# SDK</span>
-					<code class="text-muted-foreground break-all text-xs">{commands.csharp}</code>
-				</div>
-				{#if copiedItem === 'csharp'}
-					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
-					<span class="sr-only">Copied</span>
-				{:else}
-					<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
-				{/if}
-			</button>
-
-			<button
-				type="button"
-				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
-				onclick={() => copyToClipboard(commands.rust, 'rust')}
-				aria-label="Copy Rust SDK installation command"
-			>
-				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html RustIcon}</span>
-				<div class="flex flex-1 flex-col gap-1 px-2">
-					<span class="font-medium">Rust SDK</span>
-					<code class="text-muted-foreground break-all text-xs">{commands.rust}</code>
-				</div>
-				{#if copiedItem === 'rust'}
-					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
-					<span class="sr-only">Copied</span>
-				{:else}
-					<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
-				{/if}
-			</button>
-		</DropdownMenu.Group>
-
-		<DropdownMenu.Separator />
-		<DropdownMenu.Label class="text-muted-foreground text-xs font-normal">
-			Install SDK (Windows + WinML hardware acceleration)
-		</DropdownMenu.Label>
-
-		<DropdownMenu.Group>
-			<button
-				type="button"
-				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
-				onclick={() => copyToClipboard(commands.python_winml, 'python_winml')}
-				aria-label="Copy Python WinML SDK installation command"
-			>
-				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html PythonIcon}</span>
-				<div class="flex flex-1 flex-col gap-1 px-2">
-					<span class="font-medium">Python SDK <span class="text-xs text-muted-foreground">(WinML)</span></span>
-					<code class="text-muted-foreground break-all text-xs">{commands.python_winml}</code>
-				</div>
-				{#if copiedItem === 'python_winml'}
-					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
-					<span class="sr-only">Copied</span>
-				{:else}
-					<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
-				{/if}
-			</button>
-
-			<button
-				type="button"
-				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
-				onclick={() => copyToClipboard(commands.javascript_winml, 'javascript_winml')}
-				aria-label="Copy JavaScript WinML SDK installation command"
-			>
-				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html JavaScriptIcon}</span>
-				<div class="flex flex-1 flex-col gap-1 px-2">
-					<span class="font-medium">JavaScript SDK <span class="text-xs text-muted-foreground">(WinML)</span></span>
-					<code class="text-muted-foreground break-all text-xs">{commands.javascript_winml}</code>
-				</div>
-				{#if copiedItem === 'javascript_winml'}
-					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
-					<span class="sr-only">Copied</span>
-				{:else}
-					<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
-				{/if}
-			</button>
-
-			<button
-				type="button"
-				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
-				onclick={() => copyToClipboard(commands.csharp_winml, 'csharp_winml')}
-				aria-label="Copy C# WinML SDK installation command"
-			>
-				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html CSharpIcon}</span>
-				<div class="flex flex-1 flex-col gap-1 px-2">
-					<span class="font-medium">C# SDK <span class="text-xs text-muted-foreground">(WinML)</span></span>
-					<code class="text-muted-foreground break-all text-xs">{commands.csharp_winml}</code>
-				</div>
-				{#if copiedItem === 'csharp_winml'}
-					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
-					<span class="sr-only">Copied</span>
-				{:else}
-					<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
-				{/if}
-			</button>
-
-			<button
-				type="button"
-				class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer select-none items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm outline-none transition-colors"
-				onclick={() => copyToClipboard(commands.rust_winml, 'rust_winml')}
-				aria-label="Copy Rust WinML SDK installation command"
-			>
-				<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html RustIcon}</span>
-				<div class="flex flex-1 flex-col gap-1 px-2">
-					<span class="font-medium">Rust SDK <span class="text-xs text-muted-foreground">(WinML)</span></span>
-					<code class="text-muted-foreground break-all text-xs">{commands.rust_winml}</code>
-				</div>
-				{#if copiedItem === 'rust_winml'}
-					<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
-					<span class="sr-only">Copied</span>
-				{:else}
-					<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
-				{/if}
-			</button>
-		</DropdownMenu.Group>
-
-		<DropdownMenu.Separator />
-
 		<DropdownMenu.Group>
 			<DropdownMenu.Item>
 				<a
@@ -301,8 +212,7 @@
 					class="flex w-full items-center"
 					aria-label="View all releases on GitHub (opens in new tab)"
 				>
-					<svg class="mr-2 size-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
-					<span>All Releases</span>
+					<span>All releases</span>
 				</a>
 			</DropdownMenu.Item>
 		</DropdownMenu.Group>

--- a/www/src/lib/components/download-dropdown.svelte
+++ b/www/src/lib/components/download-dropdown.svelte
@@ -12,20 +12,6 @@
 		class?: string;
 	}
 
-	type CommandItem = {
-		id: string;
-		label: string;
-		command: string;
-		badge: string;
-		ariaLabel: string;
-	};
-
-	type CommandSection = {
-		title: string;
-		description: string;
-		items: CommandItem[];
-	};
-
 	let {
 		variant = 'ghost',
 		size = 'default',
@@ -35,106 +21,99 @@
 
 	const isMobile = new IsMobile();
 
-	const sections: CommandSection[] = [
+	// Platform SVG icons
+	const AppleIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M11.182.008C11.148-.03 9.923.023 8.857 1.18c-1.066 1.156-.902 2.482-.878 2.516.024.034 1.52.087 2.475-1.258.955-1.345.762-2.391.728-2.43zm3.314 11.733c-.048-.096-2.325-1.234-2.113-3.422.212-2.189 1.675-2.789 1.698-2.854.023-.065-.597-.79-1.254-1.157a3.692 3.692 0 0 0-1.563-.434c-.108-.003-.483-.095-1.254.116-.508.139-1.653.589-1.968.607-.316.018-1.256-.522-2.267-.665-.647-.125-1.333.131-1.824.328-.49.196-1.422.754-2.074 2.237-.652 1.482-.311 3.83-.067 4.56.244.729.625 1.924 1.273 2.796.576.984 1.34 1.667 1.659 1.899.319.232 1.219.386 1.843.067.502-.308 1.408-.485 1.766-.472.357.013 1.061.154 1.782.539.571.197 1.111.115 1.652-.105.541-.221 1.324-1.059 2.238-2.758.347-.79.505-1.217.473-1.282z"/></svg>`;
+
+	const WindowsIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M6.555 1.375 0 2.237v5.45h6.555V1.375zM0 13.795l6.555.933V8.313H0v5.482zm7.278-5.4.026 6.378L16 16V8.395H7.278zM16 0 7.33 1.244v6.414H16V0z"/></svg>`;
+
+	const PythonIcon = `<svg role="img" width="16" height="16" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Python</title><path d="M14.25.18l.9.2.73.26.59.3.45.32.34.34.25.34.16.33.1.3.04.26.02.2-.01.13V8.5l-.05.63-.13.55-.21.46-.26.38-.3.31-.33.25-.35.19-.35.14-.33.1-.3.07-.26.04-.21.02H8.77l-.69.05-.59.14-.5.22-.41.27-.33.32-.27.35-.2.36-.15.37-.1.35-.07.32-.04.27-.02.21v3.06H3.17l-.21-.03-.28-.07-.32-.12-.35-.18-.36-.26-.36-.36-.35-.46-.32-.59-.28-.73-.21-.88-.14-1.05-.05-1.23.06-1.22.16-1.04.24-.87.32-.71.36-.57.4-.44.42-.33.42-.24.4-.16.36-.1.32-.05.24-.01h.16l.06.01h8.16v-.83H6.18l-.01-2.75-.02-.37.05-.34.11-.31.17-.28.25-.26.31-.23.38-.2.44-.18.51-.15.58-.12.64-.1.71-.06.77-.04.84-.02 1.27.05zm-6.3 1.98l-.23.33-.08.41.08.41.23.34.33.22.41.09.41-.09.33-.22.23-.34.08-.41-.08-.41-.23-.33-.33-.22-.41-.09-.41.09zm13.09 3.95l.28.06.32.12.35.18.36.27.36.35.35.47.32.59.28.73.21.88.14 1.04.05 1.23-.06 1.23-.16 1.04-.24.86-.32.71-.36.57-.4.45-.42.33-.42.24-.4.16-.36.09-.32.05-.24.02-.16-.01h-8.22v.82h5.84l.01 2.76.02.36-.05.34-.11.31-.17.29-.25.25-.31.24-.38.2-.44.17-.51.15-.58.13-.64.09-.71.07-.77.04-.84.01-1.27-.04-1.07-.14-.9-.2-.73-.25-.59-.3-.45-.33-.34-.34-.25-.34-.16-.33-.1-.3-.04-.25-.02-.2.01-.13v-5.34l.05-.64.13-.54.21-.46.26-.38.3-.32.33-.24.35-.2.35-.14.33-.1.3-.06.26-.04.21-.02.13-.01h5.84l.69-.05.59-.14.5-.21.41-.28.33-.32.27-.35.2-.36.15-.36.1-.35.07-.32.04-.28.02-.21V6.07h2.09l.14.01zm-6.47 14.25l-.23.33-.08.41.08.41.23.33.33.23.41.08.41-.08.33-.23.23-.33.08-.41-.08-.41-.23-.33-.33-.23-.41-.08-.41.08z"/></svg>`;
+
+	const JavaScriptIcon = `<svg role="img" width="16" height="16" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>JavaScript</title><path d="M0 0h24v24H0V0zm22.034 18.276c-.175-1.095-.888-2.015-3.003-2.873-.736-.345-1.554-.585-1.797-1.14-.091-.33-.105-.51-.046-.705.15-.646.915-.84 1.515-.66.39.12.75.42.976.9 1.034-.676 1.034-.676 1.755-1.125-.27-.42-.404-.601-.586-.78-.63-.705-1.469-1.065-2.834-1.034l-.705.089c-.676.165-1.32.525-1.71 1.005-1.14 1.291-.811 3.541.569 4.471 1.365 1.02 3.361 1.244 3.616 2.205.24 1.17-.87 1.545-1.966 1.41-.811-.18-1.26-.586-1.755-1.336l-1.83 1.051c.21.48.45.689.81 1.109 1.74 1.756 6.09 1.666 6.871-1.004.029-.09.24-.705.074-1.65l.046.067zm-8.983-7.245h-2.248c0 1.938-.009 3.864-.009 5.805 0 1.232.063 2.363-.138 2.711-.33.689-1.18.601-1.566.48-.396-.196-.597-.466-.83-.855-.063-.105-.11-.196-.127-.196l-1.825 1.125c.305.63.75 1.172 1.324 1.517.855.51 2.004.675 3.207.405.783-.226 1.458-.691 1.811-1.411.51-.93.402-2.07.397-3.346.012-2.054 0-4.109 0-6.179l.004-.056z"/></svg>`;
+
+	const CSharpIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 50 50" fill="currentColor"><path d="M 25 2 C 24.285156 2 23.570313 2.179688 22.933594 2.539063 L 6.089844 12.003906 C 4.800781 12.726563 4 14.082031 4 15.535156 L 4 34.464844 C 4 35.917969 4.800781 37.273438 6.089844 37.996094 L 22.933594 47.460938 C 23.570313 47.820313 24.285156 48 25 48 C 25.714844 48 26.429688 47.820313 27.066406 47.460938 L 43.910156 38 C 45.199219 37.273438 46 35.917969 46 34.464844 L 46 15.535156 C 46 14.082031 45.199219 12.726563 43.910156 12.003906 L 27.066406 2.539063 C 26.429688 2.179688 25.714844 2 25 2 Z M 25 13 C 28.78125 13 32.277344 14.753906 34.542969 17.738281 L 30.160156 20.277344 C 28.84375 18.835938 26.972656 18 25 18 C 21.140625 18 18 21.140625 18 25 C 18 28.859375 21.140625 32 25 32 C 26.972656 32 28.84375 31.164063 30.160156 29.722656 L 34.542969 32.261719 C 32.277344 35.246094 28.78125 37 25 37 C 18.382813 37 13 31.617188 13 25 C 13 18.382813 18.382813 13 25 13 Z M 35 20 L 37 20 L 37 22 L 39 22 L 39 20 L 41 20 L 41 22 L 43 22 L 43 24 L 41 24 L 41 26 L 43 26 L 43 28 L 41 28 L 41 30 L 39 30 L 39 28 L 37 28 L 37 30 L 35 30 L 35 28 L 33 28 L 33 26 L 35 26 L 35 24 L 33 24 L 33 22 L 35 22 Z M 37 24 L 37 26 L 39 26 L 39 24 Z"/></svg>`;
+
+	const RustIcon = `<svg role="img" width="16" height="16" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M23.8346 11.7033l-1.0073-.6236a13.7268 13.7268 0 00-.0283-.2936l.8656-.8069a.3483.3483 0 00-.1154-.578l-1.1066-.414a8.4958 8.4958 0 00-.087-.2856l.6904-.9587a.3462.3462 0 00-.2257-.5446l-1.1663-.1894a9.3574 9.3574 0 00-.1407-.2622l.49-1.0761a.3437.3437 0 00-.0274-.3361.3486.3486 0 00-.3006-.154l-1.1845.0416a6.7444 6.7444 0 00-.1873-.2268l.2723-1.153a.3472.3472 0 00-.417-.4172l-1.1532.2724a14.0183 14.0183 0 00-.2278-.1873l.0415-1.1845a.3442.3442 0 00-.49-.328l-1.076.491c-.0872-.0476-.1742-.0952-.2623-.1407l-.1903-1.1673A.3483.3483 0 0016.256.955l-.9597.6905a8.4867 8.4867 0 00-.2855-.086l-.414-1.1066a.3483.3483 0 00-.5781-.1154l-.8069.8666a9.2936 9.2936 0 00-.2936-.0284L12.2946.1683a.3462.3462 0 00-.5892 0l-.6236 1.0073a13.7383 13.7383 0 00-.2936.0284L9.9803.3374a.3462.3462 0 00-.578.1154l-.4141 1.1065c-.0962.0274-.1903.0567-.2855.086L7.744.955a.3483.3483 0 00-.5447.2258L7.009 2.348a9.3574 9.3574 0 00-.2622.1407l-1.0762-.491a.3462.3462 0 00-.49.328l.0416 1.1845a7.9826 7.9826 0 00-.2278.1873L3.8413 3.425a.3472.3472 0 00-.4171.4171l.2713 1.1531c-.0628.075-.1255.1509-.1863.2268l-1.1845-.0415a.3462.3462 0 00-.328.49l.491 1.0761a9.167 9.167 0 00-.1407.2622l-1.1662.1894a.3483.3483 0 00-.2258.5446l.6904.9587a13.303 13.303 0 00-.087.2855l-1.1065.414a.3483.3483 0 00-.1155.5781l.8656.807a9.2936 9.2936 0 00-.0283.2935l-1.0073.6236a.3442.3442 0 000 .5892l1.0073.6236c.008.0982.0182.1964.0283.2936l-.8656.8079a.3462.3462 0 00.1155.578l1.1065.4141c.0273.0962.0567.1914.087.2855l-.6904.9587a.3452.3452 0 00.2268.5447l1.1662.1893c.0456.088.0922.1751.1408.2622l-.491 1.0762a.3462.3462 0 00.328.49l1.1834-.0415c.0618.0769.1235.1528.1873.2277l-.2713 1.1541a.3462.3462 0 00.4171.4161l1.153-.2713c.075.0638.151.1255.2279.1863l-.0415 1.1845a.3442.3442 0 00.49.327l1.0761-.49c.087.0486.1741.0951.2622.1407l.1903 1.1662a.3483.3483 0 00.5447.2268l.9587-.6904a9.299 9.299 0 00.2855.087l.414 1.1066a.3452.3452 0 00.5781.1154l.8079-.8656c.0972.0111.1954.0203.2936.0294l.6236 1.0073a.3472.3472 0 00.5892 0l.6236-1.0073c.0982-.0091.1964-.0183.2936-.0294l.8069.8656a.3483.3483 0 00.578-.1154l.4141-1.1066a8.4626 8.4626 0 00.2855-.087l.9587.6904a.3452.3452 0 00.5447-.2268l.1903-1.1662c.088-.0456.1751-.0931.2622-.1407l1.0762.49a.3472.3472 0 00.49-.327l-.0415-1.1845a6.7267 6.7267 0 00.2267-.1863l1.1531.2713a.3472.3472 0 00.4171-.416l-.2713-1.1542c.0628-.0749.1255-.1508.1863-.2278l1.1845.0415a.3442.3442 0 00.328-.49l-.49-1.076c.0475-.0872.0951-.1742.1407-.2623l1.1662-.1893a.3483.3483 0 00.2258-.5447l-.6904-.9587.087-.2855 1.1066-.414a.3462.3462 0 00.1154-.5781l-.8656-.8079c.0101-.0972.0202-.1954.0283-.2936l1.0073-.6236a.3442.3442 0 000-.5892zm-6.7413 8.3551a.7138.7138 0 01.2986-1.396.714.714 0 11-.2997 1.396zm-.3422-2.3142a.649.649 0 00-.7715.5l-.3573 1.6685c-1.1035.501-2.3285.7795-3.6193.7795a8.7368 8.7368 0 01-3.6951-.814l-.3574-1.6684a.648.648 0 00-.7714-.499l-1.473.3158a8.7216 8.7216 0 01-.7613-.898h7.1676c.081 0 .1356-.0141.1356-.088v-2.536c0-.074-.0536-.0881-.1356-.0881h-2.0966v-1.6077h2.2677c.2065 0 1.1065.0587 1.394 1.2088.0901.3533.2875 1.5044.4232 1.8729.1346.413.6833 1.2381 1.2685 1.2381h3.5716a.7492.7492 0 00.1296-.0131 8.7874 8.7874 0 01-.8119.9526zM6.8369 20.024a.714.714 0 11-.2997-1.396.714.714 0 01.2997 1.396zM4.1177 8.9972a.7137.7137 0 11-1.304.5791.7137.7137 0 011.304-.579zm-.8352 1.9813l1.5347-.6824a.65.65 0 00.33-.8585l-.3158-.7147h1.2432v5.6025H3.5669a8.7753 8.7753 0 01-.2834-3.348zm6.7343-.5437V8.7836h2.9601c.153 0 1.0792.1772 1.0792.8697 0 .575-.7107.7815-1.2948.7815zm10.7574 1.4862c0 .2187-.008.4363-.0243.651h-.9c-.09 0-.1265.0586-.1265.1477v.413c0 .973-.5487 1.1846-1.0296 1.2382-.4576.0517-.9648-.1913-1.0275-.4717-.2704-1.5186-.7198-1.8436-1.4305-2.4034.8817-.5599 1.799-1.386 1.799-2.4915 0-1.1936-.819-1.9458-1.3769-2.3153-.7825-.5163-1.6491-.6195-1.883-.6195H5.4682a8.7651 8.7651 0 014.907-2.7699l1.0974 1.151a.648.648 0 00.9182.0213l1.227-1.1743a8.7753 8.7753 0 016.0044 4.2762l-.8403 1.8982a.652.652 0 00.33.8585l1.6178.7188c.0283.2875.0425.577.0425.8717zm-9.3006-9.5993a.7128.7128 0 11.984 1.0316.7137.7137 0 01-.984-1.0316zm8.3389 6.71a.7107.7107 0 01.9395-.3625.7137.7137 0 11-.9405.3635z"/></svg>`;
+
+	type CliInstallOption = {
+		id: string;
+		label: string;
+		command: string;
+		icon: string;
+	};
+
+	type SdkInstallOption = {
+		id: string;
+		label: string;
+		icon: string;
+		crossPlatformId: string;
+		crossPlatformCommand: string;
+		winmlId: string;
+		winmlCommand: string;
+	};
+
+	const cliInstallOptions: CliInstallOption[] = [
 		{
-			title: 'Start with an SDK',
-			description: 'Use this path when you are building an application with local inference.',
-			items: [
-				{
-					id: 'python',
-					label: 'Python SDK',
-					command: 'pip install foundry-local-sdk',
-					badge: 'PY',
-					ariaLabel: 'Copy Python SDK installation command'
-				},
-				{
-					id: 'javascript',
-					label: 'JavaScript SDK',
-					command: 'npm install foundry-local-sdk',
-					badge: 'JS',
-					ariaLabel: 'Copy JavaScript SDK installation command'
-				},
-				{
-					id: 'csharp',
-					label: 'C# SDK',
-					command: 'dotnet add package Microsoft.AI.Foundry.Local',
-					badge: 'C#',
-					ariaLabel: 'Copy C# SDK installation command'
-				},
-				{
-					id: 'rust',
-					label: 'Rust SDK',
-					command: 'cargo add foundry-local-sdk',
-					badge: 'RS',
-					ariaLabel: 'Copy Rust SDK installation command'
-				}
-			]
+			id: 'windows',
+			label: 'Windows CLI',
+			command: 'winget install Microsoft.FoundryLocal',
+			icon: WindowsIcon
 		},
 		{
-			title: 'Windows SDK acceleration',
-			description: 'Use WinML packages when you want Windows hardware acceleration from the SDK.',
-			items: [
-				{
-					id: 'python_winml',
-					label: 'Python SDK (WinML)',
-					command: 'pip install foundry-local-sdk-winml',
-					badge: 'PY',
-					ariaLabel: 'Copy Python WinML SDK installation command'
-				},
-				{
-					id: 'javascript_winml',
-					label: 'JavaScript SDK (WinML)',
-					command: 'npm install foundry-local-sdk-winml',
-					badge: 'JS',
-					ariaLabel: 'Copy JavaScript WinML SDK installation command'
-				},
-				{
-					id: 'csharp_winml',
-					label: 'C# SDK (WinML)',
-					command: 'dotnet add package Microsoft.AI.Foundry.Local.WinML',
-					badge: 'C#',
-					ariaLabel: 'Copy C# WinML SDK installation command'
-				},
-				{
-					id: 'rust_winml',
-					label: 'Rust SDK (WinML)',
-					command: 'cargo add foundry-local-sdk --features winml',
-					badge: 'RS',
-					ariaLabel: 'Copy Rust WinML SDK installation command'
-				}
-			]
-		},
-		{
-			title: 'Optional CLI tools',
-			description: 'Use the CLI to explore models or test prompts outside your app.',
-			items: [
-				{
-					id: 'windows',
-					label: 'Windows CLI',
-					command: 'winget install Microsoft.FoundryLocal',
-					badge: 'WIN',
-					ariaLabel: 'Copy Windows CLI installation command'
-				},
-				{
-					id: 'macos',
-					label: 'macOS CLI',
-					command: 'brew install microsoft/foundrylocal/foundrylocal',
-					badge: 'MAC',
-					ariaLabel: 'Copy macOS CLI installation command'
-				}
-			]
+			id: 'macos',
+			label: 'macOS CLI',
+			command: 'brew install microsoft/foundrylocal/foundrylocal',
+			icon: AppleIcon
 		}
 	];
 
-	let copiedItem = $state<string | null>(null);
+	const sdkInstallOptions: SdkInstallOption[] = [
+		{
+			id: 'python',
+			label: 'Python SDK',
+			icon: PythonIcon,
+			crossPlatformId: 'python-cross-platform',
+			crossPlatformCommand: 'pip install foundry-local-sdk',
+			winmlId: 'python-winml',
+			winmlCommand: 'pip install foundry-local-sdk-winml'
+		},
+		{
+			id: 'javascript',
+			label: 'JavaScript SDK',
+			icon: JavaScriptIcon,
+			crossPlatformId: 'javascript-cross-platform',
+			crossPlatformCommand: 'npm install foundry-local-sdk',
+			winmlId: 'javascript-winml',
+			winmlCommand: 'npm install foundry-local-sdk-winml'
+		},
+		{
+			id: 'csharp',
+			label: 'C# SDK',
+			icon: CSharpIcon,
+			crossPlatformId: 'csharp-cross-platform',
+			crossPlatformCommand: 'dotnet add package Microsoft.AI.Foundry.Local',
+			winmlId: 'csharp-winml',
+			winmlCommand: 'dotnet add package Microsoft.AI.Foundry.Local.WinML'
+		},
+		{
+			id: 'rust',
+			label: 'Rust SDK',
+			icon: RustIcon,
+			crossPlatformId: 'rust-cross-platform',
+			crossPlatformCommand: 'cargo add foundry-local-sdk',
+			winmlId: 'rust-winml',
+			winmlCommand: 'cargo add foundry-local-sdk --features winml'
+		}
+	];
 
-	async function copyToClipboard(text: string, label: string) {
+	let copiedItemId = $state<string | null>(null);
+
+	async function copyToClipboard(text: string, id: string) {
 		try {
 			await navigator.clipboard.writeText(text);
-			copiedItem = label;
-			toast.success('Copied to clipboard!');
+			copiedItemId = id;
+			toast.success(`Copied to clipboard!`);
 			setTimeout(() => {
-				copiedItem = null;
+				copiedItemId = null;
 			}, 2000);
 		} catch (err) {
 			toast.error('Failed to copy to clipboard');
@@ -145,64 +124,111 @@
 <DropdownMenu.Root bind:open>
 	<DropdownMenu.Trigger
 		class={`${buttonVariants({ variant, size })} ${className} group`}
-		aria-label="Install Foundry Local SDK or CLI"
+		aria-label="Download Foundry Local for your platform"
 	>
 		<Download
 			class="download-hover-icon mr-2 size-4 transition-transform duration-300"
 			aria-hidden="true"
 		/>
-		<span>Install</span>
+		<span>Download</span>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content
 		align="end"
-		class={isMobile.current ? 'mx-4 w-[calc(100vw-2rem)]' : 'w-[30rem]'}
-		aria-label="Install options"
+		class={isMobile.current ? 'mx-4 w-[calc(100vw-2rem)]' : 'w-[28rem]'}
+		aria-label="Download options"
 	>
-		<DropdownMenu.Label>Install Foundry Local</DropdownMenu.Label>
-		<p class="text-muted-foreground px-2 pb-2 text-xs leading-relaxed">
-			Choose an SDK to embed local AI in your app. The CLI is available as secondary developer
-			tooling.
-		</p>
+		<DropdownMenu.Label>Download Foundry Local</DropdownMenu.Label>
+		<DropdownMenu.Separator />
 
-		{#each sections as section}
-			<DropdownMenu.Separator />
-			<DropdownMenu.Label class="text-muted-foreground text-xs font-normal">
-				{section.title}
-			</DropdownMenu.Label>
-			<p class="text-muted-foreground px-2 pb-1 text-[11px] leading-relaxed">
-				{section.description}
-			</p>
+		<DropdownMenu.Label class="text-muted-foreground text-xs font-normal">
+			Start with an SDK
+		</DropdownMenu.Label>
 
-			<DropdownMenu.Group>
-				{#each section.items as item}
-					<button
-						type="button"
-						class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm transition-colors outline-none select-none"
-						onclick={() => copyToClipboard(item.command, item.id)}
-						aria-label={item.ariaLabel}
-					>
-						<span
-							class="bg-primary/10 text-primary mt-0.5 inline-flex min-w-8 shrink-0 items-center justify-center rounded-md px-1.5 py-1 font-mono text-[10px] font-bold"
-							aria-hidden="true"
+		<DropdownMenu.Group>
+			{#each sdkInstallOptions as item}
+				<div class="rounded-sm px-2 py-2.5 text-sm">
+					<div class="mb-2 flex items-center gap-2">
+						<span class="inline-flex shrink-0" aria-hidden="true">{@html item.icon}</span>
+						<span class="font-medium">{item.label}</span>
+					</div>
+
+					<div class="space-y-1.5 pl-6">
+						<button
+							type="button"
+							class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left transition-colors outline-none"
+							onclick={() => copyToClipboard(item.crossPlatformCommand, item.crossPlatformId)}
+							aria-label={`Copy cross-platform ${item.label} installation command`}
 						>
-							{item.badge}
-						</span>
-						<div class="flex flex-1 flex-col gap-1 px-2">
-							<span class="font-medium">{item.label}</span>
-							<code class="text-muted-foreground text-xs break-all">{item.command}</code>
-						</div>
-						{#if copiedItem === item.id}
-							<Check class="text-primary size-4 shrink-0" aria-hidden="true" />
-							<span class="sr-only">Copied</span>
-						{:else}
-							<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
-						{/if}
-					</button>
-				{/each}
-			</DropdownMenu.Group>
-		{/each}
+							<span
+								class="border-border bg-muted/50 text-muted-foreground rounded border px-1.5 py-0.5 text-[10px] font-medium tracking-wide uppercase"
+								>Cross-platform</span
+							>
+							<code class="text-muted-foreground min-w-0 flex-1 text-xs break-all"
+								>{item.crossPlatformCommand}</code
+							>
+							{#if copiedItemId === item.crossPlatformId}
+								<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
+								<span class="sr-only">Copied</span>
+							{:else}
+								<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
+							{/if}
+						</button>
+
+						<button
+							type="button"
+							class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left transition-colors outline-none"
+							onclick={() => copyToClipboard(item.winmlCommand, item.winmlId)}
+							aria-label={`Copy Windows WinML ${item.label} installation command`}
+						>
+							<span
+								class="border-primary/30 bg-primary/10 text-primary rounded border px-1.5 py-0.5 text-[10px] font-medium tracking-wide uppercase"
+								>Windows</span
+							>
+							<code class="text-muted-foreground min-w-0 flex-1 text-xs break-all"
+								>{item.winmlCommand}</code
+							>
+							{#if copiedItemId === item.winmlId}
+								<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
+								<span class="sr-only">Copied</span>
+							{:else}
+								<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
+							{/if}
+						</button>
+					</div>
+				</div>
+			{/each}
+		</DropdownMenu.Group>
 
 		<DropdownMenu.Separator />
+		<DropdownMenu.Label class="text-muted-foreground text-xs font-normal">
+			Optional CLI tools
+		</DropdownMenu.Label>
+
+		<DropdownMenu.Group>
+			{#each cliInstallOptions as item}
+				<button
+					type="button"
+					class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex min-h-[44px] w-full cursor-pointer items-start justify-between rounded-sm px-2 py-2.5 text-left text-sm transition-colors outline-none select-none"
+					onclick={() => copyToClipboard(item.command, item.id)}
+					aria-label={`Copy ${item.label} installation command`}
+				>
+					<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html item.icon}</span>
+					<div class="flex flex-1 flex-col gap-1 px-2">
+						<span class="font-medium">{item.label}</span>
+						<code class="text-muted-foreground text-xs break-all">{item.command}</code>
+					</div>
+					{#if copiedItemId === item.id}
+						<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
+						<span class="sr-only">Copied</span>
+					{:else}
+						<Copy class="size-4 shrink-0 opacity-50" aria-hidden="true" />
+					{/if}
+				</button>
+			{/each}
+		</DropdownMenu.Group>
+
+		<DropdownMenu.Separator />
+
 		<DropdownMenu.Group>
 			<DropdownMenu.Item>
 				<a
@@ -212,7 +238,12 @@
 					class="flex w-full items-center"
 					aria-label="View all releases on GitHub (opens in new tab)"
 				>
-					<span>All releases</span>
+					<svg class="mr-2 size-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"
+						><path
+							d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+						/></svg
+					>
+					<span>All Releases</span>
 				</a>
 			</DropdownMenu.Item>
 		</DropdownMenu.Group>

--- a/www/src/lib/components/home/features.svelte
+++ b/www/src/lib/components/home/features.svelte
@@ -98,23 +98,26 @@
 					<div
 						class="mt-auto overflow-hidden rounded-xl bg-gray-900 p-4 font-mono text-xs text-gray-300 dark:bg-black/40"
 					>
-						<div class="mb-1 text-emerald-400">// Initialize & Load</div>
+						<div class="mb-1 text-emerald-400">// Initialize, download, load & chat</div>
 						<div class="code-line code-line-1">
-							<span class="text-purple-400">const</span> manager =
+							<span class="text-purple-400">const</span> mgr =
 							<span class="text-blue-400">FoundryLocalManager</span>.<span class="text-yellow-300"
 								>create</span
-							>(config)
+							>({'{'} appName: <span class="text-amber-300">'my-app'</span> {'}'})
 						</div>
 						<div class="code-line code-line-2">
-							<span class="text-purple-400">const</span> model = manager.<span
-								class="text-yellow-300">getCatalog</span
-							>().<span class="text-yellow-300">getModel</span>(<span class="text-amber-300"
-								>'gpt-oss-20b'</span
+							<span class="text-purple-400">const</span> model = <span class="text-purple-400">await</span> mgr.<span
+								class="text-yellow-300">catalog</span
+							>.<span class="text-yellow-300">getModel</span>(<span class="text-amber-300"
+								>'qwen2.5-0.5b'</span
 							>)
 						</div>
 						<div class="code-line code-line-3">
 							<span class="text-purple-400">await</span>
-							model.<span class="text-yellow-300">load</span>()<span class="typing-cursor">|</span>
+							model.<span class="text-yellow-300">download</span>(); <span class="text-purple-400">await</span> model.<span class="text-yellow-300">load</span>()
+						</div>
+						<div class="code-line code-line-4">
+							<span class="text-purple-400">const</span> res = <span class="text-purple-400">await</span> model.<span class="text-yellow-300">createChatClient</span>().<span class="text-yellow-300">completeChat</span>(msgs)<span class="typing-cursor">|</span>
 						</div>
 					</div>
 					<style>
@@ -130,6 +133,9 @@
 						}
 						.code-line-3 {
 							animation-delay: 1.5s;
+						}
+						.code-line-4 {
+							animation-delay: 2.1s;
 						}
 						@keyframes typeIn {
 							from {
@@ -171,7 +177,7 @@
 					</div>
 					<h3 class="mb-2 text-2xl font-bold text-gray-900 dark:text-white">Hardware Optimized</h3>
 					<p class="mb-6 text-lg text-gray-600 dark:text-neutral-400">
-						We work directly with hardware vendors for maximum performance
+						Automatic execution provider management for maximum performance
 					</p>
 					<!-- Hardware acceleration visual with glowing cards -->
 					<div class="mt-auto grid grid-cols-3 gap-3">
@@ -235,7 +241,7 @@
 					</div>
 					<h3 class="mb-2 text-xl font-semibold text-gray-900 dark:text-white">Edge-Ready</h3>
 					<p class="text-gray-600 dark:text-neutral-400">
-						Works fully offline with no cloud dependencies
+						Works fully offline. ~20 MB runtime, no cloud dependencies
 					</p>
 				</div>
 				<!-- Dramatic wifi disconnect animation -->
@@ -429,7 +435,7 @@
 						OpenAI Compatible
 					</h3>
 					<p class="text-gray-600 dark:text-neutral-400">
-						Drop-in API replacement for easy integration
+						Native SDK API plus optional OpenAI-compatible REST server
 					</p>
 				</div>
 				<!-- Animated API comparison -->

--- a/www/src/lib/components/home/features.svelte
+++ b/www/src/lib/components/home/features.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-	import { features } from '$lib/config';
-	import { Button } from '$lib/components/ui/button';
-	import { ArrowRight, Rocket, Cpu, Wifi, Code, Bot, Shield } from 'lucide-svelte';
+	import { Rocket, Cpu, Wifi, Code, Bot, Shield } from 'lucide-svelte';
 	import { animate } from '$lib/utils/animations';
 	import { onMount } from 'svelte';
 
@@ -64,14 +62,14 @@
 				use:animate={{ delay: 0, duration: 800, animation: 'slide-up', threshold: 0.2 }}
 				class="mb-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl dark:text-white"
 			>
-				Purpose built for shipping AI applications
+				The fastest path from SDK install to shipped local AI
 			</h2>
 			<p
 				use:animate={{ delay: 200, duration: 800, animation: 'slide-up', threshold: 0.2 }}
 				class="text-lg text-gray-600 dark:text-neutral-400"
 			>
-				Everything you need to embed AI into your products, with the performance and reliability
-				your users expect.
+				Start with native SDKs, keep inference in your app process, and use CLI or REST tools only
+				when they help your development workflow.
 			</p>
 		</div>
 
@@ -90,34 +88,44 @@
 					>
 						<Rocket class="size-7" aria-hidden="true" />
 					</div>
-					<h3 class="mb-2 text-2xl font-bold text-gray-900 dark:text-white">Ship to Production</h3>
+					<h3 class="mb-2 text-2xl font-bold text-gray-900 dark:text-white">One SDK lifecycle</h3>
 					<p class="mb-6 text-lg text-gray-600 dark:text-neutral-400">
-						Built as an SDK for shipping AI-powered applications, not just running models locally
+						Initialize the manager, choose a model alias, download and cache it, load it, then call
+						chat or audio clients from your app.
 					</p>
 					<!-- Animated code snippet with typing effect -->
 					<div
 						class="mt-auto overflow-hidden rounded-xl bg-gray-900 p-4 font-mono text-xs text-gray-300 dark:bg-black/40"
 					>
-						<div class="mb-1 text-emerald-400">// Initialize, download, load & chat</div>
+						<div class="mb-1 text-emerald-400">
+							// SDK lifecycle: initialize, download, load, call
+						</div>
 						<div class="code-line code-line-1">
 							<span class="text-purple-400">const</span> mgr =
 							<span class="text-blue-400">FoundryLocalManager</span>.<span class="text-yellow-300"
 								>create</span
-							>({'{'} appName: <span class="text-amber-300">'my-app'</span> {'}'})
+							>({'{'} appName: <span class="text-amber-300">'my-app'</span>
+							{'}'})
 						</div>
 						<div class="code-line code-line-2">
-							<span class="text-purple-400">const</span> model = <span class="text-purple-400">await</span> mgr.<span
-								class="text-yellow-300">catalog</span
-							>.<span class="text-yellow-300">getModel</span>(<span class="text-amber-300"
-								>'qwen2.5-0.5b'</span
-							>)
+							<span class="text-purple-400">const</span> model =
+							<span class="text-purple-400">await</span>
+							mgr.<span class="text-yellow-300">catalog</span>.<span class="text-yellow-300"
+								>getModel</span
+							>(<span class="text-amber-300">'qwen2.5-0.5b'</span>)
 						</div>
 						<div class="code-line code-line-3">
 							<span class="text-purple-400">await</span>
-							model.<span class="text-yellow-300">download</span>(); <span class="text-purple-400">await</span> model.<span class="text-yellow-300">load</span>()
+							model.<span class="text-yellow-300">download</span>();
+							<span class="text-purple-400">await</span>
+							model.<span class="text-yellow-300">load</span>()
 						</div>
 						<div class="code-line code-line-4">
-							<span class="text-purple-400">const</span> res = <span class="text-purple-400">await</span> model.<span class="text-yellow-300">createChatClient</span>().<span class="text-yellow-300">completeChat</span>(msgs)<span class="typing-cursor">|</span>
+							<span class="text-purple-400">const</span> res =
+							<span class="text-purple-400">await</span>
+							model.<span class="text-yellow-300">createChatClient</span>().<span
+								class="text-yellow-300">completeChat</span
+							>(msgs)<span class="typing-cursor">|</span>
 						</div>
 					</div>
 					<style>
@@ -175,9 +183,12 @@
 					>
 						<Cpu class="size-7" aria-hidden="true" />
 					</div>
-					<h3 class="mb-2 text-2xl font-bold text-gray-900 dark:text-white">Hardware Optimized</h3>
+					<h3 class="mb-2 text-2xl font-bold text-gray-900 dark:text-white">
+						Hardware handled for you
+					</h3>
 					<p class="mb-6 text-lg text-gray-600 dark:text-neutral-400">
-						Automatic execution provider management for maximum performance
+						The SDK picks and registers execution providers so apps can target NPU, GPU, or CPU
+						without custom device plumbing.
 					</p>
 					<!-- Hardware acceleration visual with glowing cards -->
 					<div class="mt-auto grid grid-cols-3 gap-3">
@@ -239,9 +250,12 @@
 					>
 						<Wifi class="size-6" aria-hidden="true" />
 					</div>
-					<h3 class="mb-2 text-xl font-semibold text-gray-900 dark:text-white">Edge-Ready</h3>
+					<h3 class="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
+						Offline app runtime
+					</h3>
 					<p class="text-gray-600 dark:text-neutral-400">
-						Works fully offline. ~20 MB runtime, no cloud dependencies
+						The runtime and cached models stay local so user workflows keep running without a
+						network.
 					</p>
 				</div>
 				<!-- Dramatic wifi disconnect animation -->
@@ -364,10 +378,10 @@
 					>
 						<Code class="size-6" aria-hidden="true" />
 					</div>
-					<h3 class="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
-						Multi-Language SDKs
-					</h3>
-					<p class="text-gray-600 dark:text-neutral-400">Python, JavaScript, C#, and Rust</p>
+					<h3 class="mb-2 text-xl font-semibold text-gray-900 dark:text-white">Native SDKs</h3>
+					<p class="text-gray-600 dark:text-neutral-400">
+						Start in Python or JavaScript; ship production apps in C# and Rust too.
+					</p>
 				</div>
 				<!-- Language icons with staggered pop animation -->
 				<div class="absolute right-4 bottom-4 flex gap-2">
@@ -432,10 +446,11 @@
 						<Bot class="size-6" aria-hidden="true" />
 					</div>
 					<h3 class="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
-						OpenAI Compatible
+						Native first, REST when needed
 					</h3>
 					<p class="text-gray-600 dark:text-neutral-400">
-						Native SDK API plus optional OpenAI-compatible REST server
+						Use SDK clients in-process, or start the optional OpenAI-compatible server for
+						frameworks like LangChain.
 					</p>
 				</div>
 				<!-- Animated API comparison -->
@@ -490,7 +505,9 @@
 						<Shield class="size-6" aria-hidden="true" />
 					</div>
 					<h3 class="mb-2 text-xl font-semibold text-gray-900 dark:text-white">Data Privacy</h3>
-					<p class="text-gray-600 dark:text-neutral-400">Everything stays on-device</p>
+					<p class="text-gray-600 dark:text-neutral-400">
+						Prompts, audio, and responses stay on the user's device.
+					</p>
 				</div>
 				<!-- Animated shield with glow pulse -->
 				<div class="absolute -right-4 -bottom-4">

--- a/www/src/lib/components/home/footer.svelte
+++ b/www/src/lib/components/home/footer.svelte
@@ -23,7 +23,7 @@
 					/>
 				</a>
 				<p class="max-w-xs text-sm text-muted-foreground">
-					Run AI models locally with the power of Microsoft's Azure AI technology.
+					Ship AI-powered applications with on-device inference. No cloud required.
 				</p>
 				<div class="mt-6">
 					<SocialMedia />
@@ -36,7 +36,7 @@
 				<ul class="space-y-3 text-sm">
 					<li>
 						<a
-							href="https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-local/get-started"
+							href="https://learn.microsoft.com/en-us/azure/foundry-local/get-started"
 							target="_blank"
 							rel="noopener noreferrer"
 							class="text-muted-foreground transition-colors hover:text-foreground"

--- a/www/src/lib/components/home/footer.svelte
+++ b/www/src/lib/components/home/footer.svelte
@@ -7,7 +7,7 @@
 
 <footer
 	use:animate={{ delay: 0, duration: 800, animation: 'fade-in', threshold: 0.1 }}
-	class="border-t border-border bg-muted/30"
+	class="border-border bg-muted/30 border-t"
 >
 	<div class="mx-auto w-full max-w-[85rem] px-4 py-12 sm:px-6 lg:px-8">
 		<div class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-12">
@@ -22,8 +22,8 @@
 						alt="Foundry Local"
 					/>
 				</a>
-				<p class="max-w-xs text-sm text-muted-foreground">
-					Ship AI-powered applications with on-device inference. No cloud required.
+				<p class="text-muted-foreground max-w-xs text-sm">
+					Build AI-powered applications with on-device inference through native SDKs.
 				</p>
 				<div class="mt-6">
 					<SocialMedia />
@@ -32,19 +32,19 @@
 
 			<!-- Links - Product & Resources -->
 			<nav class="lg:col-span-3" aria-label="Product links">
-				<h3 class="mb-4 text-sm font-semibold text-foreground">Product</h3>
+				<h3 class="text-foreground mb-4 text-sm font-semibold">Product</h3>
 				<ul class="space-y-3 text-sm">
 					<li>
 						<a
 							href="https://learn.microsoft.com/en-us/azure/foundry-local/get-started"
 							target="_blank"
 							rel="noopener noreferrer"
-							class="text-muted-foreground transition-colors hover:text-foreground"
+							class="text-muted-foreground hover:text-foreground transition-colors"
 							aria-label="Documentation (opens in new tab)">Documentation</a
 						>
 					</li>
 					<li>
-						<a href="/models" class="text-muted-foreground transition-colors hover:text-foreground"
+						<a href="/models" class="text-muted-foreground hover:text-foreground transition-colors"
 							>Model Hub</a
 						>
 					</li>
@@ -53,8 +53,8 @@
 							href="https://github.com/microsoft/Foundry-Local/tree/main/samples"
 							target="_blank"
 							rel="noopener noreferrer"
-							class="text-muted-foreground transition-colors hover:text-foreground"
-							aria-label="Examples (opens in new tab)">Examples</a
+							class="text-muted-foreground hover:text-foreground transition-colors"
+							aria-label="SDK samples (opens in new tab)">SDK Samples</a
 						>
 					</li>
 					<li>
@@ -62,7 +62,7 @@
 							href="https://github.com/microsoft/foundry-local/releases"
 							target="_blank"
 							rel="noopener noreferrer"
-							class="text-muted-foreground transition-colors hover:text-foreground"
+							class="text-muted-foreground hover:text-foreground transition-colors"
 							aria-label="Releases (opens in new tab)">Releases</a
 						>
 					</li>
@@ -71,14 +71,14 @@
 
 			<!-- Community links -->
 			<nav class="lg:col-span-3" aria-label="Community links">
-				<h3 class="mb-4 text-sm font-semibold text-foreground">Community</h3>
+				<h3 class="text-foreground mb-4 text-sm font-semibold">Community</h3>
 				<ul class="space-y-3 text-sm">
 					<li>
 						<a
 							href="https://github.com/microsoft/foundry-local"
 							target="_blank"
 							rel="noopener noreferrer"
-							class="text-muted-foreground transition-colors hover:text-foreground"
+							class="text-muted-foreground hover:text-foreground transition-colors"
 							aria-label="GitHub (opens in new tab)">GitHub</a
 						>
 					</li>
@@ -87,7 +87,7 @@
 							href="https://github.com/microsoft/foundry-local/issues"
 							target="_blank"
 							rel="noopener noreferrer"
-							class="text-muted-foreground transition-colors hover:text-foreground"
+							class="text-muted-foreground hover:text-foreground transition-colors"
 							aria-label="Support (opens in new tab)">Support</a
 						>
 					</li>
@@ -96,7 +96,7 @@
 							href="https://github.com/microsoft/Foundry-Local/blob/main/LICENSE"
 							target="_blank"
 							rel="noopener noreferrer"
-							class="text-muted-foreground transition-colors hover:text-foreground"
+							class="text-muted-foreground hover:text-foreground transition-colors"
 							aria-label="MIT License (opens in new tab)">MIT License</a
 						>
 					</li>
@@ -105,16 +105,16 @@
 		</div>
 
 		<!-- Copyright -->
-		<div class="mt-12 border-t border-border pt-8">
+		<div class="border-border mt-12 border-t pt-8">
 			<div class="flex flex-col items-center gap-2">
-				<p class="text-center text-sm text-muted-foreground">
+				<p class="text-muted-foreground text-center text-sm">
 					&copy; {new Date().getFullYear()} Microsoft Corporation. All rights reserved.
 				</p>
 				<a
 					href="https://go.microsoft.com/fwlink/?LinkId=521839"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="text-sm text-muted-foreground transition-colors hover:text-foreground"
+					class="text-muted-foreground hover:text-foreground text-sm transition-colors"
 					aria-label="Microsoft Privacy Statement (opens in new tab)"
 				>
 					Privacy Statement

--- a/www/src/lib/components/home/hero.svelte
+++ b/www/src/lib/components/home/hero.svelte
@@ -122,7 +122,7 @@
 			>
 				<Button
 					variant="outline"
-					href="https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-local/get-started"
+					href="https://learn.microsoft.com/en-us/azure/foundry-local/get-started"
 					target="_blank"
 					rel="noopener noreferrer"
 					size="lg"

--- a/www/src/lib/components/home/hero.svelte
+++ b/www/src/lib/components/home/hero.svelte
@@ -1,41 +1,17 @@
 <!-- DocHero.svelte -->
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { Badge } from '$lib/components/ui/badge';
-	import { Download, Shield, Cpu, Rocket, Wifi, Code, Bot, ArrowRight, BookOpen, FileText, Box } from 'lucide-svelte';
+	import { BookOpen, FileText, Box } from 'lucide-svelte';
 	import { siteConfig } from '$lib/config';
 	import { animate } from '$lib/utils/animations';
 	import LogoTransition from '$lib/components/logo-transition.svelte';
 	import InstallCommand from '$lib/components/install-command.svelte';
 	import { onMount } from 'svelte';
 
-	let { isDownloadOpen = $bindable(false) } = $props();
-
-	function openDownloadDropdown() {
-		isDownloadOpen = true;
-	}
-
-	let badgesContainer: HTMLElement;
 	let buttonsContainer: HTMLElement;
 	let installCommandContainer: HTMLElement;
 
 	onMount(() => {
-		// Stagger animation for badges
-		if (badgesContainer) {
-			const badges = Array.from(badgesContainer.children) as HTMLElement[];
-			badges.forEach((badge, index) => {
-				badge.style.opacity = '0';
-				badge.style.transform = 'translateY(20px)';
-				badge.style.transition = 'all 600ms cubic-bezier(0.4, 0, 0.2, 1)';
-				badge.style.transitionDelay = `${600 + index * 100}ms`;
-
-				requestAnimationFrame(() => {
-					badge.style.opacity = '1';
-					badge.style.transform = 'translateY(0)';
-				});
-			});
-		}
-
 		// Animation for install command
 		if (installCommandContainer) {
 			installCommandContainer.style.opacity = '0';
@@ -71,7 +47,7 @@
 </script>
 
 <div class="relative overflow-hidden">
-	<div class="relative mx-auto max-w-[85rem] px-4 pb-10 pt-24 sm:px-6 lg:px-8">
+	<div class="relative mx-auto max-w-[85rem] px-4 pt-24 pb-10 sm:px-6 lg:px-8">
 		<!-- Brand mark -->
 		<div
 			class="mx-auto flex max-w-2xl justify-center"
@@ -94,7 +70,8 @@
 				use:animate={{ delay: 150, duration: 800, animation: 'slide-up' }}
 				class="block text-4xl font-bold text-gray-800 md:text-5xl lg:text-6xl dark:text-neutral-200"
 			>
-				<span class="text-primary">Foundry Local</span>
+				<span class="text-primary">Build local AI</span><br />
+				into your app
 			</h1>
 		</div>
 
@@ -111,14 +88,14 @@
 		<!-- Action Buttons -->
 		<div class="mt-8 flex flex-col items-center justify-center gap-6">
 			<!-- Install Command - Primary CTA -->
-			<div bind:this={installCommandContainer} class="w-full max-w-2xl px-4 sm:px-6">
+			<div bind:this={installCommandContainer} class="w-full max-w-4xl px-4 sm:px-6">
 				<InstallCommand />
 			</div>
 
 			<!-- Secondary Actions -->
 			<div
 				bind:this={buttonsContainer}
-				class="flex w-full max-w-2xl flex-col items-stretch gap-3 px-4 sm:flex-row sm:justify-center sm:px-6"
+				class="flex w-full max-w-3xl flex-col items-stretch gap-3 px-4 sm:flex-row sm:justify-center sm:px-6"
 			>
 				<Button
 					variant="outline"
@@ -127,13 +104,28 @@
 					rel="noopener noreferrer"
 					size="lg"
 					class="group min-h-[44px] flex-1 border-2 transition-all duration-300 hover:scale-105 hover:shadow-lg"
-					aria-label="View documentation (opens in new tab)"
+					aria-label="Read the SDK documentation (opens in new tab)"
 				>
 					<BookOpen
 						class="mr-2 size-4 transition-transform duration-300 group-hover:scale-110"
 						aria-hidden="true"
 					/>
-					Docs
+					SDK Docs
+				</Button>
+				<Button
+					variant="outline"
+					href="https://github.com/microsoft/Foundry-Local/tree/main/samples"
+					target="_blank"
+					rel="noopener noreferrer"
+					size="lg"
+					class="group min-h-[44px] flex-1 border-2 transition-all duration-300 hover:scale-105 hover:shadow-lg"
+					aria-label="Browse SDK samples on GitHub (opens in new tab)"
+				>
+					<FileText
+						class="mr-2 size-4 transition-transform duration-300 group-hover:scale-110"
+						aria-hidden="true"
+					/>
+					Samples
 				</Button>
 				<Button
 					variant="outline"
@@ -147,19 +139,6 @@
 						aria-hidden="true"
 					/>
 					Models
-				</Button>
-				<Button
-					variant="outline"
-					onclick={openDownloadDropdown}
-					size="lg"
-					class="group min-h-[44px] flex-1 border-2 transition-all duration-300 hover:scale-105 hover:shadow-lg"
-					aria-label="Download Foundry Local"
-				>
-					<Download
-						class="download-hover-icon mr-2 size-4 transition-transform duration-300"
-						aria-hidden="true"
-					/>
-					Install Options
 				</Button>
 			</div>
 		</div>

--- a/www/src/lib/components/install-command.svelte
+++ b/www/src/lib/components/install-command.svelte
@@ -2,150 +2,147 @@
 	import { Copy, Check, Terminal } from 'lucide-svelte';
 	import { toast } from 'svelte-sonner';
 	import { onMount } from 'svelte';
-	import { getInstallCommand } from '$lib/utils/platform';
+	import { detectPlatform } from '$lib/utils/platform';
 
 	let copied = $state(false);
-	let copiedModel = $state(false);
-	let showModelCommand = $state(false);
+	let copiedCode = $state(false);
+	let showCodeSnippet = $state(false);
 	let commandElement: HTMLElement;
-	let modelCommandElement: HTMLElement;
-	let installInfo = $state({
-		command: 'brew install microsoft/foundrylocal/foundrylocal',
-		label: 'Install',
-		description: 'Install via Homebrew'
-	});
+	let activeTab = $state<'python' | 'javascript' | 'csharp' | 'rust'>('python');
 
-	const modelCommand = 'foundry model run qwen2.5-0.5b';
+	const sdkCommands = {
+		python: 'pip install foundry-local-sdk',
+		javascript: 'npm install foundry-local-sdk',
+		csharp: 'dotnet add package Microsoft.AI.Foundry.Local',
+		rust: 'cargo add foundry-local-sdk'
+	};
 
-	// Platform SVG icons
-	const AppleIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M11.182.008C11.148-.03 9.923.023 8.857 1.18c-1.066 1.156-.902 2.482-.878 2.516.024.034 1.52.087 2.475-1.258.955-1.345.762-2.391.728-2.43zm3.314 11.733c-.048-.096-2.325-1.234-2.113-3.422.212-2.189 1.675-2.789 1.698-2.854.023-.065-.597-.79-1.254-1.157a3.692 3.692 0 0 0-1.563-.434c-.108-.003-.483-.095-1.254.116-.508.139-1.653.589-1.968.607-.316.018-1.256-.522-2.267-.665-.647-.125-1.333.131-1.824.328-.49.196-1.422.754-2.074 2.237-.652 1.482-.311 3.83-.067 4.56.244.729.625 1.924 1.273 2.796.576.984 1.34 1.667 1.659 1.899.319.232 1.219.386 1.843.067.502-.308 1.408-.485 1.766-.472.357.013 1.061.154 1.782.539.571.197 1.111.115 1.652-.105.541-.221 1.324-1.059 2.238-2.758.347-.79.505-1.217.473-1.282z"/></svg>`;
+	const codeSnippets: Record<string, string> = {
+		python: `from foundry_local_sdk import Configuration, FoundryLocalManager
+config = Configuration(app_name="my-app")
+FoundryLocalManager.initialize(config)
+model = FoundryLocalManager.instance.catalog.get_model("qwen2.5-0.5b")
+model.download(); model.load()
+response = model.get_chat_client().complete_chat(
+    [{"role": "user", "content": "Hello!"}])
+print(response.choices[0].message.content)`,
+		javascript: `import { FoundryLocalManager } from 'foundry-local-sdk';
+const manager = FoundryLocalManager.create({ appName: 'my-app' });
+const model = await manager.catalog.getModel('qwen2.5-0.5b');
+await model.download(); await model.load();
+const chat = model.createChatClient();
+const res = await chat.completeChat(
+    [{ role: 'user', content: 'Hello!' }]);
+console.log(res.choices[0]?.message?.content);`,
+		csharp: `using Microsoft.AI.Foundry.Local;
+await FoundryLocalManager.CreateAsync(
+    new Configuration { AppName = "my-app" });
+var catalog = await FoundryLocalManager.Instance.GetCatalogAsync();
+var model = await catalog.GetModelAsync("qwen2.5-0.5b");
+await model.DownloadAsync(); await model.LoadAsync();
+var client = await model.GetChatClientAsync();
+var res = await client.CompleteChatAsync(new[] {
+    new ChatMessage { Role="user", Content="Hello!" }});
+Console.WriteLine(res.Choices![0].Message.Content);`,
+		rust: `use foundry_local_sdk::*;
+let manager = FoundryLocalManager::create(
+    FoundryLocalConfig::new("my-app"))?;
+let model = manager.catalog().get_model("qwen2.5-0.5b").await?;
+model.download(None).await?; model.load().await?;
+let client = model.create_chat_client();
+let msgs = vec![ChatCompletionRequestUserMessage
+    ::from("Hello!").into()];
+let res = client.complete_chat(&msgs, None).await?;
+println!("{}", res.choices[0].message.content
+    .as_ref().unwrap());`
+	};
 
-	const WindowsIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M6.555 1.375 0 2.237v5.45h6.555V1.375zM0 13.795l6.555.933V8.313H0v5.482zm7.278-5.4.026 6.378L16 16V8.395H7.278zM16 0 7.33 1.244v6.414H16V0z"/></svg>`;
+	const tabLabels: Record<string, string> = {
+		python: 'Python',
+		javascript: 'JS',
+		csharp: 'C#',
+		rust: 'Rust'
+	};
 
 	onMount(() => {
-		installInfo = getInstallCommand();
-
-		// Listen for manual copy events (Ctrl+C, Cmd+C, right-click copy)
-		const handleCopy = (e: ClipboardEvent) => {
-			const selection = window.getSelection();
-			const selectedText = selection?.toString().trim();
-
-			// Check if the selected text matches our install command
-			if (selectedText && selectedText.includes(installInfo.command)) {
-				if (!showModelCommand) {
-					setTimeout(() => {
-						showModelCommand = true;
-					}, 400);
-					toast.success('Great! Now run a model');
-				}
-			}
-			// Check if the selected text matches our model command
-			else if (selectedText && selectedText.includes(modelCommand)) {
-				if (!copiedModel) {
-					copiedModel = true;
-					toast.success('Copied model command!');
-					setTimeout(() => {
-						copiedModel = false;
-					}, 2000);
-				}
-			}
-		};
-
-		// Listen for text selection to show step 2 even if they don't copy yet
-		const handleSelection = () => {
-			const selection = window.getSelection();
-			const selectedText = selection?.toString().trim();
-
-			// If they've selected the install command text, show step 2
-			if (selectedText && selectedText.includes(installInfo.command) && !showModelCommand) {
-				setTimeout(() => {
-					showModelCommand = true;
-				}, 400);
-			}
-		};
-
-		document.addEventListener('copy', handleCopy);
-		document.addEventListener('selectionchange', handleSelection);
-
-		return () => {
-			document.removeEventListener('copy', handleCopy);
-			document.removeEventListener('selectionchange', handleSelection);
-		};
+		const platform = detectPlatform();
+		if (platform === 'windows') {
+			activeTab = 'csharp';
+		} else {
+			activeTab = 'python';
+		}
 	});
+
+	$effect(() => {
+		// Reactively derive current command from active tab
+		void activeTab;
+	});
+
+	let currentCommand = $derived(sdkCommands[activeTab]);
 
 	async function copyCommand() {
 		try {
-			await navigator.clipboard.writeText(installInfo.command);
+			await navigator.clipboard.writeText(currentCommand);
 			copied = true;
 			toast.success('Copied to clipboard!');
-
-			// Show the model command after copying
-			setTimeout(() => {
-				showModelCommand = true;
-			}, 400);
-
-			setTimeout(() => {
-				copied = false;
-			}, 2000);
+			setTimeout(() => { showCodeSnippet = true; }, 400);
+			setTimeout(() => { copied = false; }, 2000);
 		} catch (err) {
 			toast.error('Failed to copy to clipboard');
 		}
 	}
 
-	async function copyModelCommand() {
+	async function copyCodeSnippet() {
 		try {
-			await navigator.clipboard.writeText(modelCommand);
-			copiedModel = true;
-			toast.success('Copied model command!');
-			setTimeout(() => {
-				copiedModel = false;
-			}, 2000);
+			await navigator.clipboard.writeText(codeSnippets[activeTab]);
+			copiedCode = true;
+			toast.success('Copied code snippet!');
+			setTimeout(() => { copiedCode = false; }, 2000);
 		} catch (err) {
 			toast.error('Failed to copy to clipboard');
 		}
 	}
-
-	function getPlatformIcon(label: string) {
-		if (label.toLowerCase().includes('windows')) {
-			return WindowsIcon;
-		} else if (label.toLowerCase().includes('macos')) {
-			return AppleIcon;
-		}
-		return WindowsIcon; // default
-	}
-
-	const platformIcon = $derived(getPlatformIcon(installInfo.label));
 </script>
 
 <div
 	class="border-primary/20 bg-primary/5 hover:border-primary/40 relative w-full rounded-lg border-2 p-4 transition-all duration-300 hover:shadow-lg sm:p-5"
 >
 	<div class="mb-3 text-center">
-		<h3 class="text-foreground text-sm font-semibold sm:text-base">Get Started in Two Steps</h3>
+		<h3 class="text-foreground text-sm font-semibold sm:text-base">Get Started: Install the SDK</h3>
+	</div>
+
+	<!-- Language Tabs -->
+	<div class="mb-3 flex justify-center gap-1">
+		{#each Object.entries(tabLabels) as [key, label]}
+			<button
+				type="button"
+				class="rounded-md px-3 py-1.5 text-xs font-medium transition-all duration-200 {activeTab === key
+					? 'bg-primary text-primary-foreground shadow-sm'
+					: 'text-muted-foreground hover:text-foreground hover:bg-muted'}"
+				onclick={() => { activeTab = key as 'python' | 'javascript' | 'csharp' | 'rust'; showCodeSnippet = false; }}
+			>
+				{label}
+			</button>
+		{/each}
 	</div>
 
 	<div class="flex flex-col gap-2.5">
-		<!-- Step 1: Install Command -->
+		<!-- Install Command -->
 		<div class="flex flex-col gap-1.5">
-			<span class="text-muted-foreground text-xs font-medium">Step 1: Install Foundry Local</span>
+			<span class="text-muted-foreground text-xs font-medium">Install the SDK</span>
 			<div
 				class="border-primary/30 bg-background/50 hover:border-primary/50 hover:bg-background group relative flex items-center gap-2 rounded-md border px-3 py-2.5 transition-all duration-300 sm:gap-3"
 			>
-				<!-- Platform Icon -->
-				<div class="flex shrink-0 items-center justify-center" role="img" aria-label={installInfo.label}>
-					<span class="text-primary" aria-hidden="true">{@html platformIcon}</span>
+				<div class="flex shrink-0 items-center justify-center">
+					<Terminal class="text-primary size-5" aria-hidden="true" />
 				</div>
-
-				<!-- Command -->
 				<code
 					bind:this={commandElement}
 					class="text-foreground flex-1 select-all overflow-x-auto font-mono text-xs sm:text-sm"
 					style="scrollbar-width: thin;"
 				>
-					{installInfo.command}
+					{currentCommand}
 				</code>
-
-				<!-- Copy Button -->
 				<button
 					type="button"
 					onclick={copyCommand}
@@ -163,46 +160,36 @@
 			</div>
 		</div>
 
-		<!-- Step 2: Model Command (appears after copying) -->
+		<!-- Code Snippet (appears after copying) -->
 		<div
 			class="flex flex-col gap-1.5 overflow-hidden transition-all duration-700 ease-out"
-			style={showModelCommand
-				? 'max-height: 120px; opacity: 1;'
+			style={showCodeSnippet
+				? 'max-height: 300px; opacity: 1;'
 				: 'max-height: 0; opacity: 0; margin-top: -10px;'}
 		>
-			<span class="text-muted-foreground text-xs font-medium">Step 2: Run a model</span>
+			<span class="text-muted-foreground text-xs font-medium">Run your first completion</span>
 			<div
-				class="border-primary/30 bg-background/50 hover:border-primary/50 hover:bg-background group relative flex items-center gap-2 rounded-md border px-3 py-2.5 transition-all duration-300 sm:gap-3"
+				class="border-primary/30 bg-background/50 group relative rounded-md border transition-all duration-300"
 			>
-				<!-- Terminal Icon -->
-				<div class="flex shrink-0 items-center justify-center" aria-label="Run model">
-					<Terminal class="text-primary size-5" aria-hidden="true" />
-				</div>
-
-				<!-- Command -->
-				<code
-					bind:this={modelCommandElement}
-					class="text-foreground flex-1 select-all overflow-x-auto font-mono text-xs sm:text-sm"
-					style="scrollbar-width: thin;"
-				>
-					{modelCommand}
-				</code>
-				<!-- Copy Button -->
+				<pre class="overflow-x-auto p-3 font-mono text-[10px] leading-relaxed text-gray-300 sm:text-xs"><code>{codeSnippets[activeTab]}</code></pre>
 				<button
 					type="button"
-					onclick={copyModelCommand}
-					class="bg-primary/10 text-primary hover:bg-primary/20 focus:ring-primary flex shrink-0 items-center gap-1.5 rounded px-2 py-1.5 text-xs font-medium transition-all duration-200 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-offset-2 sm:px-2.5"
-					aria-label="Copy model run command"
+					onclick={copyCodeSnippet}
+					class="bg-primary/10 text-primary hover:bg-primary/20 focus:ring-primary absolute top-2 right-2 flex shrink-0 items-center gap-1 rounded px-1.5 py-1 text-xs font-medium transition-all duration-200 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-offset-2"
+					aria-label="Copy code snippet"
 				>
-					{#if copiedModel}
-						<Check class="size-3.5 sm:size-4" aria-hidden="true" />
-						<span class="hidden sm:inline">Copied!</span>
+					{#if copiedCode}
+						<Check class="size-3" aria-hidden="true" />
 					{:else}
-						<Copy class="size-3.5 sm:size-4" aria-hidden="true" />
-						<span class="hidden sm:inline">Copy</span>
+						<Copy class="size-3" aria-hidden="true" />
 					{/if}
 				</button>
 			</div>
 		</div>
+
+		<!-- CLI note -->
+		<p class="text-muted-foreground text-center text-[10px]">
+			For interactive development, install the <a href="https://learn.microsoft.com/en-us/azure/foundry-local/reference/reference-cli" target="_blank" rel="noopener noreferrer" class="underline hover:text-foreground">CLI</a> separately.
+		</p>
 	</div>
 </div>

--- a/www/src/lib/components/install-command.svelte
+++ b/www/src/lib/components/install-command.svelte
@@ -171,7 +171,7 @@ println!("{}", res.choices[0].message.content
 			<div
 				class="border-primary/30 bg-background/50 group relative rounded-md border transition-all duration-300"
 			>
-				<pre class="overflow-x-auto p-3 font-mono text-[10px] leading-relaxed text-gray-300 sm:text-xs"><code>{codeSnippets[activeTab]}</code></pre>
+				<pre class="text-foreground overflow-x-auto p-3 font-mono text-[10px] leading-relaxed sm:text-xs"><code>{codeSnippets[activeTab]}</code></pre>
 				<button
 					type="button"
 					onclick={copyCodeSnippet}

--- a/www/src/lib/components/install-command.svelte
+++ b/www/src/lib/components/install-command.svelte
@@ -35,8 +35,10 @@ const res = await chat.completeChat(
     [{ role: 'user', content: 'Hello!' }]);
 console.log(res.choices[0]?.message?.content);`,
 		csharp: `using Microsoft.AI.Foundry.Local;
+using Microsoft.Extensions.Logging.Abstractions;
 await FoundryLocalManager.CreateAsync(
-    new Configuration { AppName = "my-app" });
+    new Configuration { AppName = "my-app" },
+    NullLogger.Instance);
 var catalog = await FoundryLocalManager.Instance.GetCatalogAsync();
 var model = await catalog.GetModelAsync("qwen2.5-0.5b");
 await model.DownloadAsync(); await model.LoadAsync();
@@ -48,7 +50,8 @@ Console.WriteLine(res.Choices![0].Message.Content);`,
 let manager = FoundryLocalManager::create(
     FoundryLocalConfig::new("my-app"))?;
 let model = manager.catalog().get_model("qwen2.5-0.5b").await?;
-model.download(None).await?; model.load().await?;
+model.download(None::<fn(f64)>).await?;
+model.load().await?;
 let client = model.create_chat_client();
 let msgs = vec![ChatCompletionRequestUserMessage
     ::from("Hello!").into()];

--- a/www/src/lib/components/install-command.svelte
+++ b/www/src/lib/components/install-command.svelte
@@ -1,198 +1,383 @@
 <script lang="ts">
-	import { Copy, Check, Terminal } from 'lucide-svelte';
+	import { Bot, Copy, Check, Terminal, Code2 } from 'lucide-svelte';
 	import { toast } from 'svelte-sonner';
-	import { onMount } from 'svelte';
-	import { detectPlatform } from '$lib/utils/platform';
+	import { cubicOut } from 'svelte/easing';
 
-	let copied = $state(false);
-	let copiedCode = $state(false);
-	let showCodeSnippet = $state(false);
-	let commandElement: HTMLElement;
-	let activeTab = $state<'python' | 'javascript' | 'csharp' | 'rust'>('python');
+	type SdkLanguage = 'python' | 'javascript' | 'csharp' | 'rust';
 
-	const sdkCommands = {
+	type Snippet = {
+		raw: string;
+		html: string;
+	};
+
+	const tabs: Array<{ key: SdkLanguage; label: string }> = [
+		{ key: 'python', label: 'Python' },
+		{ key: 'javascript', label: 'JS' },
+		{ key: 'csharp', label: 'C#' },
+		{ key: 'rust', label: 'Rust' }
+	];
+
+	const sdkCommands: Record<SdkLanguage, string> = {
 		python: 'pip install foundry-local-sdk',
 		javascript: 'npm install foundry-local-sdk',
 		csharp: 'dotnet add package Microsoft.AI.Foundry.Local',
 		rust: 'cargo add foundry-local-sdk'
 	};
 
-	const codeSnippets: Record<string, string> = {
-		python: `from foundry_local_sdk import Configuration, FoundryLocalManager
-config = Configuration(app_name="my-app")
-FoundryLocalManager.initialize(config)
+	const setupSnippets: Record<SdkLanguage, Snippet> = {
+		python: {
+			raw: `FoundryLocalManager.initialize(Configuration(app_name="my-app"))
 model = FoundryLocalManager.instance.catalog.get_model("qwen2.5-0.5b")
 model.download(); model.load()
-response = model.get_chat_client().complete_chat(
-    [{"role": "user", "content": "Hello!"}])
-print(response.choices[0].message.content)`,
-		javascript: `import { FoundryLocalManager } from 'foundry-local-sdk';
-const manager = FoundryLocalManager.create({ appName: 'my-app' });
+client = model.get_chat_client()`,
+			html: `<span class="code-type">FoundryLocalManager</span>.<span class="code-call">initialize</span>(<span class="code-type">Configuration</span>(app_name=<span class="code-string">"my-app"</span>))
+model = <span class="code-type">FoundryLocalManager</span>.instance.catalog.<span class="code-call">get_model</span>(<span class="code-string">"qwen2.5-0.5b"</span>)
+model.<span class="code-call">download</span>(); model.<span class="code-call">load</span>()
+client = model.<span class="code-call">get_chat_client</span>()`
+		},
+		javascript: {
+			raw: `const manager = FoundryLocalManager.create({ appName: 'my-app' });
 const model = await manager.catalog.getModel('qwen2.5-0.5b');
 await model.download(); await model.load();
-const chat = model.createChatClient();
-const res = await chat.completeChat(
-    [{ role: 'user', content: 'Hello!' }]);
-console.log(res.choices[0]?.message?.content);`,
-		csharp: `using Microsoft.AI.Foundry.Local;
-using Microsoft.Extensions.Logging.Abstractions;
-await FoundryLocalManager.CreateAsync(
-    new Configuration { AppName = "my-app" },
-    NullLogger.Instance);
-var catalog = await FoundryLocalManager.Instance.GetCatalogAsync();
+const chat = model.createChatClient();`,
+			html: `<span class="code-keyword">const</span> manager = <span class="code-type">FoundryLocalManager</span>.<span class="code-call">create</span>({ appName: <span class="code-string">'my-app'</span> });
+<span class="code-keyword">const</span> model = <span class="code-keyword">await</span> manager.catalog.<span class="code-call">getModel</span>(<span class="code-string">'qwen2.5-0.5b'</span>);
+<span class="code-keyword">await</span> model.<span class="code-call">download</span>(); <span class="code-keyword">await</span> model.<span class="code-call">load</span>();
+<span class="code-keyword">const</span> chat = model.<span class="code-call">createChatClient</span>();`
+		},
+		csharp: {
+			raw: `await FoundryLocalManager.CreateAsync(config, logger);
 var model = await catalog.GetModelAsync("qwen2.5-0.5b");
 await model.DownloadAsync(); await model.LoadAsync();
-var client = await model.GetChatClientAsync();
-var res = await client.CompleteChatAsync(new[] {
-    new ChatMessage { Role="user", Content="Hello!" }});
-Console.WriteLine(res.Choices![0].Message.Content);`,
-		rust: `use foundry_local_sdk::*;
-let manager = FoundryLocalManager::create(
-    FoundryLocalConfig::new("my-app"))?;
+var chat = await model.GetChatClientAsync();`,
+			html: `<span class="code-keyword">await</span> <span class="code-type">FoundryLocalManager</span>.<span class="code-call">CreateAsync</span>(config, logger);
+<span class="code-keyword">var</span> model = <span class="code-keyword">await</span> catalog.<span class="code-call">GetModelAsync</span>(<span class="code-string">"qwen2.5-0.5b"</span>);
+<span class="code-keyword">await</span> model.<span class="code-call">DownloadAsync</span>(); <span class="code-keyword">await</span> model.<span class="code-call">LoadAsync</span>();
+<span class="code-keyword">var</span> chat = <span class="code-keyword">await</span> model.<span class="code-call">GetChatClientAsync</span>();`
+		},
+		rust: {
+			raw: `let manager = FoundryLocalManager::create(FoundryLocalConfig::new("my-app"))?;
 let model = manager.catalog().get_model("qwen2.5-0.5b").await?;
-model.download(None::<fn(f64)>).await?;
-model.load().await?;
-let client = model.create_chat_client();
-let msgs = vec![ChatCompletionRequestUserMessage
-    ::from("Hello!").into()];
-let res = client.complete_chat(&msgs, None).await?;
-println!("{}", res.choices[0].message.content
-    .as_ref().unwrap());`
-	};
-
-	const tabLabels: Record<string, string> = {
-		python: 'Python',
-		javascript: 'JS',
-		csharp: 'C#',
-		rust: 'Rust'
-	};
-
-	onMount(() => {
-		const platform = detectPlatform();
-		if (platform === 'windows') {
-			activeTab = 'csharp';
-		} else {
-			activeTab = 'python';
+model.download(None::<fn(f64)>).await?; model.load().await?;
+let client = model.create_chat_client();`,
+			html: `<span class="code-keyword">let</span> manager = <span class="code-type">FoundryLocalManager</span>::<span class="code-call">create</span>(<span class="code-type">FoundryLocalConfig</span>::<span class="code-call">new</span>(<span class="code-string">"my-app"</span>))?;
+<span class="code-keyword">let</span> model = manager.<span class="code-call">catalog</span>().<span class="code-call">get_model</span>(<span class="code-string">"qwen2.5-0.5b"</span>).await?;
+model.<span class="code-call">download</span>(None::&lt;fn(f64)&gt;).await?; model.<span class="code-call">load</span>().await?;
+<span class="code-keyword">let</span> client = model.<span class="code-call">create_chat_client</span>();`
 		}
-	});
+	};
 
-	$effect(() => {
-		// Reactively derive current command from active tab
-		void activeTab;
-	});
+	const inferenceSnippets: Record<SdkLanguage, Snippet> = {
+		python: {
+			raw: `response = client.complete_chat([
+    {"role": "user", "content": "Hello!"}
+])
+print(response.choices[0].message.content)`,
+			html: `response = client.<span class="code-call">complete_chat</span>([
+    {<span class="code-string">"role"</span>: <span class="code-string">"user"</span>, <span class="code-string">"content"</span>: <span class="code-string">"Hello!"</span>}
+])
+<span class="code-call">print</span>(response.choices[0].message.content)`
+		},
+		javascript: {
+			raw: `const response = await chat.completeChat([
+  { role: 'user', content: 'Hello!' }
+]);
+console.log(response.choices[0]?.message?.content);`,
+			html: `<span class="code-keyword">const</span> response = <span class="code-keyword">await</span> chat.<span class="code-call">completeChat</span>([
+  { role: <span class="code-string">'user'</span>, content: <span class="code-string">'Hello!'</span> }
+]);
+console.<span class="code-call">log</span>(response.choices[0]?.message?.content);`
+		},
+		csharp: {
+			raw: `var response = await chat.CompleteChatAsync(new[] {
+    new ChatMessage { Role = "user", Content = "Hello!" }
+});
+Console.WriteLine(response.Choices![0].Message.Content);`,
+			html: `<span class="code-keyword">var</span> response = <span class="code-keyword">await</span> chat.<span class="code-call">CompleteChatAsync</span>(new[] {
+    <span class="code-keyword">new</span> <span class="code-type">ChatMessage</span> { Role = <span class="code-string">"user"</span>, Content = <span class="code-string">"Hello!"</span> }
+});
+<span class="code-type">Console</span>.<span class="code-call">WriteLine</span>(response.Choices![0].Message.Content);`
+		},
+		rust: {
+			raw: `let messages = vec![
+    ChatCompletionRequestUserMessage::from("Hello!").into()
+];
+let response = client.complete_chat(&messages, None).await?;`,
+			html: `<span class="code-keyword">let</span> messages = vec![
+    <span class="code-type">ChatCompletionRequestUserMessage</span>::<span class="code-call">from</span>(<span class="code-string">"Hello!"</span>).<span class="code-call">into</span>()
+];
+<span class="code-keyword">let</span> response = client.<span class="code-call">complete_chat</span>(&messages, None).await?;`
+		}
+	};
+
+	let copiedCommand = $state(false);
+	let copiedSetup = $state(false);
+	let copiedInference = $state(false);
+	let activeTab = $state<SdkLanguage>('python');
+	let revealedStep = $state(1);
 
 	let currentCommand = $derived(sdkCommands[activeTab]);
+	let currentSetupSnippet = $derived(setupSnippets[activeTab]);
+	let currentInferenceSnippet = $derived(inferenceSnippets[activeTab]);
+
+	function revealMotion(node: HTMLElement) {
+		const height = node.offsetHeight;
+		const shouldReduceMotion =
+			typeof window !== 'undefined' &&
+			window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+		return {
+			duration: shouldReduceMotion ? 0 : 240,
+			easing: cubicOut,
+			css: (t: number) => `
+				max-height: ${t * height}px;
+				opacity: ${t};
+				overflow: hidden;
+				transform: translateY(${(1 - t) * -6}px);
+			`
+		};
+	}
+
+	function revealStep(step: number) {
+		if (revealedStep < step) {
+			revealedStep = step;
+		}
+	}
 
 	async function copyCommand() {
 		try {
 			await navigator.clipboard.writeText(currentCommand);
-			copied = true;
-			toast.success('Copied to clipboard!');
-			setTimeout(() => { showCodeSnippet = true; }, 400);
-			setTimeout(() => { copied = false; }, 2000);
+			copiedCommand = true;
+			revealStep(2);
+			toast.success('Copied install command');
+			setTimeout(() => {
+				copiedCommand = false;
+			}, 2000);
 		} catch (err) {
-			toast.error('Failed to copy to clipboard');
+			toast.error('Failed to copy install command');
 		}
 	}
 
-	async function copyCodeSnippet() {
+	async function copySetupSnippet() {
 		try {
-			await navigator.clipboard.writeText(codeSnippets[activeTab]);
-			copiedCode = true;
-			toast.success('Copied code snippet!');
-			setTimeout(() => { copiedCode = false; }, 2000);
+			await navigator.clipboard.writeText(currentSetupSnippet.raw);
+			copiedSetup = true;
+			revealStep(3);
+			toast.success('Copied model setup');
+			setTimeout(() => {
+				copiedSetup = false;
+			}, 2000);
 		} catch (err) {
-			toast.error('Failed to copy to clipboard');
+			toast.error('Failed to copy model setup');
+		}
+	}
+
+	async function copyInferenceSnippet() {
+		try {
+			await navigator.clipboard.writeText(currentInferenceSnippet.raw);
+			copiedInference = true;
+			toast.success('Copied inference call');
+			setTimeout(() => {
+				copiedInference = false;
+			}, 2000);
+		} catch (err) {
+			toast.error('Failed to copy inference call');
 		}
 	}
 </script>
 
 <div
-	class="border-primary/20 bg-primary/5 hover:border-primary/40 relative w-full rounded-lg border-2 p-4 transition-all duration-300 hover:shadow-lg sm:p-5"
+	class="border-primary/20 bg-primary/5 hover:border-primary/40 relative w-full rounded-xl border p-4 transition-all duration-300 hover:shadow-lg sm:p-5"
 >
-	<div class="mb-3 text-center">
-		<h3 class="text-foreground text-sm font-semibold sm:text-base">Get Started: Install the SDK</h3>
+	<div class="mb-4 text-center">
+		<h3 class="text-foreground text-sm font-semibold sm:text-base">Start with the SDK</h3>
+		<p class="text-muted-foreground mx-auto mt-1 max-w-xl text-xs">
+			Install one package, load a model, then run inference in-process.
+		</p>
 	</div>
 
-	<!-- Language Tabs -->
-	<div class="mb-3 flex justify-center gap-1">
-		{#each Object.entries(tabLabels) as [key, label]}
+	<div class="mb-4 flex justify-center gap-1">
+		{#each tabs as tab}
 			<button
 				type="button"
-				class="rounded-md px-3 py-1.5 text-xs font-medium transition-all duration-200 {activeTab === key
+				class="min-h-9 rounded-md px-3 py-1.5 text-xs font-medium transition-all duration-200 {activeTab ===
+				tab.key
 					? 'bg-primary text-primary-foreground shadow-sm'
 					: 'text-muted-foreground hover:text-foreground hover:bg-muted'}"
-				onclick={() => { activeTab = key as 'python' | 'javascript' | 'csharp' | 'rust'; showCodeSnippet = false; }}
+				onclick={() => {
+					activeTab = tab.key;
+				}}
 			>
-				{label}
+				{tab.label}
 			</button>
 		{/each}
 	</div>
 
-	<div class="flex flex-col gap-2.5">
-		<!-- Install Command -->
-		<div class="flex flex-col gap-1.5">
-			<span class="text-muted-foreground text-xs font-medium">Install the SDK</span>
-			<div
-				class="border-primary/30 bg-background/50 hover:border-primary/50 hover:bg-background group relative flex items-center gap-2 rounded-md border px-3 py-2.5 transition-all duration-300 sm:gap-3"
-			>
-				<div class="flex shrink-0 items-center justify-center">
-					<Terminal class="text-primary size-5" aria-hidden="true" />
-				</div>
-				<code
-					bind:this={commandElement}
-					class="text-foreground flex-1 select-all overflow-x-auto font-mono text-xs sm:text-sm"
-					style="scrollbar-width: thin;"
+	<div class="grid gap-3">
+		<section class="border-primary/20 bg-background/55 rounded-lg border p-3">
+			<div class="text-muted-foreground mb-2 flex items-center gap-2 text-xs font-medium">
+				<span
+					class="bg-primary text-primary-foreground flex size-5 items-center justify-center rounded-full font-mono text-[11px]"
+					aria-hidden="true">1</span
 				>
+				<Terminal class="text-primary size-4" aria-hidden="true" />
+				<span>Install package</span>
+			</div>
+			<div
+				class="group border-border bg-muted/40 flex items-center gap-2 rounded-md border px-3 py-2.5"
+			>
+				<code class="text-foreground min-w-0 flex-1 overflow-x-auto font-mono text-xs select-all">
 					{currentCommand}
 				</code>
 				<button
 					type="button"
 					onclick={copyCommand}
-					class="bg-primary/10 text-primary hover:bg-primary/20 focus:ring-primary flex shrink-0 items-center gap-1.5 rounded px-2 py-1.5 text-xs font-medium transition-all duration-200 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-offset-2 sm:px-2.5"
+					class="bg-primary/10 text-primary hover:bg-primary/20 focus:ring-primary flex shrink-0 items-center gap-1 rounded px-2 py-1.5 text-xs font-medium transition-all duration-200 focus:ring-2 focus:ring-offset-2 focus:outline-none"
 					aria-label="Copy installation command"
 				>
-					{#if copied}
-						<Check class="size-3.5 sm:size-4" aria-hidden="true" />
-						<span class="hidden sm:inline">Copied!</span>
+					{#if copiedCommand}
+						<Check class="size-3.5" aria-hidden="true" />
 					{:else}
-						<Copy class="size-3.5 sm:size-4" aria-hidden="true" />
-						<span class="hidden sm:inline">Copy</span>
+						<Copy class="size-3.5" aria-hidden="true" />
 					{/if}
 				</button>
 			</div>
-		</div>
+		</section>
 
-		<!-- Code Snippet (appears after copying) -->
-		<div
-			class="flex flex-col gap-1.5 overflow-hidden transition-all duration-700 ease-out"
-			style={showCodeSnippet
-				? 'max-height: 300px; opacity: 1;'
-				: 'max-height: 0; opacity: 0; margin-top: -10px;'}
-		>
-			<span class="text-muted-foreground text-xs font-medium">Run your first completion</span>
-			<div
-				class="border-primary/30 bg-background/50 group relative rounded-md border transition-all duration-300"
+		{#if revealedStep >= 2}
+			<section
+				transition:revealMotion
+				class="border-primary/20 bg-background/55 rounded-lg border p-3"
 			>
-				<pre class="text-foreground overflow-x-auto p-3 font-mono text-[10px] leading-relaxed sm:text-xs"><code>{codeSnippets[activeTab]}</code></pre>
-				<button
-					type="button"
-					onclick={copyCodeSnippet}
-					class="bg-primary/10 text-primary hover:bg-primary/20 focus:ring-primary absolute top-2 right-2 flex shrink-0 items-center gap-1 rounded px-1.5 py-1 text-xs font-medium transition-all duration-200 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-offset-2"
-					aria-label="Copy code snippet"
-				>
-					{#if copiedCode}
-						<Check class="size-3" aria-hidden="true" />
-					{:else}
-						<Copy class="size-3" aria-hidden="true" />
-					{/if}
-				</button>
-			</div>
-		</div>
+				<div class="mb-2 flex items-center justify-between gap-3">
+					<div class="text-muted-foreground flex items-center gap-2 text-xs font-medium">
+						<span
+							class="bg-primary text-primary-foreground flex size-5 items-center justify-center rounded-full font-mono text-[11px]"
+							aria-hidden="true">2</span
+						>
+						<Code2 class="text-primary size-4" aria-hidden="true" />
+						<span>Load a model</span>
+					</div>
+					<button
+						type="button"
+						onclick={copySetupSnippet}
+						class="bg-primary/10 text-primary hover:bg-primary/20 focus:ring-primary flex shrink-0 items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-all duration-200 focus:ring-2 focus:ring-offset-2 focus:outline-none"
+						aria-label="Copy model setup"
+					>
+						{#if copiedSetup}
+							<Check class="size-3.5" aria-hidden="true" />
+							Copied
+						{:else}
+							<Copy class="size-3.5" aria-hidden="true" />
+							Copy
+						{/if}
+					</button>
+				</div>
+				<pre
+					class="snippet border-border bg-muted/40 text-foreground max-h-40 overflow-auto rounded-md border p-3 font-mono text-[11px] leading-relaxed sm:text-xs"><code
+						>{@html currentSetupSnippet.html}</code
+					></pre>
+			</section>
+		{:else}
+			<button
+				type="button"
+				transition:revealMotion
+				class="border-border/80 bg-background/35 hover:border-primary/35 hover:bg-primary/5 focus:ring-primary text-muted-foreground hover:text-foreground w-full rounded-lg border border-dashed p-3 text-left transition-all duration-200 focus:ring-2 focus:ring-offset-2 focus:outline-none"
+				onclick={() => revealStep(2)}
+				aria-label="Reveal model setup"
+			>
+				<span class="flex items-center gap-2 text-xs">
+					<span
+						class="border-border bg-muted flex size-5 shrink-0 items-center justify-center rounded-full border font-mono text-[11px]"
+						aria-hidden="true">2</span
+					>
+					<Code2 class="text-muted-foreground/60 size-4 shrink-0" aria-hidden="true" />
+					<span class="font-medium">Load a model</span>
+					<span class="text-muted-foreground/50 ml-auto hidden shrink-0 sm:inline"
+						>copy step 1 or click to reveal</span
+					>
+				</span>
+			</button>
+		{/if}
 
-		<!-- CLI note -->
-		<p class="text-muted-foreground text-center text-[10px]">
-			For interactive development, install the <a href="https://learn.microsoft.com/en-us/azure/foundry-local/reference/reference-cli" target="_blank" rel="noopener noreferrer" class="underline hover:text-foreground">CLI</a> separately.
-		</p>
+		{#if revealedStep >= 3}
+			<section
+				transition:revealMotion
+				class="border-primary/20 bg-background/55 rounded-lg border p-3"
+			>
+				<div class="mb-2 flex items-center justify-between gap-3">
+					<div class="text-muted-foreground flex items-center gap-2 text-xs font-medium">
+						<span
+							class="bg-primary text-primary-foreground flex size-5 items-center justify-center rounded-full font-mono text-[11px]"
+							aria-hidden="true">3</span
+						>
+						<Bot class="text-primary size-4" aria-hidden="true" />
+						<span>Run chat inference</span>
+					</div>
+					<button
+						type="button"
+						onclick={copyInferenceSnippet}
+						class="bg-primary/10 text-primary hover:bg-primary/20 focus:ring-primary flex shrink-0 items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-all duration-200 focus:ring-2 focus:ring-offset-2 focus:outline-none"
+						aria-label="Copy inference call"
+					>
+						{#if copiedInference}
+							<Check class="size-3.5" aria-hidden="true" />
+							Copied
+						{:else}
+							<Copy class="size-3.5" aria-hidden="true" />
+							Copy
+						{/if}
+					</button>
+				</div>
+				<pre
+					class="snippet border-border bg-muted/40 text-foreground max-h-40 overflow-auto rounded-md border p-3 font-mono text-[11px] leading-relaxed sm:text-xs"><code
+						>{@html currentInferenceSnippet.html}</code
+					></pre>
+			</section>
+		{:else}
+			<button
+				type="button"
+				transition:revealMotion
+				class="border-border/80 bg-background/35 hover:border-primary/35 hover:bg-primary/5 focus:ring-primary text-muted-foreground hover:text-foreground w-full rounded-lg border border-dashed p-3 text-left transition-all duration-200 focus:ring-2 focus:ring-offset-2 focus:outline-none"
+				onclick={() => revealStep(3)}
+				aria-label="Reveal chat inference call"
+			>
+				<span class="flex items-center gap-2 text-xs">
+					<span
+						class="border-border bg-muted flex size-5 shrink-0 items-center justify-center rounded-full border font-mono text-[11px]"
+						aria-hidden="true">3</span
+					>
+					<Bot class="text-muted-foreground/60 size-4 shrink-0" aria-hidden="true" />
+					<span class="font-medium">Run chat inference</span>
+					<span class="text-muted-foreground/50 ml-auto hidden shrink-0 sm:inline"
+						>copy step 2 or click to reveal</span
+					>
+				</span>
+			</button>
+		{/if}
 	</div>
 </div>
+
+<style>
+	.snippet {
+		scrollbar-width: thin;
+	}
+
+	.snippet :global(.code-keyword) {
+		color: hsl(var(--primary));
+		font-weight: 600;
+	}
+
+	.snippet :global(.code-type) {
+		color: hsl(var(--warning));
+		font-weight: 600;
+	}
+
+	.snippet :global(.code-call) {
+		color: hsl(var(--info));
+	}
+
+	.snippet :global(.code-string) {
+		color: hsl(var(--success));
+	}
+</style>

--- a/www/src/lib/components/install-command.svelte
+++ b/www/src/lib/components/install-command.svelte
@@ -46,12 +46,26 @@ const chat = model.createChatClient();`,
 <span class="code-keyword">const</span> chat = model.<span class="code-call">createChatClient</span>();`
 		},
 		csharp: {
-			raw: `await FoundryLocalManager.CreateAsync(config, logger);
-var model = await catalog.GetModelAsync("qwen2.5-0.5b");
+			raw: `using Microsoft.AI.Foundry.Local;
+using Microsoft.Extensions.Logging.Abstractions;
+using Betalgo.Ranul.OpenAI.ObjectModels.RequestModels;
+await FoundryLocalManager.CreateAsync(
+    new Configuration { AppName = "my-app" },
+    NullLogger.Instance);
+var catalog = await FoundryLocalManager.Instance.GetCatalogAsync();
+var model = await catalog.GetModelAsync("qwen2.5-0.5b")
+    ?? throw new Exception("Model not found.");
 await model.DownloadAsync(); await model.LoadAsync();
 var chat = await model.GetChatClientAsync();`,
-			html: `<span class="code-keyword">await</span> <span class="code-type">FoundryLocalManager</span>.<span class="code-call">CreateAsync</span>(config, logger);
-<span class="code-keyword">var</span> model = <span class="code-keyword">await</span> catalog.<span class="code-call">GetModelAsync</span>(<span class="code-string">"qwen2.5-0.5b"</span>);
+			html: `<span class="code-keyword">using</span> <span class="code-type">Microsoft.AI.Foundry.Local</span>;
+<span class="code-keyword">using</span> <span class="code-type">Microsoft.Extensions.Logging.Abstractions</span>;
+<span class="code-keyword">using</span> <span class="code-type">Betalgo.Ranul.OpenAI.ObjectModels.RequestModels</span>;
+<span class="code-keyword">await</span> <span class="code-type">FoundryLocalManager</span>.<span class="code-call">CreateAsync</span>(
+    <span class="code-keyword">new</span> <span class="code-type">Configuration</span> { AppName = <span class="code-string">"my-app"</span> },
+    <span class="code-type">NullLogger</span>.Instance);
+<span class="code-keyword">var</span> catalog = <span class="code-keyword">await</span> <span class="code-type">FoundryLocalManager</span>.Instance.<span class="code-call">GetCatalogAsync</span>();
+<span class="code-keyword">var</span> model = <span class="code-keyword">await</span> catalog.<span class="code-call">GetModelAsync</span>(<span class="code-string">"qwen2.5-0.5b"</span>)
+    ?? <span class="code-keyword">throw new</span> <span class="code-type">Exception</span>(<span class="code-string">"Model not found."</span>);
 <span class="code-keyword">await</span> model.<span class="code-call">DownloadAsync</span>(); <span class="code-keyword">await</span> model.<span class="code-call">LoadAsync</span>();
 <span class="code-keyword">var</span> chat = <span class="code-keyword">await</span> model.<span class="code-call">GetChatClientAsync</span>();`
 		},

--- a/www/src/lib/components/ui/sonner/sonner.svelte
+++ b/www/src/lib/components/ui/sonner/sonner.svelte
@@ -9,13 +9,85 @@
 	theme={mode.current}
 	class="toaster group"
 	toastOptions={{
+		duration: 2400,
 		classes: {
-			toast:
-				'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+			toast: 'toast group border-border bg-background text-foreground shadow-lg',
+			success: 'toast-success',
+			error: 'toast-error',
+			info: 'toast-info',
+			warning: 'toast-warning',
 			description: 'group-[.toast]:text-muted-foreground',
+			icon: 'toast-icon',
 			actionButton: 'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
 			cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground'
 		}
 	}}
 	{...restProps}
 />
+
+<style>
+	:global([data-sonner-toast].toast) {
+		border-color: hsl(var(--border));
+		background: hsl(var(--background));
+		color: hsl(var(--foreground));
+		box-shadow:
+			0 8px 24px hsl(var(--foreground) / 0.08),
+			0 1px 2px hsl(var(--foreground) / 0.08);
+	}
+
+	:global([data-sonner-toast].toast [data-title]) {
+		font-weight: 500;
+	}
+
+	:global([data-sonner-toast].toast [data-description]) {
+		color: hsl(var(--muted-foreground));
+	}
+
+	:global([data-sonner-toast].toast .toast-icon) {
+		color: hsl(var(--primary));
+	}
+
+	:global([data-sonner-toast].toast-success) {
+		border-color: hsl(var(--success) / 0.35);
+		background:
+			linear-gradient(90deg, hsl(var(--success) / 0.14), hsl(var(--success) / 0.06)),
+			hsl(var(--background));
+	}
+
+	:global([data-sonner-toast].toast-success .toast-icon) {
+		color: hsl(var(--success));
+	}
+
+	:global([data-sonner-toast].toast-error) {
+		border-color: hsl(var(--destructive) / 0.35);
+		background:
+			linear-gradient(90deg, hsl(var(--destructive) / 0.12), hsl(var(--destructive) / 0.05)),
+			hsl(var(--background));
+	}
+
+	:global([data-sonner-toast].toast-error .toast-icon) {
+		color: hsl(var(--destructive));
+	}
+
+	:global([data-sonner-toast].toast-info) {
+		border-color: hsl(var(--info) / 0.35);
+		background:
+			linear-gradient(90deg, hsl(var(--info) / 0.12), hsl(var(--info) / 0.05)),
+			hsl(var(--background));
+	}
+
+	:global([data-sonner-toast].toast-info .toast-icon) {
+		color: hsl(var(--info));
+	}
+
+	:global([data-sonner-toast].toast-warning) {
+		border-color: hsl(var(--warning) / 0.4);
+		background:
+			linear-gradient(90deg, hsl(var(--warning) / 0.14), hsl(var(--warning) / 0.05)),
+			hsl(var(--background));
+	}
+
+	:global([data-sonner-toast].toast-warning .toast-icon) {
+		color: hsl(var(--warning));
+	}
+</style>

--- a/www/src/lib/config.ts
+++ b/www/src/lib/config.ts
@@ -18,13 +18,13 @@ import type { Feature, PromoConfig, SiteConfig } from './types/config';
 export const siteConfig: SiteConfig = {
 	title: 'Foundry Local',
 	description:
-		'Build once, run locally. The SDK for shipping AI-powered applications with hardware-optimized on-device inference.',
+		'Ship AI-powered apps with on-device inference. Native SDKs for C#, JavaScript, Python, and Rust. ~20 MB runtime, no cloud required.',
 	github: 'https://github.com/microsoft/foundry-local',
 	npm: '',
 	quickLinks: [
 		{
 			title: 'Getting Started',
-			href: 'https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-local/get-started'
+			href: 'https://learn.microsoft.com/en-us/azure/foundry-local/get-started'
 		},
 		{ title: 'GitHub', href: 'https://github.com/microsoft/foundry-local' }
 	],
@@ -42,7 +42,7 @@ export let navItems: NavItem[] = [
 	},
 	{
 		title: 'Docs',
-		href: 'https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-local/get-started',
+		href: 'https://learn.microsoft.com/en-us/azure/foundry-local/get-started',
 		icon: BookOpen
 	}
 ];
@@ -66,13 +66,13 @@ export const features: Feature[] = [
 	{
 		icon: Cpu,
 		title: 'Hardware Optimized',
-		description: 'We work directly with hardware vendors for NPU, GPU & CPU acceleration',
+		description: 'Automatic execution provider management for NPU, GPU & CPU acceleration',
 		size: 'large'
 	},
 	{
 		icon: Wifi,
 		title: 'Edge-Ready',
-		description: 'Works fully offline with no cloud dependencies',
+		description: 'Works fully offline. ~20 MB runtime, no cloud dependencies',
 		size: 'medium'
 	},
 	{
@@ -84,7 +84,7 @@ export const features: Feature[] = [
 	{
 		icon: Bot,
 		title: 'OpenAI Compatible',
-		description: 'Drop-in API replacement for easy integration',
+		description: 'Native SDK API plus optional OpenAI-compatible REST server',
 		size: 'medium'
 	},
 	{

--- a/www/src/lib/config.ts
+++ b/www/src/lib/config.ts
@@ -18,7 +18,7 @@ import type { Feature, PromoConfig, SiteConfig } from './types/config';
 export const siteConfig: SiteConfig = {
 	title: 'Foundry Local',
 	description:
-		'Ship AI-powered apps with on-device inference. Native SDKs for C#, JavaScript, Python, and Rust. ~20 MB runtime, no cloud required.',
+		'Use native SDKs to download, cache, load, and call optimized local models on-device.',
 	github: 'https://github.com/microsoft/foundry-local',
 	npm: '',
 	quickLinks: [
@@ -58,39 +58,38 @@ export let socialLinks: SocialLink[] = [
 export const features: Feature[] = [
 	{
 		icon: Rocket,
-		title: 'Ship to Production',
-		description:
-			'Built as an SDK for shipping AI-powered applications, not just running models locally',
+		title: 'SDK-First App Integration',
+		description: 'Initialize, download, load, and call models directly from your app process',
 		size: 'large'
 	},
 	{
 		icon: Cpu,
 		title: 'Hardware Optimized',
-		description: 'Automatic execution provider management for NPU, GPU & CPU acceleration',
+		description: 'Automatic execution provider management for NPU, GPU, and CPU acceleration',
 		size: 'large'
 	},
 	{
 		icon: Wifi,
-		title: 'Edge-Ready',
-		description: 'Works fully offline. ~20 MB runtime, no cloud dependencies',
+		title: 'Offline by Design',
+		description: '~20 MB runtime and cached models keep apps running without a network',
 		size: 'medium'
 	},
 	{
 		icon: Code,
-		title: 'Multi-Language SDKs',
-		description: 'Python, JavaScript, C#, and Rust SDKs',
+		title: 'Native SDKs',
+		description: 'Start in Python or JavaScript; ship across C# and Rust too',
 		size: 'medium'
 	},
 	{
 		icon: Bot,
-		title: 'OpenAI Compatible',
-		description: 'Native SDK API plus optional OpenAI-compatible REST server',
+		title: 'Native First, REST When Needed',
+		description: 'Use SDK clients in-process, or start the optional OpenAI-compatible server',
 		size: 'medium'
 	},
 	{
 		icon: Shield,
 		title: 'Data Privacy',
-		description: 'Everything stays on-device',
+		description: 'Prompts, audio, and responses stay on the user device',
 		size: 'medium'
 	}
 ];

--- a/www/src/routes/+page.svelte
+++ b/www/src/routes/+page.svelte
@@ -10,7 +10,7 @@
 
 <Nav bind:isDownloadOpen />
 <main id="main-content">
-	<Hero bind:isDownloadOpen />
+	<Hero />
 	<Features />
 </main>
 <Footer />

--- a/www/src/routes/models/+page.svelte
+++ b/www/src/routes/models/+page.svelte
@@ -7,14 +7,29 @@
 	import type { GroupedFoundryModel } from './types';
 	import Nav from '$lib/components/home/nav.svelte';
 	import Footer from '$lib/components/home/footer.svelte';
+	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { toast } from 'svelte-sonner';
 	import { ModelFilters, ModelGrid, ModelDetailsModal } from './components';
+	import { Terminal, Copy, Check } from 'lucide-svelte';
 
 	// Known device names used as shorthand URL params (e.g. /models?cpu)
 	const KNOWN_DEVICES = ['cpu', 'gpu', 'npu'];
 	const MODEL_QUERY_PARAM = 'model';
+	const CLI_RUN_COMMAND = 'foundry model run qwen2.5-0.5b';
+	const CLI_INSTALL_COMMANDS = [
+		{
+			id: 'windows-cli',
+			label: 'Windows',
+			command: 'winget install Microsoft.FoundryLocal'
+		},
+		{
+			id: 'macos-cli',
+			label: 'macOS',
+			command: 'brew install microsoft/foundrylocal/foundrylocal'
+		}
+	];
 
 	// Debounce timer for search
 	let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -26,6 +41,7 @@
 	let loading = false;
 	let error = '';
 	let copiedModelId: string | null = null;
+	let copiedCliCommandId: string | null = null;
 
 	// Modal state
 	let selectedModel: GroupedFoundryModel | null = null;
@@ -127,9 +143,7 @@
 
 	function getModelByAlias(modelAlias: string): GroupedFoundryModel | null {
 		const normalizedAlias = normalizeModelAlias(modelAlias);
-		return (
-			allModels.find((model) => normalizeModelAlias(model.alias) === normalizedAlias) ?? null
-		);
+		return allModels.find((model) => normalizeModelAlias(model.alias) === normalizedAlias) ?? null;
 	}
 
 	function syncSelectedModelFromUrl() {
@@ -262,14 +276,18 @@
 	// Check if model matches search term
 	function matchesSearchTerm(model: GroupedFoundryModel, searchLower: string): boolean {
 		if (!searchLower) return true;
-		
+
 		return Boolean(
 			model.displayName.toLowerCase().includes(searchLower) ||
 			model.alias.toLowerCase().includes(searchLower) ||
 			model.description.toLowerCase().includes(searchLower) ||
 			model.tags.some((tag) => tag.toLowerCase().includes(searchLower)) ||
 			model.variants?.some((v) => v.name.toLowerCase().includes(searchLower)) ||
-			(model.acceleration && foundryModelService.getAccelerationDisplayName(model.acceleration).toLowerCase().includes(searchLower))
+			(model.acceleration &&
+				foundryModelService
+					.getAccelerationDisplayName(model.acceleration)
+					.toLowerCase()
+					.includes(searchLower))
 		);
 	}
 
@@ -293,12 +311,20 @@
 
 	function applyFilters() {
 		const searchLower = debouncedSearchTerm.toLowerCase();
-		
+
 		filteredModels = allModels.filter((model) => {
 			const matchesSearch = matchesSearchTerm(model, searchLower);
-			const matchesDevice = selectedDevices.length === 0 || selectedDevices.some((device) => model.deviceSupport.includes(device));
-			const matchesFamily = !selectedFamily || model.displayName.toLowerCase().includes(selectedFamily.toLowerCase()) || model.alias.toLowerCase().includes(selectedFamily.toLowerCase());
-			const matchesAcceleration = !selectedAcceleration || model.acceleration === selectedAcceleration || model.variants?.some((v) => v.acceleration === selectedAcceleration);
+			const matchesDevice =
+				selectedDevices.length === 0 ||
+				selectedDevices.some((device) => model.deviceSupport.includes(device));
+			const matchesFamily =
+				!selectedFamily ||
+				model.displayName.toLowerCase().includes(selectedFamily.toLowerCase()) ||
+				model.alias.toLowerCase().includes(selectedFamily.toLowerCase());
+			const matchesAcceleration =
+				!selectedAcceleration ||
+				model.acceleration === selectedAcceleration ||
+				model.variants?.some((v) => v.acceleration === selectedAcceleration);
 
 			return matchesSearch && matchesDevice && matchesFamily && matchesAcceleration;
 		});
@@ -353,6 +379,19 @@
 			toast.success('Run command copied to clipboard');
 			setTimeout(() => {
 				copiedModelId = null;
+			}, 2000);
+		} catch (err) {
+			toast.error('Failed to copy to clipboard');
+		}
+	}
+
+	async function copyCliCommand(command: string, id: string) {
+		try {
+			await navigator.clipboard.writeText(command);
+			copiedCliCommandId = id;
+			toast.success('CLI command copied to clipboard');
+			setTimeout(() => {
+				copiedCliCommandId = null;
 			}, 2000);
 		} catch (err) {
 			toast.error('Failed to copy to clipboard');
@@ -463,6 +502,71 @@
 
 	<div class="bg-white dark:bg-neutral-950">
 		<main id="main-content" class="mx-auto w-full max-w-6xl px-6 py-8 sm:px-8 lg:px-12">
+			<section
+				class="border-border/50 bg-muted/30 mb-4 rounded-lg border px-3 py-2.5 sm:px-4"
+				aria-label="CLI quick test"
+			>
+				<div class="flex flex-col gap-2 xl:flex-row xl:items-center">
+					<div class="flex shrink-0 items-center gap-2">
+						<Terminal class="text-primary size-4" aria-hidden="true" />
+						<div class="leading-tight">
+							<div class="text-sm font-medium">Test with the CLI</div>
+							<div class="text-muted-foreground text-xs">
+								Copy a command, then swap in any model alias.
+							</div>
+						</div>
+					</div>
+
+					<div
+						class="grid min-w-0 flex-1 gap-2 md:grid-cols-[minmax(11rem,0.9fr)_minmax(11rem,0.9fr)_minmax(21rem,1.1fr)]"
+					>
+						{#each CLI_INSTALL_COMMANDS as item}
+							<button
+								type="button"
+								class="border-border/60 bg-background/60 hover:bg-background focus:ring-primary flex min-h-11 min-w-0 items-center justify-between gap-3 rounded-md border px-3 py-2 text-left transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none"
+								onclick={() => copyCliCommand(item.command, item.id)}
+								aria-label={`Copy ${item.label} CLI installation command`}
+							>
+								<span class="min-w-0">
+									<span class="block truncate text-sm font-medium">{item.label} install</span>
+								</span>
+								{#if copiedCliCommandId === item.id}
+									<span
+										class="flex shrink-0 items-center gap-1.5 text-xs font-medium text-green-600"
+									>
+										<Check class="size-4" aria-hidden="true" />
+										Copied
+									</span>
+								{:else}
+									<span class="text-primary flex shrink-0 items-center gap-1.5 text-xs font-medium">
+										<Copy class="size-4" aria-hidden="true" />
+										Copy
+									</span>
+								{/if}
+							</button>
+						{/each}
+
+						<button
+							type="button"
+							class="border-primary/20 bg-background/80 hover:bg-background focus:ring-primary flex min-h-11 min-w-0 items-center gap-2 rounded-md border px-3 py-2 text-left transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none"
+							onclick={() => copyCliCommand(CLI_RUN_COMMAND, 'run-model')}
+							aria-label="Copy CLI model run command"
+						>
+							<span class="text-primary shrink-0 text-xs font-medium">Run</span>
+							<code class="text-muted-foreground min-w-0 flex-1 text-xs whitespace-nowrap"
+								>{CLI_RUN_COMMAND}</code
+							>
+							{#if copiedCliCommandId === 'run-model'}
+								<Check class="size-4 shrink-0 text-green-600" aria-hidden="true" />
+								<span class="sr-only">Copied</span>
+							{:else}
+								<Copy class="size-4 shrink-0 opacity-60" aria-hidden="true" />
+							{/if}
+						</button>
+					</div>
+				</div>
+			</section>
+
 			<ModelFilters
 				bind:searchTerm
 				bind:selectedDevices
@@ -482,9 +586,13 @@
 
 			<!-- Loading State -->
 			{#if loading}
-				<div class="flex flex-col items-center justify-center py-20" role="status" aria-live="polite">
+				<div
+					class="flex flex-col items-center justify-center py-20"
+					role="status"
+					aria-live="polite"
+				>
 					<div
-						class="mb-4 size-12 animate-spin rounded-full border-4 border-primary border-t-transparent"
+						class="border-primary mb-4 size-12 animate-spin rounded-full border-4 border-t-transparent"
 						aria-hidden="true"
 					></div>
 					<p class="text-lg text-gray-600 dark:text-gray-400">Loading foundry models...</p>
@@ -493,7 +601,10 @@
 
 			<!-- Error State -->
 			{#if error}
-				<Card.Root class="border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950" role="alert">
+				<Card.Root
+					class="border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950"
+					role="alert"
+				>
 					<Card.Content class="pt-6">
 						<div class="flex items-start gap-4">
 							<div class="rounded-full bg-red-100 p-2 dark:bg-red-900">


### PR DESCRIPTION
## Summary

Foundry Local is now delivered as a native SDK (~20 MB) that ships inside your app. The website still led with CLI install commands (`winget install` + `foundry model run`), which framed it as a CLI tool. This PR updates the website to reflect the SDK-first positioning.

## Changes

### Hero / Install Command (`install-command.svelte`)
- Replaced the 2-step CLI flow (`winget install` → `foundry model run`) with **tabbed SDK install commands** (Python / JS / C# / Rust)
- Each tab shows the correct `pip install` / `npm install` / `dotnet add package` / `cargo add` command
- Copying the install command reveals a per-language **hello-world code snippet** showing the full lifecycle: init → catalog → download → load → chat

### Features Section (`features.svelte`)
- Fixed the "Ship to Production" code example: was showing `manager.getCatalog().getModel('gpt-oss-20b')` (wrong API, fake model). Now shows correct SDK pattern: `catalog.getModel('qwen2.5-0.5b')` with `download()` → `load()` → `createChatClient()` → `completeChat()`
- Updated feature descriptions to mention EP management, ~20 MB runtime, native SDK + optional REST server

### Download Dropdown (`download-dropdown.svelte`)
- Fixed Rust package name: `cargo add foundry-local` → `cargo add foundry-local-sdk`
- Added **WinML variants** section for Windows with all 4 languages (`-winml` packages)

### Docs Links (all files)
- Fixed broken links: `azure/ai-foundry/foundry-local/` → `azure/foundry-local/` across hero, nav, footer, and config

### Messaging Updates (`config.ts`, `footer.svelte`)
- Updated site description and footer tagline to reflect SDK-first positioning
- Updated feature card descriptions

## Verification
- `svelte-check`: 18 errors before, 18 errors after (all pre-existing in UI library types, zero introduced)

## Not included (separate repo: MicrosoftDocs/azure-ai-docs)
A docs discrepancy audit found 14 issues in the Learn docs. Key items:
- Python samples wrap synchronous SDK in `asyncio.run()` (4 pages)
- Streaming code uses `chunk.choices[0].message.content` instead of `delta.content` (2 pages)
- "Foundry Local CLI" framing on pages that also apply to the SDK (3 pages)
- Landing page meta description is generic Azure AI boilerplate

Full audit available on request.