### PR TITLE
fixes trigger issues with mega pipeline

### DIFF
--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -80,12 +80,12 @@ extends:
     #   sdkVersion  – semver for JS, C#, Rust (e.g. 1.0.0-dev.202604061234)
     #   pyVersion   – PEP 440 for Python     (e.g. 1.0.0.dev202604061234)
     #   flcVersion  – NuGet/FLC style         (e.g. 1.0.0-dev-202604061234-ab12cd34)
-    - stage: compute_version
-      displayName: 'Compute Version'
+    - stage: preamble
+      displayName: 'Preamble'
       dependsOn: []
       jobs:
       - job: version
-        displayName: 'Compute Version'
+        displayName: 'preamble'
         pool:
           name: onnxruntime-Win-CPU-2022
           os: windows
@@ -96,6 +96,24 @@ extends:
             targetPath: '$(Build.ArtifactStagingDirectory)/version-info'
         steps:
         - checkout: none
+        - task: PowerShell@2
+          displayName: 'Cancel previous runs for this branch'
+          inputs:
+            targetType: inline
+            script: |
+              $headers = @{ Authorization = "Bearer $(System.AccessToken)"; "Content-Type" = "application/json" }
+              $base = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/builds"
+              $branch = "$(Build.SourceBranch)"
+              $currentId = $(Build.BuildId)
+              $defId = $(System.DefinitionId)
+              $url = "${base}?definitions=${defId}&statusFilter=inProgress&branchName=${branch}&api-version=7.1"
+              $runs = (Invoke-RestMethod -Uri $url -Headers $headers).value | Where-Object { $_.id -ne $currentId }
+              foreach ($run in $runs) {
+                Write-Host "Cancelling build $($run.id) (started $($run.startTime))"
+                $body = '{"status":"cancelling"}'
+                Invoke-RestMethod -Method Patch -Uri "${base}/$($run.id)?api-version=7.1" -Headers $headers -Body $body | Out-Null
+              }
+              if ($runs.Count -eq 0) { Write-Host "No previous runs to cancel." }
         - task: PowerShell@2
           displayName: 'Compute and write version files'
           inputs:
@@ -133,7 +151,7 @@ extends:
     # ── Build FLC ──
     - stage: build_core
       displayName: 'Build Core'
-      dependsOn: compute_version
+      dependsOn: preamble
       jobs:
       - job: flc_win_x64
         displayName: 'Core win-x64'
@@ -448,7 +466,7 @@ extends:
     # ── Build FLC (WinML) ──
     - stage: build_core_winml
       displayName: 'Build Core (WinML)'
-      dependsOn: compute_version
+      dependsOn: preamble
       jobs:
       - job: flc_winml_win_x64
         displayName: 'Core win-x64 (WinML)'

--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -8,9 +8,11 @@
 #   rust-sdk, rust-sdk-winml
 
 pr:
-- main
-- releases/*
-autoCancel: true
+  autoCancel: true
+  branches:
+    include:
+    - main
+    - releases/*
 
 name: $(Date:yyyyMMdd).$(Rev:r)
 

--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -8,7 +8,7 @@
 #   rust-sdk, rust-sdk-winml
 
 pr:
-  autoCancel: true
+  autoCancel: true # https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pr?view=azure-pipelines#pr-autocancel-branches-paths-drafts
   branches:
     include:
     - main

--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -6,7 +6,7 @@
 # Produces artifacts: flc-nuget, flc-nuget-winml, flc-wheels, flc-wheels-winml,
 #   cs-sdk, cs-sdk-winml, js-sdk, js-sdk-winml, python-sdk, python-sdk-winml,
 #   rust-sdk, rust-sdk-winml
-
+# test auto cancel
 pr:
   autoCancel: true
   branches:

--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -8,11 +8,8 @@
 #   rust-sdk, rust-sdk-winml
 
 pr:
-  autoCancel: true # https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pr?view=azure-pipelines#pr-autocancel-branches-paths-drafts
-  branches:
-    include:
-    - main
-    - releases/*
+- main
+- releases/*
 
 name: $(Date:yyyyMMdd).$(Rev:r)
 

--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -81,16 +81,11 @@ extends:
       displayName: 'Preamble'
       dependsOn: []
       jobs:
-      - job: version
-        displayName: 'preamble'
+      - job: cancel_previous
+        displayName: 'Cancel Previous'
         pool:
           name: onnxruntime-Win-CPU-2022
           os: windows
-        templateContext:
-          outputs:
-          - output: pipelineArtifact
-            artifactName: 'version-info'
-            targetPath: '$(Build.ArtifactStagingDirectory)/version-info'
         steps:
         - checkout: none
         - task: PowerShell@2
@@ -111,6 +106,19 @@ extends:
                 Invoke-RestMethod -Method Patch -Uri "${base}/$($run.id)?api-version=7.1" -Headers $headers -Body $body | Out-Null
               }
               if ($runs.Count -eq 0) { Write-Host "No previous runs to cancel." }
+
+      - job: version
+        displayName: 'Compute Version'
+        pool:
+          name: onnxruntime-Win-CPU-2022
+          os: windows
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            artifactName: 'version-info'
+            targetPath: '$(Build.ArtifactStagingDirectory)/version-info'
+        steps:
+        - checkout: none
         - task: PowerShell@2
           displayName: 'Compute and write version files'
           inputs:

--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -6,7 +6,7 @@
 # Produces artifacts: flc-nuget, flc-nuget-winml, flc-wheels, flc-wheels-winml,
 #   cs-sdk, cs-sdk-winml, js-sdk, js-sdk-winml, python-sdk, python-sdk-winml,
 #   rust-sdk, rust-sdk-winml
-# test auto cancel
+
 pr:
   autoCancel: true
   branches:

--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -11,14 +11,14 @@ pr:
   autoCancel: true
   branches:
     include:
-    - main
-    - releases/*
+      - main
+      - releases/*
 
 trigger:
   branches:
     include:
-    - main
-    - releases/*
+      - main
+      - releases/*
 
 name: $(Date:yyyyMMdd).$(Rev:r)
 

--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -8,8 +8,17 @@
 #   rust-sdk, rust-sdk-winml
 
 pr:
-- main
-- releases/*
+  autoCancel: true
+  branches:
+    include:
+    - main
+    - releases/*
+
+trigger:
+  branches:
+    include:
+    - main
+    - releases/*
 
 name: $(Date:yyyyMMdd).$(Rev:r)
 

--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -12,12 +12,6 @@ pr:
 - releases/*
 autoCancel: true
 
-trigger:
-  branches:
-    include:
-      - main
-      - releases/*
-
 name: $(Date:yyyyMMdd).$(Rev:r)
 
 parameters:

--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -8,11 +8,9 @@
 #   rust-sdk, rust-sdk-winml
 
 pr:
-  autoCancel: true
-  branches:
-    include:
-      - main
-      - releases/*
+- main
+- releases/*
+autoCancel: true
 
 trigger:
   branches:


### PR DESCRIPTION
Three changes:

1. pr.autoCancel: true — cancels in-progress runs when new commits are pushed to a PR
2. trigger section added — explicitly limits CI push triggers to only main and releases/* branches, so random branch pushes no longer trigger the pipeline
3. PR trigger kept for main and releases/* — PRs targeting these branches still trigger builds

Previously the absence of an explicit trigger: section meant ADO used the default behavior of triggering on all branch pushes.