### PR TITLE
Remove node_modules from flc installation folder

### DIFF
--- a/.pipelines/templates/build-js-steps.yml
+++ b/.pipelines/templates/build-js-steps.yml
@@ -106,7 +106,7 @@ steps:
       Expand-Archive -Path $zip -DestinationPath $extractDir -Force
 
       # Place FLC binary so the install script skips downloading it
-      $destDir = "$(repoRoot)/sdk/js/node_modules/@foundry-local-core/$platformKey"
+      $destDir = "$(repoRoot)/sdk/js/foundry-local-core/$platformKey"
       New-Item -ItemType Directory -Path $destDir -Force | Out-Null
       $nativeDir = "$extractDir/runtimes/$rid/native"
       if (Test-Path $nativeDir) {
@@ -160,7 +160,7 @@ steps:
       Expand-Archive -Path $zip -DestinationPath $extractDir -Force
 
       # Overwrite FLC binary in the npm-installed location
-      $destDir = "$(repoRoot)/sdk/js/node_modules/@foundry-local-core/$platformKey"
+      $destDir = "$(repoRoot)/sdk/js/foundry-local-core/$platformKey"
       New-Item -ItemType Directory -Path $destDir -Force | Out-Null
       $nativeDir = "$extractDir/runtimes/$rid/native"
       if (Test-Path $nativeDir) {

--- a/.pipelines/templates/test-js-steps.yml
+++ b/.pipelines/templates/test-js-steps.yml
@@ -83,7 +83,7 @@ steps:
       Copy-Item $nupkg.FullName $zip -Force
       Expand-Archive -Path $zip -DestinationPath $extractDir -Force
 
-      $destDir = "$(repoRoot)/sdk/js/node_modules/@foundry-local-core/$platformKey"
+      $destDir = "$(repoRoot)/sdk/js/foundry-local-core/$platformKey"
       New-Item -ItemType Directory -Path $destDir -Force | Out-Null
       $nativeDir = "$extractDir/runtimes/$rid/native"
       if (Test-Path $nativeDir) {

--- a/sdk/js/script/install-utils.cjs
+++ b/sdk/js/script/install-utils.cjs
@@ -19,9 +19,8 @@ const PLATFORM_MAP = {
 };
 const platformKey = `${os.platform()}-${os.arch()}`;
 const RID = PLATFORM_MAP[platformKey];
-// Install binaries into node_modules/@foundry-local-core/<platform> so they
-// are shared across foundry-local-sdk and foundry-local-sdk-winml.
-const BIN_DIR = path.join(__dirname, '..', 'node_modules', '@foundry-local-core', platformKey);
+// Install binaries into foundry-local-core/<platform> inside the package root.
+const BIN_DIR = path.join(__dirname, '..', 'foundry-local-core', platformKey);
 const EXT = os.platform() === 'win32' ? '.dll' : os.platform() === 'darwin' ? '.dylib' : '.so';
 
 const REQUIRED_FILES = [
@@ -155,7 +154,7 @@ async function installPackage(artifact, tempDir, binDir, skipIfPresent) {
         console.warn(`    No files found for RID ${RID} in ${pkgName}.`);
     }
 
-    // Overwrite FLC platform package.json so require.resolve can find the package
+    // Write a metadata package.json with version info for diagnostics
     if (pkgName.startsWith('Microsoft.AI.Foundry.Local.Core')) {
         const pkgJsonPath = path.join(binDir, 'package.json');
         const pkgContent = {

--- a/sdk/js/script/install-winml.cjs
+++ b/sdk/js/script/install-winml.cjs
@@ -24,7 +24,7 @@ const deps = require(depsPath);
 // Resolve foundry-local-sdk's binary directory
 const sdkRoot = path.dirname(require.resolve('foundry-local-sdk/package.json'));
 const platformKey = `${process.platform}-${process.arch}`;
-const binDir = path.join(sdkRoot, 'node_modules', '@foundry-local-core', platformKey);
+const binDir = path.join(sdkRoot, 'foundry-local-core', platformKey);
 
 const ARTIFACTS = [
     { name: 'Microsoft.AI.Foundry.Local.Core.WinML', version: deps['foundry-local-core']['nuget'], feed: ORT_NIGHTLY_FEED },

--- a/sdk/js/script/preinstall.cjs
+++ b/sdk/js/script/preinstall.cjs
@@ -25,7 +25,7 @@ const ALL_PLATFORMS = Object.keys(optionalDependencies)
     };
   });
 
-const packagesRoot = path.join(__dirname, '..', 'node_modules', '@foundry-local-core');
+const packagesRoot = path.join(__dirname, '..', 'foundry-local-core');
 
 for (const platform of ALL_PLATFORMS) {
   const dir = path.join(packagesRoot, platform.key);

--- a/sdk/js/src/detail/coreInterop.ts
+++ b/sdk/js/src/detail/coreInterop.ts
@@ -59,10 +59,11 @@ export class CoreInterop {
         const arch = process.arch;
         const platformKey = `${platform}-${arch}`;
 
-        // Resolve the platform package directory at node_modules/@foundry-local-core/<platform>,
+        // Resolve the native binary directory at foundry-local-core/<platform>,
         // the shared location where install scripts place the native binaries.
+
         const sdkRoot = path.resolve(__dirname, '..', '..');
-        const packageDir = path.join(sdkRoot, 'node_modules', '@foundry-local-core', platformKey);
+        const packageDir = path.join(sdkRoot, 'foundry-local-core', platformKey);
         const ext = CoreInterop._getLibraryExtension();
         
         const corePath = path.join(packageDir, `Microsoft.AI.Foundry.Local.Core${ext}`);


### PR DESCRIPTION
Native libraries were stored under `node_modules/@foundry-local-core/<platform>/` inside the SDK package.

npm v7+ treats nested `node_modules` as part of the managed dependency tree, so any subsequent `npm install` (e.g. npm install koffi) would prune the folder as "extraneous", deleting the downloaded binaries.

Moves the binary storage location from node_modules/@foundry-local-core/ to foundry-local-core/