### PR TITLE
Use WinML JS installer in WinML pipeline jobs

### DIFF
--- a/.pipelines/templates/build-js-steps.yml
+++ b/.pipelines/templates/build-js-steps.yml
@@ -130,7 +130,11 @@ steps:
     script: |
       Set-Location "$(repoRoot)/sdk/js"
       node script/preinstall.cjs
-      node script/install-standard.cjs
+      if ('${{ parameters.isWinML }}' -eq 'True') {
+        node script/install-winml.cjs
+      } else {
+        node script/install-standard.cjs
+      }
 
 # Overwrite the FLC native binary with the one we just built
 - task: PowerShell@2

--- a/.pipelines/templates/test-js-steps.yml
+++ b/.pipelines/templates/test-js-steps.yml
@@ -107,7 +107,11 @@ steps:
     script: |
       Set-Location "$(repoRoot)/sdk/js"
       node script/preinstall.cjs
-      node script/install-standard.cjs
+      if ('${{ parameters.isWinML }}' -eq 'True') {
+        node script/install-winml.cjs
+      } else {
+        node script/install-standard.cjs
+      }
 
 # Build the Node-API native addon
 - task: Npm@1


### PR DESCRIPTION
## Summary
- switch the JS build pipeline template to use install-winml.cjs when isWinML is true
- switch the JS test pipeline template to use install-winml.cjs when isWinML is true
- keep the standard installer path unchanged for non-WinML jobs

## Why
origin/main currently routes WinML JS jobs through install-standard.cjs, so those jobs never exercise the WinML dependency set from deps_versions_winml.json.

This PR makes the pipeline use the installer that matches the selected runtime variant.