### PR TITLE
Add ORT-Nightly as fallback for nuget package source at installation time

### DIFF
--- a/sdk/js/script/install-standard.cjs
+++ b/sdk/js/script/install-standard.cjs
@@ -8,7 +8,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { NUGET_FEED, runInstall } = require('./install-utils.cjs');
+const { runInstall } = require('./install-utils.cjs');
 
 // deps_versions.json lives at the package root when published, or at sdk/ in the repo.
 const depsPath = fs.existsSync(path.resolve(__dirname, '..', 'deps_versions.json'))
@@ -17,9 +17,9 @@ const depsPath = fs.existsSync(path.resolve(__dirname, '..', 'deps_versions.json
 const deps = require(depsPath);
 
 const ARTIFACTS = [
-    { name: 'Microsoft.AI.Foundry.Local.Core', version: deps['foundry-local-core'].nuget, feed: NUGET_FEED },
-    { name: os.platform() === 'linux' ? 'Microsoft.ML.OnnxRuntime.Gpu.Linux' : 'Microsoft.ML.OnnxRuntime.Foundry', version: deps.onnxruntime.version, feed: NUGET_FEED },
-    { name: 'Microsoft.ML.OnnxRuntimeGenAI.Foundry', version: deps['onnxruntime-genai'].version, feed: NUGET_FEED },
+    { name: 'Microsoft.AI.Foundry.Local.Core', version: deps['foundry-local-core'].nuget },
+    { name: os.platform() === 'linux' ? 'Microsoft.ML.OnnxRuntime.Gpu.Linux' : 'Microsoft.ML.OnnxRuntime.Foundry', version: deps.onnxruntime.version },
+    { name: 'Microsoft.ML.OnnxRuntimeGenAI.Foundry', version: deps['onnxruntime-genai'].version },
 ];
 
 (async () => {

--- a/sdk/js/script/install-utils.cjs
+++ b/sdk/js/script/install-utils.cjs
@@ -29,7 +29,15 @@ const REQUIRED_FILES = [
   `${os.platform() === 'win32' ? '' : 'lib'}onnxruntime-genai${EXT}`,
 ];
 
-const NUGET_FEED = 'https://api.nuget.org/v3/index.json';
+// Feeds tried in order. Primary: nuget.org (stable releases). Fallback:
+// the public ORT-Nightly Azure DevOps NuGet feed (where dev / pre-release
+// builds of Foundry Local Core, ONNX Runtime and ONNX Runtime GenAI live
+// before they reach nuget.org). If a download from a feed fails for any
+// reason, the next feed is tried.
+const FEEDS = [
+    'https://api.nuget.org/v3/index.json',
+    'https://pkgs.dev.azure.com/aiinfra/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json',
+];
 
 // --- Download helpers ---
 
@@ -127,43 +135,60 @@ async function installPackage(artifact, tempDir, binDir, skipIfPresent) {
         }
     }
 
-    const baseAddress = await getBaseAddress(artifact.feed);
-    const nameLower = pkgName.toLowerCase();
-    const verLower = pkgVer.toLowerCase();
-    const downloadUrl = `${baseAddress}${nameLower}/${verLower}/${nameLower}.${verLower}.nupkg`;
+    // Try each configured feed in order; on failure fall back to the next.
+    let lastError;
+    for (let i = 0; i < FEEDS.length; i++) {
+        const feedUrl = FEEDS[i];
+        const feedHost = new URL(feedUrl).host;
+        try {
+            const baseAddress = await getBaseAddress(feedUrl);
+            const nameLower = pkgName.toLowerCase();
+            const verLower = pkgVer.toLowerCase();
+            const downloadUrl = `${baseAddress}${nameLower}/${verLower}/${nameLower}.${verLower}.nupkg`;
 
-    const nupkgPath = path.join(tempDir, `${pkgName}.${pkgVer}.nupkg`);
-    console.log(`  Downloading ${pkgName} ${pkgVer}...`);
-    await downloadFile(downloadUrl, nupkgPath);
+            const nupkgPath = path.join(tempDir, `${pkgName}.${pkgVer}.nupkg`);
+            console.log(`  Downloading ${pkgName} ${pkgVer} from ${feedHost}...`);
+            await downloadFile(downloadUrl, nupkgPath);
 
-    console.log(`  Extracting...`);
-    const zip = new AdmZip(nupkgPath);
-    const targetPathPrefix = `runtimes/${RID}/native/`.toLowerCase();
-    const entries = zip.getEntries().filter(e => {
-        const p = e.entryName.toLowerCase();
-        return p.includes(targetPathPrefix) && p.endsWith(EXT);
-    });
+            console.log(`  Extracting...`);
+            const zip = new AdmZip(nupkgPath);
+            const targetPathPrefix = `runtimes/${RID}/native/`.toLowerCase();
+            const entries = zip.getEntries().filter(e => {
+                const p = e.entryName.toLowerCase();
+                return p.includes(targetPathPrefix) && p.endsWith(EXT);
+            });
 
-    if (entries.length > 0) {
-        entries.forEach(entry => {
-            zip.extractEntryTo(entry, binDir, false, true);
-            console.log(`    Extracted ${entry.name}`);
-        });
-    } else {
-        console.warn(`    No files found for RID ${RID} in ${pkgName}.`);
+            if (entries.length > 0) {
+                entries.forEach(entry => {
+                    zip.extractEntryTo(entry, binDir, false, true);
+                    console.log(`    Extracted ${entry.name}`);
+                });
+            } else {
+                console.warn(`    No files found for RID ${RID} in ${pkgName}.`);
+            }
+
+            // Write a metadata package.json with version info for diagnostics
+            if (pkgName.startsWith('Microsoft.AI.Foundry.Local.Core')) {
+                const pkgJsonPath = path.join(binDir, 'package.json');
+                const pkgContent = {
+                    name: `@foundry-local-core/${platformKey}`,
+                    version: pkgVer,
+                    description: `Native binaries for Foundry Local SDK (${platformKey})`,
+                    private: true
+                };
+                fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgContent, null, 2));
+            }
+            return;
+        } catch (err) {
+            lastError = err;
+            const isLast = i === FEEDS.length - 1;
+            const reason = err instanceof Error ? err.message : String(err);
+            if (!isLast) {
+                console.warn(`  ${pkgName} ${pkgVer}: download from ${feedHost} failed (${reason}); trying next feed...`);
+            }
+        }
     }
-
-    // Write a metadata package.json with version info for diagnostics
-    if (pkgName.startsWith('Microsoft.AI.Foundry.Local.Core')) {
-        const pkgJsonPath = path.join(binDir, 'package.json');
-        const pkgContent = {
-            name: `@foundry-local-core/${platformKey}`,
-            version: pkgVer,
-            description: `Native binaries for Foundry Local SDK (${platformKey})`,
-            private: true
-        };
-        fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgContent, null, 2));
-    }
+    throw new Error(`Failed to download ${pkgName} ${pkgVer} from any configured feed (${FEEDS.map(f => new URL(f).host).join(', ')}): ${lastError instanceof Error ? lastError.message : lastError}`);
 }
 
 async function runInstall(artifacts, options) {
@@ -192,4 +217,4 @@ async function runInstall(artifacts, options) {
     }
 }
 
-module.exports = { NUGET_FEED, runInstall };
+module.exports = { runInstall };

--- a/sdk/js/script/install-winml.cjs
+++ b/sdk/js/script/install-winml.cjs
@@ -12,7 +12,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { NUGET_FEED, runInstall } = require('./install-utils.cjs');
+const { runInstall } = require('./install-utils.cjs');
 
 // WinML uses its own deps_versions_winml.json with the same key structure
 // as the standard deps_versions.json — no variant-specific keys needed.
@@ -27,9 +27,9 @@ const platformKey = `${process.platform}-${process.arch}`;
 const binDir = path.join(sdkRoot, 'foundry-local-core', platformKey);
 
 const ARTIFACTS = [
-    { name: 'Microsoft.AI.Foundry.Local.Core.WinML', version: deps['foundry-local-core']['nuget'], feed: NUGET_FEED },
-    { name: 'Microsoft.ML.OnnxRuntime.Foundry', version: deps.onnxruntime.version, feed: NUGET_FEED },
-    { name: 'Microsoft.ML.OnnxRuntimeGenAI.Foundry', version: deps['onnxruntime-genai']['version'], feed: NUGET_FEED },
+    { name: 'Microsoft.AI.Foundry.Local.Core.WinML', version: deps['foundry-local-core']['nuget'] },
+    { name: 'Microsoft.ML.OnnxRuntime.Foundry', version: deps.onnxruntime.version },
+    { name: 'Microsoft.ML.OnnxRuntimeGenAI.Foundry', version: deps['onnxruntime-genai']['version'] },
 ];
 
 (async () => {

--- a/sdk/rust/build.rs
+++ b/sdk/rust/build.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 /// Feeds tried in order. Primary: nuget.org (stable releases). Fallback:
 /// the public ORT-Nightly Azure DevOps NuGet feed (where dev / pre-release
@@ -149,8 +151,20 @@ fn get_packages(rid: &str) -> Vec<NuGetPackage> {
     packages
 }
 
-/// Resolve the PackageBaseAddress from a NuGet v3 service index.
+/// Resolve the PackageBaseAddress from a NuGet v3 service index. The result
+/// is cached per feed URL so repeated calls within a single build (e.g. one
+/// per package, plus retries on fallback feeds) only hit the network once.
 fn resolve_base_address(feed_url: &str) -> Result<String, String> {
+    static BASE_ADDRESS_CACHE: Mutex<Option<HashMap<String, String>>> = Mutex::new(None);
+    {
+        let guard = BASE_ADDRESS_CACHE.lock().unwrap();
+        if let Some(map) = guard.as_ref() {
+            if let Some(cached) = map.get(feed_url) {
+                return Ok(cached.clone());
+            }
+        }
+    }
+
     let body: String = ureq::get(feed_url)
         .call()
         .map_err(|e| format!("Failed to fetch NuGet feed index at {feed_url}: {e}"))?
@@ -174,6 +188,10 @@ fn resolve_base_address(feed_url: &str) -> Result<String, String> {
                 } else {
                     format!("{id}/")
                 };
+                let mut guard = BASE_ADDRESS_CACHE.lock().unwrap();
+                guard
+                    .get_or_insert_with(HashMap::new)
+                    .insert(feed_url.to_string(), base.clone());
                 return Ok(base);
             }
         }

--- a/sdk/rust/build.rs
+++ b/sdk/rust/build.rs
@@ -3,7 +3,15 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
-const NUGET_FEED: &str = "https://api.nuget.org/v3/index.json";
+/// Feeds tried in order. Primary: nuget.org (stable releases). Fallback:
+/// the public ORT-Nightly Azure DevOps NuGet feed (where dev / pre-release
+/// builds of Foundry Local Core, ONNX Runtime and ONNX Runtime GenAI live
+/// before they reach nuget.org). If a download from a feed fails for any
+/// reason, the next feed is tried.
+const FEEDS: &[&str] = &[
+    "https://api.nuget.org/v3/index.json",
+    "https://pkgs.dev.azure.com/aiinfra/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json",
+];
 
 /// Versions loaded from deps_versions.json (or deps_versions_winml.json).
 /// Both files share the same key structure — the build script picks the
@@ -67,7 +75,6 @@ fn load_deps_versions() -> DepsVersions {
 struct NuGetPackage {
     name: &'static str,
     version: String,
-    feed_url: &'static str,
 }
 
 fn get_rid() -> Option<&'static str> {
@@ -106,43 +113,36 @@ fn get_packages(rid: &str) -> Vec<NuGetPackage> {
         packages.push(NuGetPackage {
             name: "Microsoft.AI.Foundry.Local.Core.WinML",
             version: deps.core.clone(),
-            feed_url: NUGET_FEED,
         });
         packages.push(NuGetPackage {
             name: "Microsoft.ML.OnnxRuntime.Foundry",
             version: deps.ort.clone(),
-            feed_url: NUGET_FEED,
         });
         packages.push(NuGetPackage {
             name: "Microsoft.ML.OnnxRuntimeGenAI.Foundry",
             version: deps.genai.clone(),
-            feed_url: NUGET_FEED,
         });
     } else {
         packages.push(NuGetPackage {
             name: "Microsoft.AI.Foundry.Local.Core",
             version: deps.core.clone(),
-            feed_url: NUGET_FEED,
         });
 
         if is_linux {
             packages.push(NuGetPackage {
                 name: "Microsoft.ML.OnnxRuntime.Gpu.Linux",
                 version: deps.ort.clone(),
-                feed_url: NUGET_FEED,
             });
         } else {
             packages.push(NuGetPackage {
                 name: "Microsoft.ML.OnnxRuntime.Foundry",
                 version: deps.ort.clone(),
-                feed_url: NUGET_FEED,
             });
         }
 
         packages.push(NuGetPackage {
             name: "Microsoft.ML.OnnxRuntimeGenAI.Foundry",
             version: deps.genai.clone(),
-            feed_url: NUGET_FEED,
         });
     }
 
@@ -184,49 +184,37 @@ fn resolve_base_address(feed_url: &str) -> Result<String, String> {
     ))
 }
 
-/// Download a .nupkg and extract native libraries for the given RID into `out_dir`.
-/// Skips download if native files from this package are already present.
-fn download_and_extract(pkg: &NuGetPackage, rid: &str, out_dir: &Path) -> Result<(), String> {
-    // Skip if this package's main native library is already in out_dir
-    // (e.g. pre-populated from FOUNDRY_NATIVE_OVERRIDE_DIR).
-    let ext = native_lib_extension();
-    let prefix = if env::consts::OS == "windows" {
-        ""
-    } else {
-        "lib"
-    };
-    let expected_file = if pkg.name.contains("Foundry.Local.Core") {
-        format!("Microsoft.AI.Foundry.Local.Core.{ext}")
-    } else if pkg.name.contains("OnnxRuntimeGenAI") {
-        format!("{prefix}onnxruntime-genai.{ext}")
-    } else if pkg.name.contains("OnnxRuntime") {
-        format!("{prefix}onnxruntime.{ext}")
-    } else {
-        String::new()
-    };
-    if !expected_file.is_empty() && out_dir.join(&expected_file).exists() {
-        println!(
-            "cargo:warning={} already present, skipping download.",
-            pkg.name
-        );
-        return Ok(());
-    }
-
-    let base_address = resolve_base_address(pkg.feed_url)?;
+/// Try to download and extract a single package from a specific feed. Returns
+/// `Ok(())` on success, `Err(reason)` on any failure (network, HTTP error,
+/// zip parse error, etc.).
+fn try_download_from_feed(
+    pkg: &NuGetPackage,
+    rid: &str,
+    out_dir: &Path,
+    feed_url: &str,
+) -> Result<(), String> {
+    let base_address = resolve_base_address(feed_url)?;
     let lower_name = pkg.name.to_lowercase();
     let lower_version = pkg.version.to_lowercase();
     let url =
         format!("{base_address}{lower_name}/{lower_version}/{lower_name}.{lower_version}.nupkg");
 
+    let feed_host = feed_url
+        .split("://")
+        .nth(1)
+        .and_then(|s| s.split('/').next())
+        .unwrap_or(feed_url);
+
     println!(
-        "cargo:warning=Downloading {name} {ver} from NuGet.org",
+        "cargo:warning=Downloading {name} {ver} from {host}",
         name = pkg.name,
         ver = pkg.version,
+        host = feed_host,
     );
 
     let mut response = ureq::get(&url)
         .call()
-        .map_err(|e| format!("Failed to download {}: {e}", pkg.name))?;
+        .map_err(|e| format!("Failed to download {} from {feed_host}: {e}", pkg.name))?;
 
     let mut bytes = Vec::new();
     response
@@ -283,6 +271,57 @@ fn download_and_extract(pkg: &NuGetPackage, rid: &str, out_dir: &Path) -> Result
     }
 
     Ok(())
+}
+
+/// Download a .nupkg and extract native libraries for the given RID into `out_dir`.
+/// Skips download if native files from this package are already present.
+/// Tries each configured feed in order; on failure falls back to the next.
+fn download_and_extract(pkg: &NuGetPackage, rid: &str, out_dir: &Path) -> Result<(), String> {
+    // Skip if this package's main native library is already in out_dir
+    // (e.g. pre-populated from FOUNDRY_NATIVE_OVERRIDE_DIR).
+    let ext = native_lib_extension();
+    let prefix = if env::consts::OS == "windows" {
+        ""
+    } else {
+        "lib"
+    };
+    let expected_file = if pkg.name.contains("Foundry.Local.Core") {
+        format!("Microsoft.AI.Foundry.Local.Core.{ext}")
+    } else if pkg.name.contains("OnnxRuntimeGenAI") {
+        format!("{prefix}onnxruntime-genai.{ext}")
+    } else if pkg.name.contains("OnnxRuntime") {
+        format!("{prefix}onnxruntime.{ext}")
+    } else {
+        String::new()
+    };
+    if !expected_file.is_empty() && out_dir.join(&expected_file).exists() {
+        println!(
+            "cargo:warning={} already present, skipping download.",
+            pkg.name
+        );
+        return Ok(());
+    }
+
+    let mut last_error = String::new();
+    for (i, feed_url) in FEEDS.iter().enumerate() {
+        match try_download_from_feed(pkg, rid, out_dir, feed_url) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                let is_last = i == FEEDS.len() - 1;
+                if !is_last {
+                    println!(
+                        "cargo:warning={} {}: {e}; trying next feed...",
+                        pkg.name, pkg.version
+                    );
+                }
+                last_error = e;
+            }
+        }
+    }
+    Err(format!(
+        "Failed to download {} {} from any configured feed: {last_error}",
+        pkg.name, pkg.version
+    ))
 }
 
 /// Check whether all required native libraries are already present in `out_dir`.


### PR DESCRIPTION
The JS and Rust SDK installers download three native NuGet packages (Microsoft.AI.Foundry.Local.Core, 
Microsoft.ML.OnnxRuntime.Foundry, Microsoft.ML.OnnxRuntimeGenAI.Foundry) from a single hard-coded feed (
api.nuget.org). Dev / pre-release versions are published to the public ORT-Nightly Azure DevOps feed before they
reach nuget.org, so any build pinned to a dev version fails outright today.

Change

Both installers now try each feed in order and fall back to the next on any failure:

 1. https://api.nuget.org/v3/index.json (primary)
 2. https://pkgs.dev.azure.com/aiinfra/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json (fallback)
