### PR TITLE
fixes netstandard2.0 bug in embeddings request response types

### DIFF
--- a/sdk/cs/src/OpenAI/EmbeddingRequestResponseTypes.cs
+++ b/sdk/cs/src/OpenAI/EmbeddingRequestResponseTypes.cs
@@ -57,7 +57,7 @@ internal static class EmbeddingRequestResponseExtensions
             throw new FoundryLocalException("Embeddings command returned null or empty response data");
         }
 
-        return response.Data.ToEmbeddingResponse(logger);
+        return response.Data!.ToEmbeddingResponse(logger);
     }
 
     internal static EmbeddingCreateResponse ToEmbeddingResponse(this string responseData, ILogger logger)

--- a/sdk/cs/test/FoundryLocal.Tests/EmbeddingClientTests.cs
+++ b/sdk/cs/test/FoundryLocal.Tests/EmbeddingClientTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.AI.Foundry.Local.Tests;
 
 using System.Threading.Tasks;
 
+[SkipUnlessIntegration]
 internal sealed class EmbeddingClientTests
 {
     private static IModel? model;


### PR DESCRIPTION
```
E:\_work\1\s\sdk\cs\src\OpenAI\EmbeddingRequestResponseTypes.cs(60,16): error CS8604: 
  Possible null reference argument for parameter 'responseData' in 'EmbeddingCreateResponse EmbeddingRequestResponseExtensions.ToEmbeddingResponse(string responseData, ILogger logger)'. 
  [E:\_work\1\s\sdk\cs\src\Microsoft.AI.Foundry.Local.csproj::TargetFramework=netstandard2.0]
```

The null check string.IsNullOrWhiteSpace doesn't narrow the nullable type under netstandard2.0's annotations. Needs to be response.Data! to avoid error but we know it's not null or whitespace due to the check above.