### PR TITLE
Add a non-blocking initialization path to the JS SDK

### DIFF
--- a/sdk/js/native/foundry_local_napi.c
+++ b/sdk/js/native/foundry_local_napi.c
@@ -6,10 +6,11 @@
  *
  * Replaces the koffi FFI bridge with a lightweight native addon that
  * dynamically loads the FoundryLocalCore shared library at runtime and
- * exposes three JavaScript-callable functions:
+ * exposes the following JavaScript-callable functions:
  *
  *   loadLibrary(corePath, depPaths?)  – load native libs, resolve symbols
  *   executeCommand(cmd, dataJson)     – synchronous command execution
+ *   executeCommandAsync(cmd, dataJson) – async command execution (Promise)
  *   executeCommandWithBinary(cmd, dataJson, binaryBuf) – with binary payload
  *   executeCommandStreaming(cmd, dataJson, callback) – async + streaming
  */
@@ -474,6 +475,171 @@ static napi_value napi_execute_command_with_binary(napi_env env,
     return result;
 }
 
+/* ── Async (non-streaming) work data ──────────────────────────────────── */
+
+typedef struct {
+    char* command;
+    size_t command_length;
+    char* data;
+    size_t data_length;
+    ResponseBuffer response;
+    napi_deferred deferred;
+    napi_async_work work;
+} AsyncWorkData;
+
+/* Runs on the libuv worker thread */
+static void async_execute(napi_env env, void* data) {
+    AsyncWorkData* work_data = (AsyncWorkData*)data;
+
+    RequestBuffer req = {
+        .Command = work_data->command,
+        .CommandLength = (int32_t)work_data->command_length,
+        .Data = work_data->data,
+        .DataLength = (int32_t)work_data->data_length
+    };
+
+    work_data->response.Data = NULL;
+    work_data->response.DataLength = 0;
+    work_data->response.Error = NULL;
+    work_data->response.ErrorLength = 0;
+
+    g_execute_command(&req, &work_data->response);
+}
+
+/* Runs on the JS main thread after async_execute completes */
+static void async_complete(napi_env env, napi_status status, void* data) {
+    AsyncWorkData* work_data = (AsyncWorkData*)data;
+
+    if (status == napi_cancelled) {
+        reject_with_error(env, work_data->deferred, "Async work cancelled");
+    } else if (work_data->response.Error && work_data->response.ErrorLength > 0) {
+        int32_t elen = work_data->response.ErrorLength;
+        size_t msg_size = (size_t)elen + 128;
+        char* msg = (char*)malloc(msg_size);
+        if (msg) {
+            snprintf(msg, msg_size, "Command '%s' failed: %.*s",
+                     work_data->command, elen,
+                     (const char*)work_data->response.Error);
+            reject_with_error(env, work_data->deferred, msg);
+            free(msg);
+        } else {
+            reject_with_error(env, work_data->deferred, "Command failed (OOM)");
+        }
+    } else {
+        napi_value result;
+        napi_status st;
+        if (work_data->response.Data && work_data->response.DataLength > 0) {
+            st = napi_create_string_utf8(env,
+                (const char*)work_data->response.Data,
+                work_data->response.DataLength, &result);
+        } else {
+            st = napi_create_string_utf8(env, "", 0, &result);
+        }
+        if (st != napi_ok) {
+            reject_with_error(env, work_data->deferred,
+                "Failed to create response string");
+        } else {
+            napi_resolve_deferred(env, work_data->deferred, result);
+        }
+    }
+
+    free_native_buffer(work_data->response.Data);
+    free_native_buffer(work_data->response.Error);
+    napi_delete_async_work(env, work_data->work);
+    free(work_data->command);
+    free(work_data->data);
+    free(work_data);
+}
+
+/* executeCommandAsync(command, dataJson) → Promise<string> */
+static napi_value napi_execute_command_async(napi_env env,
+                                              napi_callback_info info) {
+    if (!g_execute_command) {
+        napi_throw_error(env, NULL, "Native library not loaded. Call loadLibrary() first.");
+        return NULL;
+    }
+
+    size_t argc = 2;
+    napi_value argv[2];
+    NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+
+    if (argc < 2) {
+        napi_throw_error(env, NULL,
+            "executeCommandAsync requires 2 arguments (command, dataJson)");
+        return NULL;
+    }
+
+    /* Extract command string */
+    size_t cmd_len = 0;
+    NAPI_CALL(env, napi_get_value_string_utf8(env, argv[0], NULL, 0, &cmd_len));
+    if (!check_string_length(env, cmd_len, "command")) return NULL;
+    char* cmd = (char*)malloc(cmd_len + 1);
+    if (!cmd) { napi_throw_error(env, NULL, "Out of memory"); return NULL; }
+    NAPI_CALL(env, napi_get_value_string_utf8(env, argv[0], cmd, cmd_len + 1, &cmd_len));
+
+    /* Extract data JSON string */
+    size_t data_len = 0;
+    NAPI_CALL(env, napi_get_value_string_utf8(env, argv[1], NULL, 0, &data_len));
+    if (!check_string_length(env, data_len, "dataJson")) { free(cmd); return NULL; }
+    char* data_str = (char*)malloc(data_len + 1);
+    if (!data_str) {
+        free(cmd);
+        napi_throw_error(env, NULL, "Out of memory");
+        return NULL;
+    }
+    NAPI_CALL(env, napi_get_value_string_utf8(env, argv[1], data_str, data_len + 1, &data_len));
+
+    /* Allocate work data */
+    AsyncWorkData* work_data = (AsyncWorkData*)calloc(1, sizeof(AsyncWorkData));
+    if (!work_data) {
+        free(cmd);
+        free(data_str);
+        napi_throw_error(env, NULL, "Out of memory");
+        return NULL;
+    }
+    work_data->command = cmd;
+    work_data->command_length = cmd_len;
+    work_data->data = data_str;
+    work_data->data_length = data_len;
+
+    /* Create promise */
+    napi_value promise;
+    napi_status st = napi_create_promise(env, &work_data->deferred, &promise);
+    if (st != napi_ok) {
+        free(cmd); free(data_str); free(work_data);
+        napi_throw_error(env, NULL, "Failed to create promise");
+        return NULL;
+    }
+
+    /* Create and queue async work */
+    napi_value work_name;
+    st = napi_create_string_utf8(env, "foundry_async_cmd", NAPI_AUTO_LENGTH, &work_name);
+    if (st != napi_ok) {
+        free(cmd); free(data_str); free(work_data);
+        napi_throw_error(env, NULL, "Failed to create async work name");
+        return NULL;
+    }
+
+    st = napi_create_async_work(env, NULL, work_name,
+                                 async_execute, async_complete,
+                                 work_data, &work_data->work);
+    if (st != napi_ok) {
+        free(cmd); free(data_str); free(work_data);
+        napi_throw_error(env, NULL, "Failed to create async work");
+        return NULL;
+    }
+
+    st = napi_queue_async_work(env, work_data->work);
+    if (st != napi_ok) {
+        napi_delete_async_work(env, work_data->work);
+        free(cmd); free(data_str); free(work_data);
+        napi_throw_error(env, NULL, "Failed to queue async work");
+        return NULL;
+    }
+
+    return promise;
+}
+
 /* ── Streaming async work data ────────────────────────────────────────── */
 
 /* Chunk data passed from the native callback to the JS thread.
@@ -807,6 +973,8 @@ static napi_value init(napi_env env, napi_value exports) {
           napi_default, NULL },
         { "executeCommand", NULL, napi_execute_command, NULL, NULL, NULL,
           napi_default, NULL },
+        { "executeCommandAsync", NULL, napi_execute_command_async, NULL,
+          NULL, NULL, napi_default, NULL },
         { "executeCommandWithBinary", NULL, napi_execute_command_with_binary,
           NULL, NULL, NULL, napi_default, NULL },
         { "executeCommandStreaming", NULL, napi_execute_command_streaming,

--- a/sdk/js/native/foundry_local_napi.c
+++ b/sdk/js/native/foundry_local_napi.c
@@ -512,6 +512,11 @@ static void async_complete(napi_env env, napi_status status, void* data) {
 
     if (status == napi_cancelled) {
         reject_with_error(env, work_data->deferred, "Async work cancelled");
+    } else if (status != napi_ok) {
+        char msg[128];
+        snprintf(msg, sizeof(msg),
+                 "Async work failed with N-API status %d", (int)status);
+        reject_with_error(env, work_data->deferred, msg);
     } else if (work_data->response.Error && work_data->response.ErrorLength > 0) {
         int32_t elen = work_data->response.ErrorLength;
         size_t msg_size = (size_t)elen + 128;

--- a/sdk/js/src/catalog.ts
+++ b/sdk/js/src/catalog.ts
@@ -18,10 +18,10 @@ export class Catalog {
     private modelIdToModelVariant: Map<string, ModelVariant> = new Map();
     private lastFetch: number = 0;
 
-    constructor(coreInterop: CoreInterop, modelLoadManager: ModelLoadManager) {
+    constructor(coreInterop: CoreInterop, modelLoadManager: ModelLoadManager, catalogName: string) {
         this.coreInterop = coreInterop;
         this.modelLoadManager = modelLoadManager;
-        this._name = this.coreInterop.executeCommand("get_catalog_name");
+        this._name = catalogName;
     }
 
     /**
@@ -43,8 +43,7 @@ export class Catalog {
             return;
         }
 
-        // Potential network call to fetch model list
-        const modelListJson = this.coreInterop.executeCommand("get_model_list");
+        const modelListJson = await this.coreInterop.executeCommandAsync("get_model_list");
         let modelsInfo: ModelInfo[] = [];
         try {
             modelsInfo = JSON.parse(modelListJson);
@@ -133,7 +132,7 @@ export class Catalog {
      */
     public async getCachedModels(): Promise<IModel[]> {
         await this.updateModels();
-        const cachedModelListJson = this.coreInterop.executeCommand("get_cached_models");
+        const cachedModelListJson = await this.coreInterop.executeCommandAsync("get_cached_models");
         let cachedModelIds: string[] = [];
         try {
             cachedModelIds = JSON.parse(cachedModelListJson);

--- a/sdk/js/src/catalog.ts
+++ b/sdk/js/src/catalog.ts
@@ -17,6 +17,7 @@ export class Catalog {
     private modelAliasToModel: Map<string, Model> = new Map();
     private modelIdToModelVariant: Map<string, ModelVariant> = new Map();
     private lastFetch: number = 0;
+    private updatePromise?: Promise<void>;
 
     constructor(coreInterop: CoreInterop, modelLoadManager: ModelLoadManager, catalogName?: string) {
         this.coreInterop = coreInterop;
@@ -42,7 +43,15 @@ export class Catalog {
         if ((Date.now() - this.lastFetch) < 6 * 60 * 60 * 1000) { // 6 hours
             return;
         }
+        if (this.updatePromise) {
+            return this.updatePromise;
+        }
+        this.updatePromise = this.fetchAndPopulateModels()
+            .finally(() => { this.updatePromise = undefined; });
+        return this.updatePromise;
+    }
 
+    private async fetchAndPopulateModels(): Promise<void> {
         const modelListJson = await this.coreInterop.executeCommandAsync("get_model_list");
         let modelsInfo: ModelInfo[] = [];
         try {
@@ -58,7 +67,7 @@ export class Catalog {
         for (const info of modelsInfo) {
             const variant = new ModelVariant(info, this.coreInterop, this.modelLoadManager);
             let model = this.modelAliasToModel.get(info.alias);
-            
+
             if (!model) {
                 model = new Model(variant);
                 this.modelAliasToModel.set(info.alias, model);

--- a/sdk/js/src/catalog.ts
+++ b/sdk/js/src/catalog.ts
@@ -18,10 +18,10 @@ export class Catalog {
     private modelIdToModelVariant: Map<string, ModelVariant> = new Map();
     private lastFetch: number = 0;
 
-    constructor(coreInterop: CoreInterop, modelLoadManager: ModelLoadManager, catalogName: string) {
+    constructor(coreInterop: CoreInterop, modelLoadManager: ModelLoadManager, catalogName?: string) {
         this.coreInterop = coreInterop;
         this.modelLoadManager = modelLoadManager;
-        this._name = catalogName;
+        this._name = catalogName ?? this.coreInterop.executeCommand("get_catalog_name");
     }
 
     /**

--- a/sdk/js/src/detail/coreInterop.ts
+++ b/sdk/js/src/detail/coreInterop.ts
@@ -116,6 +116,14 @@ export class CoreInterop {
     }
 
     /**
+     * Asynchronously execute a native command without blocking the event loop.
+     * Runs the native call on a libuv worker thread.
+     */
+    public executeCommandAsync(command: string, params?: any): Promise<string> {
+        return this.executeCommandStreaming(command, params, () => {});
+    }
+
+    /**
      * Execute a native command with binary data (e.g., audio PCM bytes).
      * Uses the execute_command_with_binary native entry point which accepts
      * both JSON params and raw binary data via StreamingRequestBuffer.

--- a/sdk/js/src/detail/coreInterop.ts
+++ b/sdk/js/src/detail/coreInterop.ts
@@ -13,6 +13,7 @@ const require = createRequire(import.meta.url);
 interface NativeAddon {
     loadLibrary(corePath: string, depPaths?: string[]): void;
     executeCommand(command: string, dataJson: string): string;
+    executeCommandAsync(command: string, dataJson: string): Promise<string>;
     executeCommandWithBinary(command: string, dataJson: string, binaryBuffer: Buffer): string;
     executeCommandStreaming(command: string, dataJson: string, callback: (chunk: string) => void): Promise<string>;
 }
@@ -120,7 +121,8 @@ export class CoreInterop {
      * Runs the native call on a libuv worker thread.
      */
     public executeCommandAsync(command: string, params?: any): Promise<string> {
-        return this.executeCommandStreaming(command, params, () => {});
+        const dataStr = params ? JSON.stringify(params) : '';
+        return this.addon.executeCommandAsync(command, dataStr);
     }
 
     /**

--- a/sdk/js/src/detail/modelLoadManager.ts
+++ b/sdk/js/src/detail/modelLoadManager.ts
@@ -37,7 +37,7 @@ export class ModelLoadManager {
             }
             return;
         }
-        this.coreInterop.executeCommand("load_model", { Params: { Model: modelId } });
+        await this.coreInterop.executeCommandAsync("load_model", { Params: { Model: modelId } });
     }
 
     /**
@@ -54,7 +54,7 @@ export class ModelLoadManager {
             }
             return;
         }
-        this.coreInterop.executeCommand("unload_model", { Params: { Model: modelId } });
+        await this.coreInterop.executeCommandAsync("unload_model", { Params: { Model: modelId } });
     }
 
     /**
@@ -72,7 +72,7 @@ export class ModelLoadManager {
             const list = await response.json();
             return list || [];
         }
-        const response = this.coreInterop.executeCommand("list_loaded_models");
+        const response = await this.coreInterop.executeCommandAsync("list_loaded_models");
         try {
             return JSON.parse(response);
         } catch (error) {

--- a/sdk/js/src/detail/modelVariant.ts
+++ b/sdk/js/src/detail/modelVariant.ts
@@ -112,7 +112,7 @@ export class ModelVariant implements IModel {
     public async download(progressCallback?: (progress: number) => void): Promise<void> {
         const request = { Params: { Model: this._modelInfo.id } };
         if (!progressCallback) {
-            this.coreInterop.executeCommand("download_model", request);
+            await this.coreInterop.executeCommandAsync("download_model", request);
         } else {
             await this.coreInterop.executeCommandStreaming("download_model", request, (chunk: string) => {
                 const progress = parseFloat(chunk);

--- a/sdk/js/src/foundryLocalManager.ts
+++ b/sdk/js/src/foundryLocalManager.ts
@@ -14,19 +14,31 @@ export class FoundryLocalManager {
     private config: Configuration;
     private coreInterop: CoreInterop;
     private _modelLoadManager: ModelLoadManager;
-    private _catalog: Catalog;
+    private _catalog!: Catalog;
     private _urls: string[] = [];
 
     private constructor(config: Configuration) {
         this.config = config;
         this.coreInterop = new CoreInterop(this.config);
-        this.coreInterop.executeCommand("initialize", { Params: this.config.params });
         this._modelLoadManager = new ModelLoadManager(this.coreInterop);
-        this._catalog = new Catalog(this.coreInterop, this._modelLoadManager);
+    }
+
+    private initializeSync(): void {
+        this.coreInterop.executeCommand("initialize", { Params: this.config.params });
+        const catalogName = this.coreInterop.executeCommand("get_catalog_name");
+        this._catalog = new Catalog(this.coreInterop, this._modelLoadManager, catalogName);
+    }
+
+    private async initializeAsync(): Promise<void> {
+        await this.coreInterop.executeCommandAsync("initialize", { Params: this.config.params });
+        const catalogName = await this.coreInterop.executeCommandAsync("get_catalog_name");
+        this._catalog = new Catalog(this.coreInterop, this._modelLoadManager, catalogName);
     }
 
     /**
      * Creates the FoundryLocalManager singleton with the provided configuration.
+     * Note: This method blocks the event loop during initialization.
+     * For non-blocking initialization, use {@link createAsync} instead.
      * @param config - The configuration settings for the SDK (plain object).
      * @returns The initialized FoundryLocalManager instance.
      * @example
@@ -40,7 +52,32 @@ export class FoundryLocalManager {
     public static create(config: FoundryLocalConfig): FoundryLocalManager {
         if (!FoundryLocalManager.instance) {
             const internalConfig = new Configuration(config);
-            FoundryLocalManager.instance = new FoundryLocalManager(internalConfig);
+            const manager = new FoundryLocalManager(internalConfig);
+            manager.initializeSync();
+            FoundryLocalManager.instance = manager;
+        }
+        return FoundryLocalManager.instance;
+    }
+
+    /**
+     * Creates the FoundryLocalManager singleton with the provided configuration
+     * without blocking the event loop.
+     * @param config - The configuration settings for the SDK (plain object).
+     * @returns A promise that resolves to the initialized FoundryLocalManager instance.
+     * @example
+     * ```typescript
+     * const manager = await FoundryLocalManager.createAsync({
+     *   appName: 'MyApp',
+     *   logLevel: 'info'
+     * });
+     * ```
+     */
+    public static async createAsync(config: FoundryLocalConfig): Promise<FoundryLocalManager> {
+        if (!FoundryLocalManager.instance) {
+            const internalConfig = new Configuration(config);
+            const manager = new FoundryLocalManager(internalConfig);
+            await manager.initializeAsync();
+            FoundryLocalManager.instance = manager;
         }
         return FoundryLocalManager.instance;
     }

--- a/sdk/js/src/foundryLocalManager.ts
+++ b/sdk/js/src/foundryLocalManager.ts
@@ -52,6 +52,12 @@ export class FoundryLocalManager {
      */
     public static create(config: FoundryLocalConfig): FoundryLocalManager {
         if (!FoundryLocalManager.instance) {
+            if (FoundryLocalManager.pendingCreate) {
+                throw new Error(
+                    "FoundryLocalManager.createAsync() is in progress. " +
+                    "Await that call instead of invoking create()."
+                );
+            }
             const internalConfig = new Configuration(config);
             const manager = new FoundryLocalManager(internalConfig);
             manager.initializeSync();

--- a/sdk/js/src/foundryLocalManager.ts
+++ b/sdk/js/src/foundryLocalManager.ts
@@ -11,6 +11,7 @@ import { EpInfo, EpDownloadResult } from './types.js';
  */
 export class FoundryLocalManager {
     private static instance: FoundryLocalManager;
+    private static pendingCreate?: Promise<FoundryLocalManager>;
     private config: Configuration;
     private coreInterop: CoreInterop;
     private _modelLoadManager: ModelLoadManager;
@@ -72,14 +73,23 @@ export class FoundryLocalManager {
      * });
      * ```
      */
-    public static async createAsync(config: FoundryLocalConfig): Promise<FoundryLocalManager> {
-        if (!FoundryLocalManager.instance) {
+    public static createAsync(config: FoundryLocalConfig): Promise<FoundryLocalManager> {
+        if (FoundryLocalManager.instance) {
+            return Promise.resolve(FoundryLocalManager.instance);
+        }
+        if (!FoundryLocalManager.pendingCreate) {
             const internalConfig = new Configuration(config);
             const manager = new FoundryLocalManager(internalConfig);
-            await manager.initializeAsync();
-            FoundryLocalManager.instance = manager;
+            FoundryLocalManager.pendingCreate = manager.initializeAsync()
+                .then(() => {
+                    FoundryLocalManager.instance = manager;
+                    return manager;
+                })
+                .finally(() => {
+                    FoundryLocalManager.pendingCreate = undefined;
+                });
         }
-        return FoundryLocalManager.instance;
+        return FoundryLocalManager.pendingCreate;
     }
 
     /**

--- a/sdk/js/src/foundryLocalManager.ts
+++ b/sdk/js/src/foundryLocalManager.ts
@@ -67,8 +67,10 @@ export class FoundryLocalManager {
     }
 
     /**
-     * Creates the FoundryLocalManager singleton with the provided configuration
-     * without blocking the event loop.
+     * Creates the FoundryLocalManager singleton with the provided configuration.
+     * Native command execution is performed asynchronously to avoid blocking the
+     * event loop during initialization. Note that some synchronous setup (e.g.,
+     * loading the native addon) still occurs before the first await.
      * @param config - The configuration settings for the SDK (plain object).
      * @returns A promise that resolves to the initialized FoundryLocalManager instance.
      * @example

--- a/sdk/js/test/catalog.test.ts
+++ b/sdk/js/test/catalog.test.ts
@@ -155,9 +155,6 @@ describe('Catalog Tests', () => {
 
         const mockCoreInterop = {
             executeCommand(command: string): string {
-                if (command === 'get_catalog_name') {
-                    return 'TestCatalog';
-                }
                 if (command === 'get_model_list') {
                     return JSON.stringify(testModelInfos);
                 }
@@ -165,6 +162,9 @@ describe('Catalog Tests', () => {
                     return '[]';
                 }
                 throw new Error(`Unexpected command: ${command}`);
+            },
+            executeCommandAsync(command: string): Promise<string> {
+                return Promise.resolve(this.executeCommand(command));
             }
         } as any;
 
@@ -172,7 +172,7 @@ describe('Catalog Tests', () => {
             listLoaded: async () => []
         } as any;
 
-        const catalog = new Catalog(mockCoreInterop, mockLoadManager);
+        const catalog = new Catalog(mockCoreInterop, mockLoadManager, 'TestCatalog');
 
         const model = await catalog.getModel('test-alias');
         expect(model).to.not.be.undefined;


### PR DESCRIPTION
The JS SDK's FoundryLocalManager.create() and ModelVariant.load() perform synchronous native calls that block the Node.js event loop.
This PR adds a non-blocking path without breaking the existing GA APIs.

Changes

Native addon (sdk/js/native/foundry_local_napi.c)

Added a new executeCommandAsync entry point that runs execute_command on a libuv worker thread and returns a Promise. This is distinct from the existing executeCommandStreaming, which uses execute_command_with_callback and isn't compatible with all commands.

CoreInterop

Exposed executeCommandAsync() that delegates to the new native entry point.

FoundryLocalManager

 - Kept create() as-is (blocking) for backward compatibility.
 - Added createAsync() that initializes via async native calls.
 - Added a pendingCreate guard so concurrent callers share the same in-flight initialization, matching the locking strategy in the C#, Rust, and Python SDKs.
 - create() throws a clear error if called while createAsync() is in flight to prevent double native initialization.

ModelLoadManager

load(), unload(), and listLoaded() now use executeCommandAsync for the core interop path. These methods already returned Promises, so no API change.

ModelVariant.download()

The no-progress path now uses executeCommandAsync. Already async, no API change.

Catalog

 - getModels() and getCachedModels() now use executeCommandAsync for the native fetches. Already async, no API change.
 - updateModels() shares an in-flight refresh promise so concurrent callers don't redundantly refetch and rebuild the model maps.
 - The constructor accepts an optional catalogName so the manager can pass it in (avoiding a sync native call during async initialization), with a fallback to the existing sync lookup. Backward compatible.

Backward compatibility

No API breakages. All existing callers of create() and load() continue to work unchanged.