### PR TITLE
[C++] Fix `Nemotron-ASR` of LiveAudioTranscriptionResponse

### DIFF
--- a/sdk/cpp/include/openai/openai_live_audio_types.h
+++ b/sdk/cpp/include/openai/openai_live_audio_types.h
@@ -19,6 +19,7 @@ namespace foundry_local {
         bool is_final = false;
         std::optional<double> start_time;
         std::optional<double> end_time;
+        std::optional<std::string> id;
         std::vector<ContentPart> content;
 
         static LiveAudioTranscriptionResponse FromJson(const std::string& json);

--- a/sdk/cpp/src/openai_live_audio_types.cpp
+++ b/sdk/cpp/src/openai_live_audio_types.cpp
@@ -39,6 +39,10 @@ namespace foundry_local {
             response.end_time = j["endTime"].get<double>();
         }
 
+        if (j.contains("id") && j["id"].is_string()) {
+            response.id = j["id"].get<std::string>();
+        }
+
         if (j.contains("content") && j["content"].is_array()) {
             for (const auto& item : j["content"]) {
                 ContentPart part;

--- a/sdk/cpp/test/live_audio_test.cpp
+++ b/sdk/cpp/test/live_audio_test.cpp
@@ -38,6 +38,27 @@ TEST(LiveAudioTypesTest, FromJson_BasicResponse) {
     EXPECT_DOUBLE_EQ(0.5, resp.start_time.value());
     ASSERT_TRUE(resp.end_time.has_value());
     EXPECT_DOUBLE_EQ(1.5, resp.end_time.value());
+    EXPECT_FALSE(resp.id.has_value());
+}
+
+TEST(LiveAudioTypesTest, FromJson_WithId) {
+    nlohmann::json j = {
+        {"text", "hello"},
+        {"is_final", true},
+        {"id", "result-abc-123"}};
+
+    auto resp = LiveAudioTranscriptionResponse::FromJson(j.dump());
+    ASSERT_TRUE(resp.id.has_value());
+    EXPECT_EQ("result-abc-123", resp.id.value());
+}
+
+TEST(LiveAudioTypesTest, FromJson_WithoutId) {
+    nlohmann::json j = {
+        {"text", "hello"},
+        {"is_final", true}};
+
+    auto resp = LiveAudioTranscriptionResponse::FromJson(j.dump());
+    EXPECT_FALSE(resp.id.has_value());
 }
 
 TEST(LiveAudioTypesTest, FromJson_CamelCaseFields) {


### PR DESCRIPTION
## Summary

Adds the optional `id` field to the C++ `LiveAudioTranscriptionResponse` for parity with the JS and Python SDKs, addressing feedback from the multi-language SDK parity review.

## Why

The JS (`liveAudioTranscriptionTypes.ts`) and Python (`live_audio_transcription_types.py`) SDKs both expose an optional `id` field on each transcription result, parsed from the native Core's JSON response when present. The C++ SDK was missing this field, creating a small parity gap.

## Changes

- `sdk/cpp/include/openai/openai_live_audio_types.h`: Add `std::optional<std::string> id;` to `LiveAudioTranscriptionResponse`.
- `sdk/cpp/src/openai_live_audio_types.cpp`: Parse `id` optionally in `FromJson` (no breakage when field is absent).
- `sdk/cpp/test/live_audio_test.cpp`: Add 2 new unit tests:
  - `FromJson_WithId`  verifies `id` is parsed when present.
  - `FromJson_WithoutId`  verifies `id` is `nullopt` when absent.
  - Updated `FromJson_BasicResponse` to assert `id` is `nullopt` by default.

## Testing

- Build: 0 errors, 0 warnings.
- All 154 unit tests passing (152 existing + 2 new).
- Backwards-compatible: existing JSON without `id` continues to parse correctly.

## Parity Status

| Field | C++ (before) | C++ (after) | JS | Python | C# | Rust |
|-------|--------------|-------------|----|--------|----|----|
| `id` |  |  |  |  |  (inherited) |  |