### PR TITLE
Fix: Download with progress callback fails with 'Operation was cancel…

### DIFF
--- a/sdk/cpp/src/core_helpers.h
+++ b/sdk/cpp/src/core_helpers.h
@@ -60,13 +60,13 @@ namespace foundry_local::detail {
             std::exception_ptr exception;
         } state{&onChunk, nullptr};
 
-        auto nativeCallback = [](void* data, int32_t len, void* user) {
+        auto nativeCallback = [](void* data, int32_t len, void* user) -> int {
             if (!data || len <= 0)
-                return;
+                return 0;
 
             auto* st = static_cast<State*>(user);
             if (st->exception)
-                return;
+                return 0;
 
             try {
                 std::string chunk(static_cast<const char*>(data), static_cast<size_t>(len));
@@ -75,6 +75,7 @@ namespace foundry_local::detail {
             catch (...) {
                 st->exception = std::current_exception();
             }
+            return 0;
         };
 
         auto response = core->call(command, logger, &payload, +nativeCallback, &state);

--- a/sdk/cpp/src/flcore_native.h
+++ b/sdk/cpp/src/flcore_native.h
@@ -23,8 +23,8 @@ extern "C"
         int32_t ErrorLength;
     };
 
-    // Callback signature: void(*)(void* data, int length, void* userData)
-    using UserCallbackFn = void(__cdecl*)(void*, int32_t, void*);
+    // Callback signature: int(*)(void* data, int length, void* userData)  — returns 0 to continue, 1 to cancel
+    using UserCallbackFn = int(__cdecl*)(void*, int32_t, void*);
 
     struct StreamingRequestBuffer {
         const void* Command;

--- a/sdk/cpp/src/foundry_local_internal_core.h
+++ b/sdk/cpp/src/foundry_local_internal_core.h
@@ -12,7 +12,7 @@ namespace foundry_local {
 
     /// Native callback signature used by the core DLL interop.
     /// Parameters: (data, dataLength, userData).
-    using NativeCallbackFn = void (*)(void*, int32_t, void*);
+    using NativeCallbackFn = int (*)(void*, int32_t, void*);
 
     /// Value returned by IFoundryLocalCore::call().
     /// On success, `data` contains the response payload and `error` is empty.

--- a/sdk/cpp/src/model.cpp
+++ b/sdk/cpp/src/model.cpp
@@ -79,9 +79,9 @@ namespace foundry_local {
                 ILogger* logger;
             } state{&onProgress, logger_};
 
-            auto nativeCallback = [](void* data, int32_t len, void* user) {
+            auto nativeCallback = [](void* data, int32_t len, void* user) -> int {
                 if (!data || len <= 0)
-                    return;
+                    return 0;
                 auto* st = static_cast<ProgressState*>(user);
                 std::string perc(static_cast<char*>(data), static_cast<size_t>(len));
                 try {
@@ -91,6 +91,7 @@ namespace foundry_local {
                 catch (...) {
                     st->logger->Log(LogLevel::Warning, "Failed to parse download progress: " + perc);
                 }
+                return 0;
             };
 
             auto response = CallWithJsonAndCallback(core_, "download_model", MakeModelParams(info_.name), *logger_,

--- a/sdk/cpp/test/model_variant_test.cpp
+++ b/sdk/cpp/test/model_variant_test.cpp
@@ -128,6 +128,24 @@ TEST_F(ModelVariantTest, Download_WithCallback) {
     EXPECT_NEAR(50.0f, lastProgress, 0.01f);
 }
 
+// Regression test: the native core DLL expects the callback to return int (0 = continue, 1 = cancel).
+// Previously NativeCallbackFn returned void, causing the core to read garbage as a cancel signal.
+TEST_F(ModelVariantTest, Download_WithCallback_ReturnsZeroToContinue) {
+    core_.OnCall("get_cached_models", R"([])");
+    core_.OnCall("download_model",
+                 [](std::string_view, const std::string*, NativeCallbackFn callback, void* userData) -> std::string {
+                     if (callback && userData) {
+                         std::string progress = "50";
+                         int result = callback(progress.data(), static_cast<int32_t>(progress.size()), userData);
+                         EXPECT_EQ(0, result) << "Callback should return 0 (continue), not " << result;
+                     }
+                     return "";
+                 });
+
+    auto variant = MakeVariant("test-model");
+    variant.Download([&](float) {});
+}
+
 TEST_F(ModelVariantTest, RemoveFromCache_CallsCore) {
     core_.OnCall("remove_cached_model", "");
     auto variant = MakeVariant("test-model");


### PR DESCRIPTION
## Fix: Download with progress callback fails with "Operation was cancelled by user"

### Problem

Calling `model->Download()` with a progress callback causes the native core to abort with:

```
[Foundry][Error] Error downloading model [qwen3.5-2b-generic-gpu]:
Operation was cancelled by user
```

The same call without a callback works correctly.

### Root Cause

The C++ SDK declared `NativeCallbackFn` as returning `void`, while the native core DLL (C#) expects the callback to return `int` (`0` = continue, `1` = cancel). Since the `void` callback never sets the return register, the C# marshalling reads an indeterminate value (garbage), interprets it as non-zero (cancel), and aborts the download.

All other SDKs correctly define the callback as returning `int`:

| SDK | Callback return type | Correct? |
|-----|---------------------|----------|
| **C++ (before fix)** | **`void`** | **No** |
| C# | `int` | Yes |
| JavaScript | `int32_t` | Yes |
| Python | `c_int` | Yes |
| Rust | `i32` | Yes |

### Fix

Changed `NativeCallbackFn` and `UserCallbackFn` from `void(*)()` to `int(*)()` and updated all callback lambdas to return `0` (continue).

### Files Changed

- **`sdk/cpp/src/foundry_local_internal_core.h`** — `NativeCallbackFn` return type `void` → `int`
- **`sdk/cpp/src/flcore_native.h`** — `UserCallbackFn` return type `void` → `int`
- **`sdk/cpp/src/model.cpp`** — download progress callback lambda returns `0`
- **`sdk/cpp/src/core_helpers.h`** — streaming callback lambda returns `0`
- **`sdk/cpp/test/model_variant_test.cpp`** — added regression test `Download_WithCallback_ReturnsZeroToContinue`

### Testing

All 163 unit tests pass, including a new regression test that invokes the callback and asserts the return value is `0`.