### PR TITLE
adds core dependency back for non-winml package

### DIFF
--- a/.pipelines/templates/build-cs-steps.yml
+++ b/.pipelines/templates/build-cs-steps.yml
@@ -169,13 +169,15 @@ steps:
   inputs:
     targetType: inline
     script: |
+      # empty RuntimeIdentifier prevents host machine from auto-injecting its RID into the build
       dotnet pack "$(repoRoot)/sdk/cs/src/Microsoft.AI.Foundry.Local.csproj" `
         --no-build --no-restore --configuration Release `
         --output "${{ parameters.outputDir }}" `
         /p:PackageVersion=$(packageVersion) `
         /p:UseWinML=${{ parameters.isWinML }} `
         /p:IncludeSymbols=true `
-        /p:SymbolPackageFormat=snupkg
+        /p:SymbolPackageFormat=snupkg `
+        /p:RuntimeIdentifier=""
       if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Sign NuGet package

--- a/.pipelines/templates/build-cs-steps.yml
+++ b/.pipelines/templates/build-cs-steps.yml
@@ -122,9 +122,11 @@ steps:
   inputs:
     targetType: inline
     script: |
+      # empty RuntimeIdentifier prevents host machine from auto-injecting its RID into the build
       dotnet build "$(repoRoot)/sdk/cs/src/Microsoft.AI.Foundry.Local.csproj" `
         --no-restore --configuration Release `
-        /p:UseWinML=${{ parameters.isWinML }}
+        /p:UseWinML=${{ parameters.isWinML }} `
+        /p:RuntimeIdentifier=""
       if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Discover target framework directory

--- a/.pipelines/templates/build-cs-steps.yml
+++ b/.pipelines/templates/build-cs-steps.yml
@@ -122,11 +122,9 @@ steps:
   inputs:
     targetType: inline
     script: |
-      # empty RuntimeIdentifier prevents host machine from auto-injecting its RID into the build
       dotnet build "$(repoRoot)/sdk/cs/src/Microsoft.AI.Foundry.Local.csproj" `
         --no-restore --configuration Release `
-        /p:UseWinML=${{ parameters.isWinML }} `
-        /p:RuntimeIdentifier=""
+        /p:UseWinML=${{ parameters.isWinML }}
       if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Discover target framework directory
@@ -169,15 +167,13 @@ steps:
   inputs:
     targetType: inline
     script: |
-      # empty RuntimeIdentifier prevents host machine from auto-injecting its RID into the build
       dotnet pack "$(repoRoot)/sdk/cs/src/Microsoft.AI.Foundry.Local.csproj" `
         --no-build --no-restore --configuration Release `
         --output "${{ parameters.outputDir }}" `
         /p:PackageVersion=$(packageVersion) `
         /p:UseWinML=${{ parameters.isWinML }} `
         /p:IncludeSymbols=true `
-        /p:SymbolPackageFormat=snupkg `
-        /p:RuntimeIdentifier=""
+        /p:SymbolPackageFormat=snupkg
       if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Sign NuGet package

--- a/sdk/cs/src/Microsoft.AI.Foundry.Local.csproj
+++ b/sdk/cs/src/Microsoft.AI.Foundry.Local.csproj
@@ -15,6 +15,7 @@
     <RepositoryType>git</RepositoryType>
 
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <RuntimeIdentifiers>win-x64;win-arm64;osx-arm64;linux-x64</RuntimeIdentifiers>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/sdk/cs/src/Microsoft.AI.Foundry.Local.csproj
+++ b/sdk/cs/src/Microsoft.AI.Foundry.Local.csproj
@@ -103,7 +103,7 @@
     <FoundryLocalCoreVersion Condition="'$(FoundryLocalCoreVersion)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(_DepsVersionsJson)', '"nuget"\s*:\s*"([^"]+)"').Groups[1].Value)</FoundryLocalCoreVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(UseWinML)' == 'false'">
+  <ItemGroup Condition="'$(UseWinML)' != 'true'">
     <PackageReference Include="Microsoft.AI.Foundry.Local.Core" Version="$(FoundryLocalCoreVersion)" />
   </ItemGroup>
 

--- a/sdk/cs/src/Microsoft.AI.Foundry.Local.csproj
+++ b/sdk/cs/src/Microsoft.AI.Foundry.Local.csproj
@@ -103,6 +103,10 @@
     <FoundryLocalCoreVersion Condition="'$(FoundryLocalCoreVersion)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(_DepsVersionsJson)', '"nuget"\s*:\s*"([^"]+)"').Groups[1].Value)</FoundryLocalCoreVersion>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(UseWinML)' == 'false'">
+    <PackageReference Include="Microsoft.AI.Foundry.Local.Core" Version="$(FoundryLocalCoreVersion)" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(UseWinML)' == 'true'">
     <PackageReference Include="Microsoft.AI.Foundry.Local.Core.WinML" Version="$(FoundryLocalCoreVersion)" />
   </ItemGroup>


### PR DESCRIPTION
was likely removed during netstandard2.0 support work https://github.com/microsoft/Foundry-Local/pull/629