### PR TITLE
Derive SDK package versions from Foundry Local Core

### DIFF
--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -1,7 +1,7 @@
 # Foundry Local Packaging Pipeline
 #
 # Builds Foundry Local Core from neutron-server (windows.ai.toolkit project),
-# then packages the C# and JS SDKs from this repo using the built Core.
+# then packages the SDKs from this repo using the built Core.
 #
 # Produces artifacts: flc-nuget, flc-nuget-winml, flc-wheels, flc-wheels-winml,
 #   cs-sdk, cs-sdk-winml, js-sdk, js-sdk-winml, python-sdk, python-sdk-winml,
@@ -14,10 +14,6 @@ pr:
 name: $(Date:yyyyMMdd).$(Rev:r)
 
 parameters:
-- name: version
-  displayName: 'Package version'
-  type: string
-  default: '1.2.0'
 - name: prereleaseId
   displayName: 'Pre-release identifier (e.g. rc1, beta).'
   type: string
@@ -56,12 +52,12 @@ extends:
         scanOutputDirectoryOnly: true
     stages:
     # ── Compute Version ──
-    # A single version string is computed once and shared across all stages.
-    # This prevents timestamp drift between standard and WinML builds.
-    # Outputs three format variants:
-    #   sdkVersion  – semver for JS, C#, Rust (e.g. X.Y.Z-dev.202604061234)
-    #   pyVersion   – PEP 440 for Python     (e.g. X.Y.Z.dev202604061234)
-    #   flcVersion  – NuGet/FLC style         (e.g. X.Y.Z-dev-202604061234-ab12cd34)
+    # A single version is computed from the selected Foundry Local Core branch
+    # and shared across all stages. This keeps SDK packages aligned with Core
+    # while still producing ecosystem-specific format variants:
+    #   sdkVersion  – SemVer for JS, C#, Rust
+    #   pyVersion   – PEP 440 for Python
+    #   flcVersion  – NuGet/FLC style
     - stage: compute_version
       displayName: 'Compute Version'
       dependsOn: []
@@ -77,40 +73,131 @@ extends:
             artifactName: 'version-info'
             targetPath: '$(Build.ArtifactStagingDirectory)/version-info'
         steps:
-        - checkout: none
+        - template: .pipelines/templates/checkout-steps.yml@self
+          parameters:
+            repoName: neutron-server
+            ref: refs/heads/${{ parameters.neutronServerBranch }}
+        - task: UseDotNet@2
+          displayName: 'Use .NET SDK from Foundry Local Core'
+          inputs:
+            packageType: sdk
+            useGlobalJson: true
+            workingDirectory: '$(Build.SourcesDirectory)/neutron-server'
         - task: PowerShell@2
-          displayName: 'Compute and write version files'
+          displayName: 'Compute versions from Foundry Local Core'
           inputs:
             targetType: inline
             script: |
-              $base = "${{ parameters.version }}"
-              $preId = "${{ parameters.prereleaseId }}"
-              $ts = Get-Date -Format "yyyyMMddHHmm"
-              $commitId = "$(Build.SourceVersion)".Substring(0, 8)
+              $ErrorActionPreference = 'Stop'
+
+              $nsRoot = "$(Build.SourcesDirectory)/neutron-server"
+              $preId = ("${{ parameters.prereleaseId }}").Trim()
+              if ($preId -eq 'none') { $preId = '' }
+              $isRelease = "${{ parameters.isRelease }}" -eq "True"
+
+              $previousPublicRelease = $env:PublicRelease
+              Push-Location $nsRoot
+              try {
+                if ($isRelease) {
+                  $env:PublicRelease = "true"
+                }
+
+                if (Test-Path ".config/dotnet-tools.json") {
+                  dotnet tool restore
+                  if ($LASTEXITCODE -ne 0) { throw "dotnet tool restore failed" }
+                  $versionJson = & dotnet tool run nbgv -- get-version -p $nsRoot -f json
+                } else {
+                  $toolPath = "$(Agent.TempDirectory)/nbgv"
+                  New-Item -ItemType Directory -Path $toolPath -Force | Out-Null
+                  $nbgv = Join-Path $toolPath "nbgv.exe"
+                  if (Test-Path $nbgv) {
+                    dotnet tool update nbgv --tool-path $toolPath --version 3.7.115
+                  } else {
+                    dotnet tool install nbgv --tool-path $toolPath --version 3.7.115
+                  }
+                  if ($LASTEXITCODE -ne 0) { throw "installing nbgv failed" }
+                  $versionJson = & $nbgv get-version -p $nsRoot -f json
+                }
+                if ($LASTEXITCODE -ne 0) { throw "nbgv get-version failed" }
+              } finally {
+                if ($null -eq $previousPublicRelease) {
+                  Remove-Item Env:\PublicRelease -ErrorAction SilentlyContinue
+                } else {
+                  $env:PublicRelease = $previousPublicRelease
+                }
+                Pop-Location
+              }
+
+              $versionInfo = $versionJson | ConvertFrom-Json
+              $simpleVersion = [string]$versionInfo.SimpleVersion
+              if ([string]::IsNullOrWhiteSpace($simpleVersion)) {
+                throw "NBGV did not return SimpleVersion"
+              }
 
               if ($preId -ne '' -and $preId -ne 'none') {
-                $sdkVersion = "$base-$preId"
-                $pyVersion  = "$base$preId"
-                $flcVersion = "$base-$preId"
-              } elseif ("${{ parameters.isRelease }}" -ne "True") {
-                $sdkVersion = "$base-dev.$ts"
-                $pyVersion  = "$base.dev$ts"
-                $flcVersion = "$base-dev-$ts-$commitId"
+                $sdkVersion = "$simpleVersion-$preId"
+                $pyVersion  = "$simpleVersion$preId"
+                $flcVersion = "$simpleVersion-$preId"
               } else {
-                $sdkVersion = $base
-                $pyVersion  = $base
-                $flcVersion = $base
+                $flcVersion = [string]$versionInfo.NuGetPackageVersion
+                $sdkVersion = [string]$versionInfo.NpmPackageVersion
+                if ([string]::IsNullOrWhiteSpace($sdkVersion)) {
+                  $sdkVersion = [string]$versionInfo.SemVer2
+                }
+
+                if ($isRelease -and $flcVersion -match '-g[0-9a-fA-F]+$') {
+                  $flcVersion = $simpleVersion
+                }
+                if ($isRelease -and $sdkVersion -match '-g[0-9a-fA-F]+$') {
+                  $sdkVersion = $simpleVersion
+                }
+
+                if ($versionInfo.PublicRelease -or $isRelease) {
+                  $pyVersion = $simpleVersion
+                } else {
+                  $pyVersion = "$simpleVersion.dev$($versionInfo.VersionHeight)"
+                }
+              }
+
+              $sdkVersion = $sdkVersion.Split('+')[0]
+              $flcVersion = $flcVersion.Split('+')[0]
+
+              foreach ($entry in @(
+                @{ Name = "SDK version"; Value = $sdkVersion },
+                @{ Name = "Python version"; Value = $pyVersion },
+                @{ Name = "FLC version"; Value = $flcVersion }
+              )) {
+                if ([string]::IsNullOrWhiteSpace($entry.Value)) {
+                  throw "$($entry.Name) was empty"
+                }
               }
 
               $outDir = "$(Build.ArtifactStagingDirectory)/version-info"
               New-Item -ItemType Directory -Path $outDir -Force | Out-Null
-              Set-Content -Path "$outDir/sdkVersion.txt" -Value $sdkVersion -NoNewline
-              Set-Content -Path "$outDir/pyVersion.txt"  -Value $pyVersion  -NoNewline
-              Set-Content -Path "$outDir/flcVersion.txt" -Value $flcVersion -NoNewline
+
+              $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+              [System.IO.File]::WriteAllText("$outDir/sdkVersion.txt", $sdkVersion, $utf8NoBom)
+              [System.IO.File]::WriteAllText("$outDir/pyVersion.txt",  $pyVersion,  $utf8NoBom)
+              [System.IO.File]::WriteAllText("$outDir/flcVersion.txt", $flcVersion, $utf8NoBom)
+
+              $versions = [ordered]@{
+                sdkVersion = $sdkVersion
+                pythonVersion = $pyVersion
+                flcVersion = $flcVersion
+                coreNuGetPackageVersion = $versionInfo.NuGetPackageVersion
+                coreNpmPackageVersion = $versionInfo.NpmPackageVersion
+                coreInformationalVersion = $versionInfo.AssemblyInformationalVersion
+                coreVersionHeight = $versionInfo.VersionHeight
+                corePublicRelease = $versionInfo.PublicRelease
+                coreCommitId = $versionInfo.GitCommitId
+                coreBranch = "${{ parameters.neutronServerBranch }}"
+              } | ConvertTo-Json
+              [System.IO.File]::WriteAllText("$outDir/versions.json", $versions, $utf8NoBom)
 
               Write-Host "SDK version: $sdkVersion"
               Write-Host "Python version: $pyVersion"
               Write-Host "FLC version: $flcVersion"
+              Write-Host "FLC informational version: $($versionInfo.AssemblyInformationalVersion)"
 
     # ── Build FLC ──
     - stage: build_core
@@ -277,9 +364,6 @@ extends:
               }
         - template: .pipelines/templates/package-core-steps.yml@self
           parameters:
-            version: ${{ parameters.version }}
-            isRelease: ${{ parameters.isRelease }}
-            prereleaseId: ${{ parameters.prereleaseId }}
             isWinML: false
             platforms:
             - name: win-x64
@@ -324,9 +408,6 @@ extends:
             repoName: test-data-shared
         - template: .pipelines/templates/build-cs-steps.yml@self
           parameters:
-            version: ${{ parameters.version }}
-            isRelease: ${{ parameters.isRelease }}
-            prereleaseId: ${{ parameters.prereleaseId }}
             isWinML: false
             flcNugetDir: '$(Pipeline.Workspace)/flc-nuget'
             depsVersionsDir: '$(Pipeline.Workspace)/deps-versions-standard'
@@ -512,9 +593,6 @@ extends:
 
         - template: .pipelines/templates/build-js-steps.yml@self
           parameters:
-            version: ${{ parameters.version }}
-            isRelease: ${{ parameters.isRelease }}
-            prereleaseId: ${{ parameters.prereleaseId }}
             isWinML: false
             flcNugetDir: '$(Pipeline.Workspace)/flc-nuget'
             depsVersionsDir: '$(Pipeline.Workspace)/deps-versions-standard'
@@ -552,9 +630,6 @@ extends:
             repoName: test-data-shared
         - template: .pipelines/templates/build-python-steps.yml@self
           parameters:
-            version: ${{ parameters.version }}
-            isRelease: ${{ parameters.isRelease }}
-            prereleaseId: ${{ parameters.prereleaseId }}
             isWinML: false
             flcWheelsDir: '$(Pipeline.Workspace)/flc-wheels'
             depsVersionsDir: '$(Pipeline.Workspace)/deps-versions-standard'
@@ -592,9 +667,6 @@ extends:
             repoName: test-data-shared
         - template: .pipelines/templates/build-rust-steps.yml@self
           parameters:
-            version: ${{ parameters.version }}
-            isRelease: ${{ parameters.isRelease }}
-            prereleaseId: ${{ parameters.prereleaseId }}
             isWinML: false
             flcNugetDir: '$(Pipeline.Workspace)/flc-nuget'
             depsVersionsDir: '$(Pipeline.Workspace)/deps-versions-standard'
@@ -635,9 +707,6 @@ extends:
     #       lfs: true
     #     - template: .pipelines/templates/build-rust-steps.yml@self
     #       parameters:
-    #         version: ${{ parameters.version }}
-    #         isRelease: ${{ parameters.isRelease }}
-    #         prereleaseId: ${{ parameters.prereleaseId }}
     #         isWinML: true
     #         flcNugetDir: '$(Pipeline.Workspace)/flc-nuget-winml'
     #         depsVersionsDir: '$(Pipeline.Workspace)/deps-versions-winml'
@@ -1104,9 +1173,6 @@ extends:
               }
         - template: .pipelines/templates/package-core-steps.yml@self
           parameters:
-            version: ${{ parameters.version }}
-            isRelease: ${{ parameters.isRelease }}
-            prereleaseId: ${{ parameters.prereleaseId }}
             isWinML: true
             platforms:
             - name: win-x64
@@ -1147,9 +1213,6 @@ extends:
             repoName: test-data-shared
         - template: .pipelines/templates/build-cs-steps.yml@self
           parameters:
-            version: ${{ parameters.version }}
-            isRelease: ${{ parameters.isRelease }}
-            prereleaseId: ${{ parameters.prereleaseId }}
             isWinML: true
             flcNugetDir: '$(Pipeline.Workspace)/flc-nuget-winml'
             depsVersionsDir: '$(Pipeline.Workspace)/deps-versions-winml'
@@ -1232,9 +1295,6 @@ extends:
 
         - template: .pipelines/templates/build-js-steps.yml@self
           parameters:
-            version: ${{ parameters.version }}
-            isRelease: ${{ parameters.isRelease }}
-            prereleaseId: ${{ parameters.prereleaseId }}
             isWinML: true
             flcNugetDir: '$(Pipeline.Workspace)/flc-nuget-winml'
             depsVersionsDir: '$(Pipeline.Workspace)/deps-versions-winml'
@@ -1272,9 +1332,6 @@ extends:
             repoName: test-data-shared
         - template: .pipelines/templates/build-python-steps.yml@self
           parameters:
-            version: ${{ parameters.version }}
-            isRelease: ${{ parameters.isRelease }}
-            prereleaseId: ${{ parameters.prereleaseId }}
             isWinML: true
             flcWheelsDir: '$(Pipeline.Workspace)/flc-wheels-winml'
             depsVersionsDir: '$(Pipeline.Workspace)/deps-versions-winml'

--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -14,14 +14,6 @@ pr:
 name: $(Date:yyyyMMdd).$(Rev:r)
 
 parameters:
-- name: prereleaseId
-  displayName: 'Pre-release identifier (e.g. rc1, beta).'
-  type: string
-  default: 'none'
-- name: isRelease
-  displayName: 'Release build'
-  type: boolean
-  default: false
 - name: neutronServerBranch
   displayName: 'Foundry Local Core branch (windows.ai.toolkit/neutron-server)'
   type: string
@@ -51,19 +43,18 @@ extends:
         break: false
         scanOutputDirectoryOnly: true
     stages:
-    # ── Compute Version ──
-    # A single version is computed from the selected Foundry Local Core branch
-    # and shared across all stages. This keeps SDK packages aligned with Core
-    # while still producing ecosystem-specific format variants:
-    #   sdkVersion  – SemVer for JS, C#, Rust
-    #   pyVersion   – PEP 440 for Python
-    #   flcVersion  – NuGet/FLC style
+    # ── Resolve Package Versions ──
+    # Package versions come from the Core dependency versions committed under sdk/.
+    # This keeps SDK package versions aligned with the Core packages they consume:
+    #   sdkVersion  – NuGet/SemVer version for JS, C#, Rust
+    #   pyVersion   – PEP 440 version for Python
+    #   flcVersion  – NuGet/FLC package version
     - stage: compute_version
-      displayName: 'Compute Version'
+      displayName: 'Resolve Package Versions'
       dependsOn: []
       jobs:
       - job: version
-        displayName: 'Compute Version'
+        displayName: 'Resolve Package Versions'
         pool:
           name: onnxruntime-Win-CPU-2022
           os: windows
@@ -73,99 +64,63 @@ extends:
             artifactName: 'version-info'
             targetPath: '$(Build.ArtifactStagingDirectory)/version-info'
         steps:
-        - template: .pipelines/templates/checkout-steps.yml@self
-          parameters:
-            repoName: neutron-server
-            ref: refs/heads/${{ parameters.neutronServerBranch }}
-        - task: UseDotNet@2
-          displayName: 'Use .NET SDK from Foundry Local Core'
-          inputs:
-            packageType: sdk
-            useGlobalJson: true
-            workingDirectory: '$(Build.SourcesDirectory)/neutron-server'
+        - checkout: self
         - task: PowerShell@2
-          displayName: 'Compute versions from Foundry Local Core'
+          displayName: 'Resolve versions from SDK dependency files'
           inputs:
             targetType: inline
             script: |
               $ErrorActionPreference = 'Stop'
 
-              $nsRoot = "$(Build.SourcesDirectory)/neutron-server"
-              $preId = ("${{ parameters.prereleaseId }}").Trim()
-              if ($preId -eq 'none') { $preId = '' }
-              $isRelease = "${{ parameters.isRelease }}" -eq "True"
+              function Get-CoreVersions {
+                param(
+                  [Parameter(Mandatory=$true)][string]$Path,
+                  [Parameter(Mandatory=$true)][string]$Label
+                )
 
-              $previousPublicRelease = $env:PublicRelease
-              Push-Location $nsRoot
-              try {
-                if ($isRelease) {
-                  $env:PublicRelease = "true"
+                if (-not (Test-Path $Path)) {
+                  throw "$Label dependency version file not found: $Path"
                 }
 
-                if (Test-Path ".config/dotnet-tools.json") {
-                  dotnet tool restore
-                  if ($LASTEXITCODE -ne 0) { throw "dotnet tool restore failed" }
-                  $versionJson = & dotnet tool run nbgv -- get-version -p $nsRoot -f json
-                } else {
-                  $toolPath = "$(Agent.TempDirectory)/nbgv"
-                  New-Item -ItemType Directory -Path $toolPath -Force | Out-Null
-                  $nbgv = Join-Path $toolPath "nbgv.exe"
-                  if (Test-Path $nbgv) {
-                    dotnet tool update nbgv --tool-path $toolPath --version 3.7.115
-                  } else {
-                    dotnet tool install nbgv --tool-path $toolPath --version 3.7.115
-                  }
-                  if ($LASTEXITCODE -ne 0) { throw "installing nbgv failed" }
-                  $versionJson = & $nbgv get-version -p $nsRoot -f json
-                }
-                if ($LASTEXITCODE -ne 0) { throw "nbgv get-version failed" }
-              } finally {
-                if ($null -eq $previousPublicRelease) {
-                  Remove-Item Env:\PublicRelease -ErrorAction SilentlyContinue
-                } else {
-                  $env:PublicRelease = $previousPublicRelease
-                }
-                Pop-Location
-              }
-
-              $versionInfo = $versionJson | ConvertFrom-Json
-              $coreCommitId = (git -C $nsRoot rev-parse HEAD).Trim()
-              if ([string]::IsNullOrWhiteSpace($coreCommitId)) {
-                throw "Failed to resolve Foundry Local Core commit"
-              }
-
-              $simpleVersion = [string]$versionInfo.SimpleVersion
-              if ([string]::IsNullOrWhiteSpace($simpleVersion)) {
-                throw "NBGV did not return SimpleVersion"
-              }
-
-              if ($preId -ne '' -and $preId -ne 'none') {
-                $sdkVersion = "$simpleVersion-$preId"
-                $pyVersion  = "$simpleVersion$preId"
-                $flcVersion = "$simpleVersion-$preId"
-              } else {
-                $flcVersion = [string]$versionInfo.NuGetPackageVersion
-                $sdkVersion = [string]$versionInfo.NpmPackageVersion
-                if ([string]::IsNullOrWhiteSpace($sdkVersion)) {
-                  $sdkVersion = [string]$versionInfo.SemVer2
+                $deps = Get-Content $Path -Raw | ConvertFrom-Json
+                $core = $deps.'foundry-local-core'
+                if ($null -eq $core) {
+                  throw "$Label dependency version file is missing foundry-local-core: $Path"
                 }
 
-                if ($isRelease -and $flcVersion -match '-g[0-9a-fA-F]+$') {
-                  $flcVersion = $simpleVersion
+                $nugetVersion = [string]$core.nuget
+                $pythonVersion = [string]$core.python
+                if ([string]::IsNullOrWhiteSpace($nugetVersion)) {
+                  throw "$Label dependency version file has empty foundry-local-core.nuget: $Path"
                 }
-                if ($isRelease -and $sdkVersion -match '-g[0-9a-fA-F]+$') {
-                  $sdkVersion = $simpleVersion
+                if ([string]::IsNullOrWhiteSpace($pythonVersion)) {
+                  throw "$Label dependency version file has empty foundry-local-core.python: $Path"
                 }
 
-                if ($versionInfo.PublicRelease -or $isRelease) {
-                  $pyVersion = $simpleVersion
-                } else {
-                  $pyVersion = "$simpleVersion.dev$($versionInfo.VersionHeight)"
+                return [pscustomobject]@{
+                  NuGet = $nugetVersion.Trim()
+                  Python = $pythonVersion.Trim()
                 }
               }
 
-              $sdkVersion = $sdkVersion.Split('+')[0]
-              $flcVersion = $flcVersion.Split('+')[0]
+              $repoRoot = "$(Build.SourcesDirectory)"
+              $standardCore = Get-CoreVersions `
+                -Path (Join-Path $repoRoot "sdk/deps_versions.json") `
+                -Label "Standard"
+              $winmlCore = Get-CoreVersions `
+                -Path (Join-Path $repoRoot "sdk/deps_versions_winml.json") `
+                -Label "WinML"
+
+              if ($standardCore.NuGet -ne $winmlCore.NuGet) {
+                throw "Core NuGet versions must match in sdk/deps_versions.json and sdk/deps_versions_winml.json. Standard: $($standardCore.NuGet); WinML: $($winmlCore.NuGet)"
+              }
+              if ($standardCore.Python -ne $winmlCore.Python) {
+                throw "Core Python versions must match in sdk/deps_versions.json and sdk/deps_versions_winml.json. Standard: $($standardCore.Python); WinML: $($winmlCore.Python)"
+              }
+
+              $sdkVersion = $standardCore.NuGet
+              $flcVersion = $standardCore.NuGet
+              $pyVersion = $standardCore.Python
 
               foreach ($entry in @(
                 @{ Name = "SDK version"; Value = $sdkVersion },
@@ -184,27 +139,22 @@ extends:
               [System.IO.File]::WriteAllText("$outDir/sdkVersion.txt", $sdkVersion, $utf8NoBom)
               [System.IO.File]::WriteAllText("$outDir/pyVersion.txt",  $pyVersion,  $utf8NoBom)
               [System.IO.File]::WriteAllText("$outDir/flcVersion.txt", $flcVersion, $utf8NoBom)
-              [System.IO.File]::WriteAllText("$outDir/neutronServerCommit.txt", $coreCommitId, $utf8NoBom)
 
               $versions = [ordered]@{
                 sdkVersion = $sdkVersion
                 pythonVersion = $pyVersion
                 flcVersion = $flcVersion
-                coreNuGetPackageVersion = $versionInfo.NuGetPackageVersion
-                coreNpmPackageVersion = $versionInfo.NpmPackageVersion
-                coreInformationalVersion = $versionInfo.AssemblyInformationalVersion
-                coreVersionHeight = $versionInfo.VersionHeight
-                corePublicRelease = $versionInfo.PublicRelease
-                coreCommitId = $coreCommitId
-                coreBranch = "${{ parameters.neutronServerBranch }}"
+                source = "sdk/deps_versions.json"
+                standardCoreNuGetPackageVersion = $standardCore.NuGet
+                standardCorePythonPackageVersion = $standardCore.Python
+                winmlCoreNuGetPackageVersion = $winmlCore.NuGet
+                winmlCorePythonPackageVersion = $winmlCore.Python
               } | ConvertTo-Json
               [System.IO.File]::WriteAllText("$outDir/versions.json", $versions, $utf8NoBom)
 
               Write-Host "SDK version: $sdkVersion"
               Write-Host "Python version: $pyVersion"
               Write-Host "FLC version: $flcVersion"
-              Write-Host "FLC informational version: $($versionInfo.AssemblyInformationalVersion)"
-              Write-Host "FLC commit: $coreCommitId"
 
     # ── Build FLC ──
     - stage: build_core
@@ -230,7 +180,6 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
-            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - template: .pipelines/templates/checkout-steps.yml@self
           parameters:
             repoName: test-data-shared
@@ -258,7 +207,6 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
-            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - template: .pipelines/templates/checkout-steps.yml@self
           parameters:
             repoName: test-data-shared
@@ -286,7 +234,6 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
-            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - template: .pipelines/templates/checkout-steps.yml@self
           parameters:
             repoName: test-data-shared
@@ -316,7 +263,6 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
-            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - template: .pipelines/templates/checkout-steps.yml@self
           parameters:
             repoName: test-data-shared
@@ -358,7 +304,6 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
-            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - task: DownloadPipelineArtifact@2
           inputs:
             buildType: current
@@ -1121,7 +1066,6 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
-            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - template: .pipelines/templates/checkout-steps.yml@self
           parameters:
             repoName: test-data-shared
@@ -1150,7 +1094,6 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
-            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - template: .pipelines/templates/checkout-steps.yml@self
           parameters:
             repoName: test-data-shared
@@ -1188,7 +1131,6 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
-            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - task: DownloadPipelineArtifact@2
           inputs:
             buildType: current

--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -129,6 +129,11 @@ extends:
               }
 
               $versionInfo = $versionJson | ConvertFrom-Json
+              $coreCommitId = (git -C $nsRoot rev-parse HEAD).Trim()
+              if ([string]::IsNullOrWhiteSpace($coreCommitId)) {
+                throw "Failed to resolve Foundry Local Core commit"
+              }
+
               $simpleVersion = [string]$versionInfo.SimpleVersion
               if ([string]::IsNullOrWhiteSpace($simpleVersion)) {
                 throw "NBGV did not return SimpleVersion"
@@ -179,6 +184,7 @@ extends:
               [System.IO.File]::WriteAllText("$outDir/sdkVersion.txt", $sdkVersion, $utf8NoBom)
               [System.IO.File]::WriteAllText("$outDir/pyVersion.txt",  $pyVersion,  $utf8NoBom)
               [System.IO.File]::WriteAllText("$outDir/flcVersion.txt", $flcVersion, $utf8NoBom)
+              [System.IO.File]::WriteAllText("$outDir/neutronServerCommit.txt", $coreCommitId, $utf8NoBom)
 
               $versions = [ordered]@{
                 sdkVersion = $sdkVersion
@@ -189,7 +195,7 @@ extends:
                 coreInformationalVersion = $versionInfo.AssemblyInformationalVersion
                 coreVersionHeight = $versionInfo.VersionHeight
                 corePublicRelease = $versionInfo.PublicRelease
-                coreCommitId = $versionInfo.GitCommitId
+                coreCommitId = $coreCommitId
                 coreBranch = "${{ parameters.neutronServerBranch }}"
               } | ConvertTo-Json
               [System.IO.File]::WriteAllText("$outDir/versions.json", $versions, $utf8NoBom)
@@ -198,6 +204,7 @@ extends:
               Write-Host "Python version: $pyVersion"
               Write-Host "FLC version: $flcVersion"
               Write-Host "FLC informational version: $($versionInfo.AssemblyInformationalVersion)"
+              Write-Host "FLC commit: $coreCommitId"
 
     # ── Build FLC ──
     - stage: build_core
@@ -210,6 +217,10 @@ extends:
           name: onnxruntime-Win-CPU-2022
           os: windows
         templateContext:
+          inputs:
+          - input: pipelineArtifact
+            artifactName: 'version-info'
+            targetPath: '$(Pipeline.Workspace)/version-info'
           outputs:
           - output: pipelineArtifact
             artifactName: 'flc-win-x64'
@@ -219,6 +230,7 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
+            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - template: .pipelines/templates/checkout-steps.yml@self
           parameters:
             repoName: test-data-shared
@@ -233,6 +245,10 @@ extends:
           name: onnxruntime-Win-CPU-2022
           os: windows
         templateContext:
+          inputs:
+          - input: pipelineArtifact
+            artifactName: 'version-info'
+            targetPath: '$(Pipeline.Workspace)/version-info'
           outputs:
           - output: pipelineArtifact
             artifactName: 'flc-win-arm64'
@@ -242,6 +258,7 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
+            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - template: .pipelines/templates/checkout-steps.yml@self
           parameters:
             repoName: test-data-shared
@@ -256,6 +273,10 @@ extends:
           name: onnxruntime-Ubuntu2404-AMD-CPU
           os: linux
         templateContext:
+          inputs:
+          - input: pipelineArtifact
+            artifactName: 'version-info'
+            targetPath: '$(Pipeline.Workspace)/version-info'
           outputs:
           - output: pipelineArtifact
             artifactName: 'flc-linux-x64'
@@ -265,6 +286,7 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
+            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - template: .pipelines/templates/checkout-steps.yml@self
           parameters:
             repoName: test-data-shared
@@ -281,6 +303,10 @@ extends:
           demands:
           - ImageOverride -equals ACES_VM_SharedPool_Sequoia
         templateContext:
+          inputs:
+          - input: pipelineArtifact
+            artifactName: 'version-info'
+            targetPath: '$(Pipeline.Workspace)/version-info'
           outputs:
           - output: pipelineArtifact
             artifactName: 'flc-osx-arm64'
@@ -290,6 +316,7 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
+            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - template: .pipelines/templates/checkout-steps.yml@self
           parameters:
             repoName: test-data-shared
@@ -331,6 +358,7 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
+            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - task: DownloadPipelineArtifact@2
           inputs:
             buildType: current
@@ -1080,6 +1108,10 @@ extends:
           name: onnxruntime-Win-CPU-2022
           os: windows
         templateContext:
+          inputs:
+          - input: pipelineArtifact
+            artifactName: 'version-info'
+            targetPath: '$(Pipeline.Workspace)/version-info'
           outputs:
           - output: pipelineArtifact
             artifactName: 'flc-winml-win-x64'
@@ -1089,6 +1121,7 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
+            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - template: .pipelines/templates/checkout-steps.yml@self
           parameters:
             repoName: test-data-shared
@@ -1104,6 +1137,10 @@ extends:
           name: onnxruntime-Win-CPU-2022
           os: windows
         templateContext:
+          inputs:
+          - input: pipelineArtifact
+            artifactName: 'version-info'
+            targetPath: '$(Pipeline.Workspace)/version-info'
           outputs:
           - output: pipelineArtifact
             artifactName: 'flc-winml-win-arm64'
@@ -1113,6 +1150,7 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
+            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - template: .pipelines/templates/checkout-steps.yml@self
           parameters:
             repoName: test-data-shared
@@ -1150,6 +1188,7 @@ extends:
           parameters:
             repoName: neutron-server
             ref: refs/heads/${{ parameters.neutronServerBranch }}
+            refFile: '$(Pipeline.Workspace)/version-info/neutronServerCommit.txt'
         - task: DownloadPipelineArtifact@2
           inputs:
             buildType: current

--- a/.pipelines/templates/build-cs-steps.yml
+++ b/.pipelines/templates/build-cs-steps.yml
@@ -2,11 +2,6 @@
 # When test-data-shared is checked out alongside self, ADO places repos under
 # $(Build.SourcesDirectory)/<repo-name>. The self repo is 'Foundry-Local'.
 parameters:
-- name: version
-  type: string
-- name: isRelease
-  type: boolean
-  default: false
 - name: isWinML
   type: boolean
   default: false
@@ -17,9 +12,6 @@ parameters:
   type: string
   default: '$(Build.ArtifactStagingDirectory)/cs-sdk'
   displayName: 'Path to directory for the packed SDK'
-- name: prereleaseId
-  type: string
-  default: ''
 - name: depsVersionsDir
   type: string
   default: ''

--- a/.pipelines/templates/build-cs-steps.yml
+++ b/.pipelines/templates/build-cs-steps.yml
@@ -41,7 +41,7 @@ steps:
     packageType: sdk
     version: '10.0.x'
 
-# Read version from the version-info artifact produced by compute_version stage.
+# Read package version resolved from the SDK dependency version files.
 - task: PowerShell@2
   displayName: 'Set package version'
   inputs:

--- a/.pipelines/templates/build-js-steps.yml
+++ b/.pipelines/templates/build-js-steps.yml
@@ -2,11 +2,6 @@
 # When test-data-shared is checked out alongside self, ADO places repos under
 # $(Build.SourcesDirectory)/<repo-name>. The self repo is 'Foundry-Local'.
 parameters:
-- name: version
-  type: string
-- name: isRelease
-  type: boolean
-  default: false
 - name: isWinML
   type: boolean
   default: false
@@ -14,9 +9,6 @@ parameters:
   type: string
   default: ''
   displayName: 'Path to directory containing the FLC .nupkg (for tests)'
-- name: prereleaseId
-  type: string
-  default: ''
 - name: depsVersionsDir
   type: string
   default: ''

--- a/.pipelines/templates/build-js-steps.yml
+++ b/.pipelines/templates/build-js-steps.yml
@@ -53,7 +53,7 @@ steps:
     artifactDir: ${{ parameters.depsVersionsDir }}
     isWinML: ${{ parameters.isWinML }}
 
-# Compute version
+# Read package version resolved from the SDK dependency version files.
 - task: PowerShell@2
   displayName: 'Set package version'
   inputs:

--- a/.pipelines/templates/build-python-steps.yml
+++ b/.pipelines/templates/build-python-steps.yml
@@ -55,7 +55,7 @@ steps:
       Write-Host "Contents of ${{ parameters.flcWheelsDir }}:"
       Get-ChildItem "${{ parameters.flcWheelsDir }}" -Recurse | ForEach-Object { Write-Host $_.FullName }
 
-# Read version from the version-info artifact produced by compute_version stage.
+# Read package version resolved from the SDK dependency version files.
 - task: PowerShell@2
   displayName: 'Set package version'
   inputs:

--- a/.pipelines/templates/build-python-steps.yml
+++ b/.pipelines/templates/build-python-steps.yml
@@ -2,11 +2,6 @@
 # When test-data-shared is checked out alongside self, ADO places repos under
 # $(Build.SourcesDirectory)/<repo-name>. The self repo is 'Foundry-Local'.
 parameters:
-- name: version
-  type: string
-- name: isRelease
-  type: boolean
-  default: false
 - name: isWinML
   type: boolean
   default: false
@@ -17,9 +12,6 @@ parameters:
   type: string
   default: '$(Build.ArtifactStagingDirectory)/python-sdk'
   displayName: 'Path to directory for the built wheel'
-- name: prereleaseId
-  type: string
-  default: ''
 - name: depsVersionsDir
   type: string
   default: ''

--- a/.pipelines/templates/build-rust-steps.yml
+++ b/.pipelines/templates/build-rust-steps.yml
@@ -33,7 +33,7 @@ steps:
       Write-Host "##vso[task.setvariable variable=repoRoot]$repoRoot"
       Write-Host "##vso[task.setvariable variable=testDataDir]$testDataDir"
 
-# Read version from the version-info artifact produced by compute_version stage.
+# Read crate version resolved from the SDK dependency version files.
 - task: PowerShell@2
   displayName: 'Set crate version'
   inputs:

--- a/.pipelines/templates/build-rust-steps.yml
+++ b/.pipelines/templates/build-rust-steps.yml
@@ -2,14 +2,6 @@
 # When test-data-shared is checked out alongside self, ADO places repos under
 # $(Build.SourcesDirectory)/<repo-name>. The self repo is 'Foundry-Local'.
 parameters:
-- name: version
-  type: string
-- name: isRelease
-  type: boolean
-  default: false
-- name: prereleaseId
-  type: string
-  default: ''
 - name: isWinML
   type: boolean
   default: false

--- a/.pipelines/templates/checkout-steps.yml
+++ b/.pipelines/templates/checkout-steps.yml
@@ -11,6 +11,10 @@ parameters:
   type: string
   default: 'refs/heads/main'
   displayName: 'Git ref to checkout (branch, tag, or commit SHA)'
+- name: refFile
+  type: string
+  default: ''
+  displayName: 'Optional file containing the exact git ref to checkout'
 - name: basePath
   type: string
   default: '$(Build.SourcesDirectory)'
@@ -27,7 +31,15 @@ steps:
       $ErrorActionPreference = 'Stop'
 
       $repoDir = "${{ parameters.basePath }}/${{ parameters.repoName }}"
-      $ref = "${{ parameters.ref }}"
+      $requestedRef = "${{ parameters.ref }}"
+      $ref = $requestedRef
+      $refFile = "${{ parameters.refFile }}"
+      if (-not [string]::IsNullOrWhiteSpace($refFile)) {
+        if (-not (Test-Path $refFile)) { throw "Ref file not found: $refFile" }
+        $ref = (Get-Content $refFile -Raw).Trim()
+        if ([string]::IsNullOrWhiteSpace($ref)) { throw "Ref file was empty: $refFile" }
+        Write-Host "Using ref from ${refFile}: $ref"
+      }
 
       # Obtain bearer token scoped to Azure DevOps
       $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
@@ -49,17 +61,40 @@ steps:
       git remote add origin $repoUrl
 
       # Fetch — use shallow clone for test-data-shared (no NBGV), full clone for others
-      $branch = $ref -replace '^refs/heads/', ''
       $repoName = '${{ parameters.repoName }}'
-      if ($repoName -eq 'test-data-shared') {
-        git fetch origin $branch --depth=1
-      } else {
-        git fetch origin $branch
+      $sourceBranch = $null
+      if ($requestedRef -match '^refs/heads/(.+)$') {
+        $sourceBranch = $Matches[1]
+      } elseif ($requestedRef -notmatch '^refs/' -and $requestedRef -notmatch '^[0-9a-fA-F]{40}$') {
+        $sourceBranch = $requestedRef
       }
-      if ($LASTEXITCODE -ne 0) { throw "git fetch failed for ${{ parameters.repoName }}" }
 
-      # Checkout
-      git checkout "origin/$branch" -B $branch
+      if ($ref -match '^[0-9a-fA-F]{40}$') {
+        if ($sourceBranch) {
+          git fetch origin $sourceBranch
+        } else {
+          git fetch origin $ref
+        }
+        if ($LASTEXITCODE -ne 0) { throw "git fetch failed for ${{ parameters.repoName }}" }
+
+        git checkout --detach $ref
+      } elseif ($ref -match '^refs/tags/(.+)$') {
+        $tag = $Matches[1]
+        git fetch origin "refs/tags/${tag}:refs/tags/${tag}"
+        if ($LASTEXITCODE -ne 0) { throw "git fetch failed for ${{ parameters.repoName }}" }
+
+        git checkout --detach "refs/tags/$tag"
+      } else {
+        $branch = $ref -replace '^refs/heads/', ''
+        if ($repoName -eq 'test-data-shared') {
+          git fetch origin $branch --depth=1
+        } else {
+          git fetch origin $branch
+        }
+        if ($LASTEXITCODE -ne 0) { throw "git fetch failed for ${{ parameters.repoName }}" }
+
+        git checkout "origin/$branch" -B $branch
+      }
       if ($LASTEXITCODE -ne 0) { throw "git checkout failed for ${{ parameters.repoName }} at ref $ref" }
 
       # LFS — enable for test-data-shared (contains LFS-tracked test data)

--- a/.pipelines/templates/checkout-steps.yml
+++ b/.pipelines/templates/checkout-steps.yml
@@ -10,7 +10,7 @@ parameters:
 - name: ref
   type: string
   default: 'refs/heads/main'
-  displayName: 'Git branch ref to checkout'
+  displayName: 'Git ref to checkout (branch, tag, or commit SHA)'
 - name: basePath
   type: string
   default: '$(Build.SourcesDirectory)'
@@ -48,7 +48,7 @@ steps:
       git init
       git remote add origin $repoUrl
 
-      # Fetch — use shallow clone for test-data-shared, full clone for others
+      # Fetch — use shallow clone for test-data-shared (no NBGV), full clone for others
       $branch = $ref -replace '^refs/heads/', ''
       $repoName = '${{ parameters.repoName }}'
       if ($repoName -eq 'test-data-shared') {
@@ -58,6 +58,7 @@ steps:
       }
       if ($LASTEXITCODE -ne 0) { throw "git fetch failed for ${{ parameters.repoName }}" }
 
+      # Checkout
       git checkout "origin/$branch" -B $branch
       if ($LASTEXITCODE -ne 0) { throw "git checkout failed for ${{ parameters.repoName }} at ref $ref" }
 

--- a/.pipelines/templates/checkout-steps.yml
+++ b/.pipelines/templates/checkout-steps.yml
@@ -10,11 +10,7 @@ parameters:
 - name: ref
   type: string
   default: 'refs/heads/main'
-  displayName: 'Git ref to checkout (branch, tag, or commit SHA)'
-- name: refFile
-  type: string
-  default: ''
-  displayName: 'Optional file containing the exact git ref to checkout'
+  displayName: 'Git branch ref to checkout'
 - name: basePath
   type: string
   default: '$(Build.SourcesDirectory)'
@@ -31,15 +27,7 @@ steps:
       $ErrorActionPreference = 'Stop'
 
       $repoDir = "${{ parameters.basePath }}/${{ parameters.repoName }}"
-      $requestedRef = "${{ parameters.ref }}"
-      $ref = $requestedRef
-      $refFile = "${{ parameters.refFile }}"
-      if (-not [string]::IsNullOrWhiteSpace($refFile)) {
-        if (-not (Test-Path $refFile)) { throw "Ref file not found: $refFile" }
-        $ref = (Get-Content $refFile -Raw).Trim()
-        if ([string]::IsNullOrWhiteSpace($ref)) { throw "Ref file was empty: $refFile" }
-        Write-Host "Using ref from ${refFile}: $ref"
-      }
+      $ref = "${{ parameters.ref }}"
 
       # Obtain bearer token scoped to Azure DevOps
       $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
@@ -60,41 +48,17 @@ steps:
       git init
       git remote add origin $repoUrl
 
-      # Fetch — use shallow clone for test-data-shared (no NBGV), full clone for others
+      # Fetch — use shallow clone for test-data-shared, full clone for others
+      $branch = $ref -replace '^refs/heads/', ''
       $repoName = '${{ parameters.repoName }}'
-      $sourceBranch = $null
-      if ($requestedRef -match '^refs/heads/(.+)$') {
-        $sourceBranch = $Matches[1]
-      } elseif ($requestedRef -notmatch '^refs/' -and $requestedRef -notmatch '^[0-9a-fA-F]{40}$') {
-        $sourceBranch = $requestedRef
-      }
-
-      if ($ref -match '^[0-9a-fA-F]{40}$') {
-        if ($sourceBranch) {
-          git fetch origin $sourceBranch
-        } else {
-          git fetch origin $ref
-        }
-        if ($LASTEXITCODE -ne 0) { throw "git fetch failed for ${{ parameters.repoName }}" }
-
-        git checkout --detach $ref
-      } elseif ($ref -match '^refs/tags/(.+)$') {
-        $tag = $Matches[1]
-        git fetch origin "refs/tags/${tag}:refs/tags/${tag}"
-        if ($LASTEXITCODE -ne 0) { throw "git fetch failed for ${{ parameters.repoName }}" }
-
-        git checkout --detach "refs/tags/$tag"
+      if ($repoName -eq 'test-data-shared') {
+        git fetch origin $branch --depth=1
       } else {
-        $branch = $ref -replace '^refs/heads/', ''
-        if ($repoName -eq 'test-data-shared') {
-          git fetch origin $branch --depth=1
-        } else {
-          git fetch origin $branch
-        }
-        if ($LASTEXITCODE -ne 0) { throw "git fetch failed for ${{ parameters.repoName }}" }
-
-        git checkout "origin/$branch" -B $branch
+        git fetch origin $branch
       }
+      if ($LASTEXITCODE -ne 0) { throw "git fetch failed for ${{ parameters.repoName }}" }
+
+      git checkout "origin/$branch" -B $branch
       if ($LASTEXITCODE -ne 0) { throw "git checkout failed for ${{ parameters.repoName }} at ref $ref" }
 
       # LFS — enable for test-data-shared (contains LFS-tracked test data)

--- a/.pipelines/templates/package-core-steps.yml
+++ b/.pipelines/templates/package-core-steps.yml
@@ -1,19 +1,11 @@
 # Steps to collect per-platform FLC native binaries, organize into NuGet layout,
 # pack + sign the NuGet package, and build Python wheels (wheel package name and
 # platforms depend on the isWinML parameter). The parent job must download all
-# platform artifacts and checkout neutron-server.
+# platform artifacts, the version-info artifact, and checkout neutron-server.
 parameters:
-- name: version
-  type: string
-- name: isRelease
-  type: boolean
-  default: false
 - name: isWinML
   type: boolean
   default: false
-- name: prereleaseId
-  type: string
-  default: ''
 - name: platforms
   type: object  # list of { name, artifactName }
 
@@ -165,14 +157,11 @@ steps:
       Copy-Item -Path $nupkg.FullName -Destination $nupkgZip -Force
       Expand-Archive -Path $nupkgZip -DestinationPath $extractDir -Force
 
-      # Convert NuGet version to PEP 440
-      # NuGet: 0.9.0-dev-202603271723-bb400310 → PEP 440: 0.9.0.dev202603271723
-      # The commit hash is dropped because .devN requires N to be a pure integer.
-      $nupkgVersion = $nupkg.BaseName -replace '^Microsoft\.AI\.Foundry\.Local\.Core(\.WinML)?\.', ''
-      $parts = $nupkgVersion -split '-'
-      $pyVersion = if ($parts.Count -ge 3 -and $parts[1] -eq 'dev') { "$($parts[0]).dev$($parts[2])" }
-                   elseif ($parts.Count -eq 2) { "$($parts[0])$($parts[1])" }
-                   else { $parts[0] }
+      # Use the Python-safe version computed from the same Core NBGV output as
+      # the NuGet version. Do not parse flcVersion here: non-public NBGV NuGet
+      # versions can include git prerelease labels that are not valid PEP 440.
+      $pyVersion = (Get-Content "$(Pipeline.Workspace)/version-info/pyVersion.txt" -Raw).Trim()
+      if ([string]::IsNullOrWhiteSpace($pyVersion)) { throw "Python version was empty" }
       Write-Host "Python package version: $pyVersion"
 
       $packageName = if ($isWinML) { "foundry_local_core_winml" } else { "foundry_local_core" }
@@ -260,11 +249,8 @@ steps:
 
       $isWinML = "${{ parameters.isWinML }}" -eq "True"
 
-      # Compute PEP 440 version from the NuGet flcVersion
-      $parts = "$(flcVersion)" -split '-'
-      $pyVer = if ($parts.Count -ge 3 -and $parts[1] -eq 'dev') { "$($parts[0]).dev$($parts[2])" }
-               elseif ($parts.Count -eq 2) { "$($parts[0])$($parts[1])" }
-               else { $parts[0] }
+      $pyVer = (Get-Content "$(Pipeline.Workspace)/version-info/pyVersion.txt" -Raw).Trim()
+      if ([string]::IsNullOrWhiteSpace($pyVer)) { throw "Python version was empty" }
 
       # Both standard and WinML write a deps_versions.json with identical key
       # structure. The pipeline produces separate artifacts (deps-versions-standard

--- a/.pipelines/templates/package-core-steps.yml
+++ b/.pipelines/templates/package-core-steps.yml
@@ -66,7 +66,7 @@ steps:
         Copy-Item $license "$unifiedPath/LICENSE.txt" -Force
       }
 
-# Read version from the version-info artifact produced by compute_version stage.
+# Read the Core package version resolved from the SDK dependency version files.
 - task: PowerShell@2
   displayName: 'Set FLC package version'
   inputs:
@@ -157,9 +157,8 @@ steps:
       Copy-Item -Path $nupkg.FullName -Destination $nupkgZip -Force
       Expand-Archive -Path $nupkgZip -DestinationPath $extractDir -Force
 
-      # Use the Python-safe version computed from the same Core NBGV output as
-      # the NuGet version. Do not parse flcVersion here: non-public NBGV NuGet
-      # versions can include git prerelease labels that are not valid PEP 440.
+      # Use the Python-safe version from version-info; Core NuGet and Python
+      # package versions are specified separately in the SDK dependency files.
       $pyVersion = (Get-Content "$(Pipeline.Workspace)/version-info/pyVersion.txt" -Raw).Trim()
       if ([string]::IsNullOrWhiteSpace($pyVersion)) { throw "Python version was empty" }
       Write-Host "Python package version: $pyVersion"
@@ -236,8 +235,9 @@ steps:
       Write-Host "`nAll wheels:"
       Get-ChildItem $stagingDir -Filter "*.whl" | ForEach-Object { Write-Host "  $($_.Name)" }
 
-# Write partial deps_versions.json for this variant. The merge_deps_versions
-# stage combines standard + WinML partials into a single complete artifact.
+# Write partial deps_versions.json for this variant. Core versions come from
+# version-info, while native dependency versions come from neutron-server.
+# The merge_deps_versions stage combines standard + WinML partials.
 - task: PowerShell@2
   displayName: 'Write deps_versions.json artifact'
   inputs:

--- a/sdk/cpp/CMakeLists.txt
+++ b/sdk/cpp/CMakeLists.txt
@@ -77,13 +77,34 @@ endif()
 # -----------------------------
 # Native dependencies (NuGet) — Windows only
 # Auto-download Core DLL and ONNX Runtime DLLs needed at runtime.
-# Versions are kept in sync with deps_versions.json.
+# Default versions come from sdk/deps_versions.json and can be overridden with
+# -DFL_CORE_VERSION=..., -DFL_ORT_VERSION=..., or -DFL_ORTGENAI_VERSION=....
 # -----------------------------
 if(WIN32)
 
-set(FL_CORE_VERSION "1.1.0" CACHE STRING "Microsoft.AI.Foundry.Local.Core NuGet version")
-set(FL_ORT_VERSION "1.25.1" CACHE STRING "Microsoft.ML.OnnxRuntime.Foundry NuGet version")
-set(FL_ORTGENAI_VERSION "0.13.2" CACHE STRING "Microsoft.ML.OnnxRuntimeGenAI.Foundry NuGet version")
+set(FL_DEPS_VERSIONS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../deps_versions.json" CACHE FILEPATH "Foundry Local dependency versions file")
+if(NOT EXISTS "${FL_DEPS_VERSIONS_FILE}")
+    message(FATAL_ERROR "Dependency versions file not found: ${FL_DEPS_VERSIONS_FILE}")
+endif()
+
+file(READ "${FL_DEPS_VERSIONS_FILE}" FL_DEPS_VERSIONS_JSON)
+string(JSON FL_CORE_VERSION_DEFAULT ERROR_VARIABLE FL_CORE_VERSION_ERROR GET "${FL_DEPS_VERSIONS_JSON}" "foundry-local-core" "nuget")
+string(JSON FL_ORT_VERSION_DEFAULT ERROR_VARIABLE FL_ORT_VERSION_ERROR GET "${FL_DEPS_VERSIONS_JSON}" "onnxruntime" "version")
+string(JSON FL_ORTGENAI_VERSION_DEFAULT ERROR_VARIABLE FL_ORTGENAI_VERSION_ERROR GET "${FL_DEPS_VERSIONS_JSON}" "onnxruntime-genai" "version")
+
+if(NOT FL_CORE_VERSION_ERROR STREQUAL "NOTFOUND")
+    message(FATAL_ERROR "Failed to read foundry-local-core.nuget from ${FL_DEPS_VERSIONS_FILE}: ${FL_CORE_VERSION_ERROR}")
+endif()
+if(NOT FL_ORT_VERSION_ERROR STREQUAL "NOTFOUND")
+    message(FATAL_ERROR "Failed to read onnxruntime.version from ${FL_DEPS_VERSIONS_FILE}: ${FL_ORT_VERSION_ERROR}")
+endif()
+if(NOT FL_ORTGENAI_VERSION_ERROR STREQUAL "NOTFOUND")
+    message(FATAL_ERROR "Failed to read onnxruntime-genai.version from ${FL_DEPS_VERSIONS_FILE}: ${FL_ORTGENAI_VERSION_ERROR}")
+endif()
+
+set(FL_CORE_VERSION "${FL_CORE_VERSION_DEFAULT}" CACHE STRING "Microsoft.AI.Foundry.Local.Core NuGet version")
+set(FL_ORT_VERSION "${FL_ORT_VERSION_DEFAULT}" CACHE STRING "Microsoft.ML.OnnxRuntime.Foundry NuGet version")
+set(FL_ORTGENAI_VERSION "${FL_ORTGENAI_VERSION_DEFAULT}" CACHE STRING "Microsoft.ML.OnnxRuntimeGenAI.Foundry NuGet version")
 set(FL_NATIVE_DEPS_DIR "${CMAKE_CURRENT_BINARY_DIR}/_native_deps")
 
 function(fl_ensure_nuget_package PKG_NAME PKG_VERSION)

--- a/sdk/cpp/README.md
+++ b/sdk/cpp/README.md
@@ -497,8 +497,8 @@ sdk/cpp/
 | Error | Cause | Fix |
 |---|---|---|
 | `DML provider requested, but GenAI has not been built with DML support` | GPU variant selected but ONNX Runtime GenAI lacks DML | Select a CPU variant or update Foundry Local |
-| `OgaGenerator_TokenCount not found in onnxruntime-genai` | Version mismatch between Foundry Local components | Update NuGet package versions in CMakeLists.txt |
-| `API version [N] is not available` | ONNX Runtime version too old for the Foundry Local service | Update NuGet package versions in CMakeLists.txt |
+| `OgaGenerator_TokenCount not found in onnxruntime-genai` | Version mismatch between Foundry Local components | Update package versions in `sdk/deps_versions.json` |
+| `API version [N] is not available` | ONNX Runtime version too old for the Foundry Local service | Update package versions in `sdk/deps_versions.json` |
 | `nuget.exe not found on PATH` | NuGet CLI not installed | Install via `winget install Microsoft.NuGet` |
 | `Failed to load shared library: Microsoft.AI.Foundry.Local.Core.dll` | Runtime DLLs not next to executable | Reconfigure with `cmake --preset x64-debug` to re-download NuGet packages, then rebuild |
 | NuGet packages not installed or DLLs not copied correctly | Stale or corrupted build cache | Delete the `out` folder (`rmdir /s /q out`) and reconfigure from scratch: `cmake --preset x64-debug && cmake --build --preset x64-debug` |


### PR DESCRIPTION
## Summary
- Derive SDK packaging versions from the selected Foundry Local Core branch via NBGV instead of a manual pipeline version parameter.
- Carry shared SemVer, PEP 440, and Core NuGet version files through the existing `version-info` artifact so all SDK package formats come from the same Core version source.
- Use the computed Python-safe version for Core wheels and generated `deps_versions*.json`.
- Read C++ SDK native dependency defaults from `sdk/deps_versions.json` instead of hard-coding Core/ORT package versions in CMake.

## Validation
- Parsed changed Azure Pipeline YAML files with PyYAML.
- Validated CMake JSON extraction for `sdk/deps_versions.json`.
- Validated Core-derived version outputs against the current `bhamehta/filter-min-fl-version` Core branch for dev, release, and explicit prerelease cases.