### PR TITLE
Bump Foundry Local Core to 1.2.0 (with ORT 1.26.0 / ORT-GenAI 0.14.0)

### DIFF
--- a/sdk/cpp/CMakeLists.txt
+++ b/sdk/cpp/CMakeLists.txt
@@ -81,9 +81,9 @@ endif()
 # -----------------------------
 if(WIN32)
 
-set(FL_CORE_VERSION "1.1.0" CACHE STRING "Microsoft.AI.Foundry.Local.Core NuGet version")
-set(FL_ORT_VERSION "1.25.1" CACHE STRING "Microsoft.ML.OnnxRuntime.Foundry NuGet version")
-set(FL_ORTGENAI_VERSION "0.13.2" CACHE STRING "Microsoft.ML.OnnxRuntimeGenAI.Foundry NuGet version")
+set(FL_CORE_VERSION "1.2.0" CACHE STRING "Microsoft.AI.Foundry.Local.Core NuGet version")
+set(FL_ORT_VERSION "1.26.0" CACHE STRING "Microsoft.ML.OnnxRuntime.Foundry NuGet version")
+set(FL_ORTGENAI_VERSION "0.14.0" CACHE STRING "Microsoft.ML.OnnxRuntimeGenAI.Foundry NuGet version")
 set(FL_NATIVE_DEPS_DIR "${CMAKE_CURRENT_BINARY_DIR}/_native_deps")
 
 function(fl_ensure_nuget_package PKG_NAME PKG_VERSION)

--- a/sdk/cpp/README.md
+++ b/sdk/cpp/README.md
@@ -61,9 +61,9 @@ This uses the `x64-debug` preset which:
 - Resolves C++ dependencies via **vcpkg** (`nlohmann-json`, `ms-gsl`, `gtest`)
 - Builds with the `x64-windows-static-md` triplet
 - Auto-downloads native runtime DLLs via **NuGet**:
-  - `Microsoft.AI.Foundry.Local.Core` (1.1.0) — Foundry Local core runtime
-  - `Microsoft.ML.OnnxRuntime.Foundry` (1.25.1) — ONNX Runtime
-  - `Microsoft.ML.OnnxRuntimeGenAI.Foundry` (0.13.2) — ONNX Runtime GenAI
+  - `Microsoft.AI.Foundry.Local.Core` (1.2.0) — Foundry Local core runtime
+  - `Microsoft.ML.OnnxRuntime.Foundry` (1.26.0) — ONNX Runtime
+  - `Microsoft.ML.OnnxRuntimeGenAI.Foundry` (0.14.0) — ONNX Runtime GenAI
 
 NuGet packages are cached in `out/build/<preset>/_native_deps/` and only downloaded on first configure. Runtime DLLs are automatically copied next to executables via post-build steps.
 

--- a/sdk/deps_versions.json
+++ b/sdk/deps_versions.json
@@ -1,7 +1,7 @@
 {
   "foundry-local-core": {
-    "nuget": "1.1.0",
-    "python": "1.1.0"
+    "nuget": "1.2.0",
+    "python": "1.2.0"
   },
   "onnxruntime": {
     "version": "1.26.0"

--- a/sdk/deps_versions_winml.json
+++ b/sdk/deps_versions_winml.json
@@ -1,15 +1,15 @@
 {
   "foundry-local-core": {
-    "nuget": "1.1.0",
-    "python": "1.1.0"
+    "nuget": "1.2.0",
+    "python": "1.2.0"
   },
   "windows-ai-machinelearning": {
     "version": "2.1.1"
   },
   "onnxruntime": {
-    "version": "1.25.1"
+    "version": "1.26.0"
   },
   "onnxruntime-genai": {
-    "version": "0.13.2"
+    "version": "0.14.0"
   }
 }

--- a/sdk/python/requirements-winml.txt
+++ b/sdk/python/requirements-winml.txt
@@ -2,6 +2,6 @@ pydantic>=2.0.0
 requests>=2.32.4
 openai>=2.24.0
 # WinML native binary packages from the ORT-Nightly PyPI feed.
-foundry-local-core-winml==1.1.0
-onnxruntime-core==1.23.2.3
-onnxruntime-genai-core==0.13.2
+foundry-local-core-winml==1.2.0
+onnxruntime-core==1.26.0
+onnxruntime-genai-core==0.14.0

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -5,7 +5,7 @@ openai>=2.24.0
 # - Linux x86_64:   onnxruntime-gpu / onnxruntime-genai-cuda (CUDA-enabled wheels).
 # - Linux aarch64:  onnxruntime / onnxruntime-genai (the CUDA variants do not ship aarch64 binaries).
 # - Other platforms: onnxruntime-core / onnxruntime-genai-core (cross-platform variants).
-foundry-local-core==1.1.0
+foundry-local-core==1.2.0
 onnxruntime-core==1.26.0; sys_platform != "linux"
 onnxruntime-gpu==1.26.0; sys_platform == "linux" and platform_machine == "x86_64"
 onnxruntime==1.26.0; sys_platform == "linux" and platform_machine == "aarch64"


### PR DESCRIPTION
Bumps Foundry Local Core pins from 1.1.0 to 1.2.0 in lockstep with the neutron-server `releases/core/rel-1.2.0` cut, and aligns the cpp + WinML ORT / ORT-GenAI pins to what neutron-server 1.2.0 ships (ORT 1.26.0 / ORT-GenAI 0.14.0).

## Files changed

| File | Change |
|------|--------|
| `sdk/deps_versions.json` | `foundry-local-core` nuget/python 1.1.0 -> 1.2.0 |
| `sdk/deps_versions_winml.json` | `foundry-local-core` nuget/python 1.1.0 -> 1.2.0; `onnxruntime` 1.25.1 -> 1.26.0; `onnxruntime-genai` 0.13.2 -> 0.14.0 |
| `sdk/python/requirements.txt` | `foundry-local-core` 1.1.0 -> 1.2.0 |
| `sdk/python/requirements-winml.txt` | `foundry-local-core-winml` 1.1.0 -> 1.2.0; `onnxruntime-core` 1.23.2.3 -> 1.26.0; `onnxruntime-genai-core` 0.13.2 -> 0.14.0 |
| `sdk/cpp/CMakeLists.txt` | `FL_CORE_VERSION` 1.1.0 -> 1.2.0; `FL_ORT_VERSION` 1.25.1 -> 1.26.0; `FL_ORTGENAI_VERSION` 0.13.2 -> 0.14.0 |
| `sdk/cpp/README.md` | Matching version doc updates |

This PR targets `main`; the changes will be cherry-picked into `releases/rel-1.2.0` separately.