### PR TITLE
Load WinML runtime DLL for SDK EP discovery

### DIFF
--- a/sdk/cs/src/Detail/CoreInterop.cs
+++ b/sdk/cs/src/Detail/CoreInterop.cs
@@ -32,9 +32,6 @@ internal partial class CoreInterop : ICoreInterop
 
     private static IntPtr genaiLibHandle = IntPtr.Zero;
     private static IntPtr ortLibHandle = IntPtr.Zero;
-#if IS_WINML
-    private static IntPtr winmlLibHandle = IntPtr.Zero;
-#endif
     private static readonly NativeCallbackFn handleCallbackDelegate = HandleCallback;
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -87,7 +84,7 @@ internal partial class CoreInterop : ICoreInterop
         IsMacOS ? $"{name}.dylib" :
         throw new PlatformNotSupportedException();
 
-    // We need to manually load ORT, ORT GenAI, and WinML runtime dlls on Windows to ensure
+    // We need to manually load ORT and ORT GenAI dlls on Windows to ensure
     // a) we're using the libraries we think we are
     // b) that dependencies are resolved correctly as the dlls may not be in the default load path.
     // It's a 'Try' as we can't do anything else if it fails as the dlls may be available somewhere else.
@@ -106,13 +103,6 @@ internal partial class CoreInterop : ICoreInterop
 
         Debug.WriteLine($"Loaded ORT:{loadedOrt} handle={ortLibHandle}");
         Debug.WriteLine($"Loaded GenAI: {loadedGenAI} handle={genaiLibHandle}");
-
-#if IS_WINML
-        var winmlLibName = AddLibraryExtension("Microsoft.Windows.AI.MachineLearning");
-        var winmlPath = Path.Combine(path, winmlLibName);
-        var loadedWinML = TryLoadNativeLibrary(winmlPath, out winmlLibHandle);
-        Debug.WriteLine($"Loaded WinML: {loadedWinML} handle={winmlLibHandle}");
-#endif
     }
 
     private static int HandleCallback(nint data, int length, nint callbackHelper)

--- a/sdk/cs/src/Detail/CoreInterop.cs
+++ b/sdk/cs/src/Detail/CoreInterop.cs
@@ -32,6 +32,9 @@ internal partial class CoreInterop : ICoreInterop
 
     private static IntPtr genaiLibHandle = IntPtr.Zero;
     private static IntPtr ortLibHandle = IntPtr.Zero;
+#if IS_WINML
+    private static IntPtr winmlLibHandle = IntPtr.Zero;
+#endif
     private static readonly NativeCallbackFn handleCallbackDelegate = HandleCallback;
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -84,7 +87,7 @@ internal partial class CoreInterop : ICoreInterop
         IsMacOS ? $"{name}.dylib" :
         throw new PlatformNotSupportedException();
 
-    // We need to manually load ORT and ORT GenAI dlls on Windows to ensure
+    // We need to manually load ORT, ORT GenAI, and WinML runtime dlls on Windows to ensure
     // a) we're using the libraries we think we are
     // b) that dependencies are resolved correctly as the dlls may not be in the default load path.
     // It's a 'Try' as we can't do anything else if it fails as the dlls may be available somewhere else.
@@ -103,6 +106,13 @@ internal partial class CoreInterop : ICoreInterop
 
         Debug.WriteLine($"Loaded ORT:{loadedOrt} handle={ortLibHandle}");
         Debug.WriteLine($"Loaded GenAI: {loadedGenAI} handle={genaiLibHandle}");
+
+#if IS_WINML
+        var winmlLibName = AddLibraryExtension("Microsoft.Windows.AI.MachineLearning");
+        var winmlPath = Path.Combine(path, winmlLibName);
+        var loadedWinML = TryLoadNativeLibrary(winmlPath, out winmlLibHandle);
+        Debug.WriteLine($"Loaded WinML: {loadedWinML} handle={winmlLibHandle}");
+#endif
     }
 
     private static int HandleCallback(nint data, int length, nint callbackHelper)

--- a/sdk/python/src/detail/core_interop.py
+++ b/sdk/python/src/detail/core_interop.py
@@ -186,7 +186,14 @@ class CoreInterop:
             winml_path = paths.core_dir / "Microsoft.Windows.AI.MachineLearning.dll"
             if winml_path.exists():
                 # only exists in the WinML variant, load if present so that Core can use WinML EPs
-                CoreInterop._winml_library = ctypes.CDLL(str(winml_path))
+                try:
+                    CoreInterop._winml_library = ctypes.CDLL(str(winml_path))
+                except OSError as e:
+                    logger.warning(
+                        "Failed to load optional WinML library '%s'; continuing without WinML EPs: %s",
+                        winml_path,
+                        e,
+                    )
         else:
             CoreInterop._ort_library = ctypes.CDLL(str(paths.ort), mode=os.RTLD_GLOBAL)
             CoreInterop._genai_library = ctypes.CDLL(str(paths.genai), mode=os.RTLD_GLOBAL)

--- a/sdk/python/src/detail/core_interop.py
+++ b/sdk/python/src/detail/core_interop.py
@@ -132,6 +132,7 @@ class CoreInterop:
     _flcore_library = None
     _genai_library = None
     _ort_library = None
+    _winml_library = None
 
     instance = None
 
@@ -182,6 +183,10 @@ class CoreInterop:
         if sys.platform.startswith("win"):
             CoreInterop._ort_library = ctypes.CDLL(str(paths.ort))
             CoreInterop._genai_library = ctypes.CDLL(str(paths.genai))
+            winml_path = paths.core_dir / "Microsoft.Windows.AI.MachineLearning.dll"
+            if winml_path.exists():
+                # only exists in the WinML variant, load if present so that Core can use WinML EPs
+                CoreInterop._winml_library = ctypes.CDLL(str(winml_path))
         else:
             CoreInterop._ort_library = ctypes.CDLL(str(paths.ort), mode=os.RTLD_GLOBAL)
             CoreInterop._genai_library = ctypes.CDLL(str(paths.genai), mode=os.RTLD_GLOBAL)

--- a/sdk/rust/src/detail/core_interop.rs
+++ b/sdk/rust/src/detail/core_interop.rs
@@ -787,6 +787,25 @@ impl CoreInterop {
             }
         }
 
+        #[cfg(feature = "winml")]
+        {
+            let winml_dep = "Microsoft.Windows.AI.MachineLearning.dll";
+            let winml_path = dir.join(winml_dep);
+            if winml_path.exists() {
+                // The WinML feature uses the WinML Core package and copies this
+                // DLL into the native directory; load it from there so callers
+                // don't need to add that directory to PATH.
+                // SAFETY: Pre-loading a known dependency DLL from the same trusted
+                // directory as the core library.
+                let lib = unsafe {
+                    Library::new(&winml_path).map_err(|e| FoundryLocalError::LibraryLoad {
+                        reason: format!("Failed to load dependency {winml_dep}: {e}"),
+                    })?
+                };
+                libs.push(lib);
+            }
+        }
+
         Ok(libs)
     }
 }


### PR DESCRIPTION
## Summary
- Load `Microsoft.Windows.AI.MachineLearning.dll` from the Core native directory for the Python SDK when present.
- Preload the same WinML runtime DLL for Rust `winml` builds from the native runtime directory.
- Preload the WinML runtime DLL for C# WinML builds alongside ORT and ORT GenAI.
- No JS SDK code change needed; its existing loader already handles the native runtime directory.

## Validation
- Rust WinML EP smoke without a caller PATH override discovered CUDA, OpenVINO, and NvTensorRTRTX, then registered OpenVINO.
- C# WinML source smoke without a caller PATH override discovered CUDA, OpenVINO, and NvTensorRTRTX, then registered OpenVINO.
- JS EP smoke without a caller PATH override discovered CUDA, OpenVINO, and NvTensorRTRTX, then registered OpenVINO.