### PR TITLE
fix(deps): resolve all 26 open Dependabot security alerts + enable automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,104 @@
+# Dependabot configuration for Foundry-Local.
+# Enables weekly version updates across all package ecosystems in the repo.
+# Security updates are managed separately in repository settings
+# (Settings -> Code security -> Dependabot security updates).
+#
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # ----- GitHub Actions -----
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - github-actions
+
+  # ----- npm: SDKs + website -----
+  - package-ecosystem: npm
+    directories:
+      - /sdk/js
+      - /sdk_legacy/js
+      - /www
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - javascript
+
+  # ----- npm: JS samples -----
+  - package-ecosystem: npm
+    directories:
+      - /samples/js/audio-transcription-example
+      - /samples/js/chat-and-audio-foundry-local
+      - /samples/js/copilot-sdk-foundry-local
+      - /samples/js/electron-chat-application
+      - /samples/js/embeddings
+      - /samples/js/langchain-integration-example
+      - /samples/js/live-audio-transcription
+      - /samples/js/native-chat-completions
+      - /samples/js/tool-calling-foundry-local
+      - /samples/js/tutorial-chat-assistant
+      - /samples/js/tutorial-document-summarizer
+      - /samples/js/tutorial-tool-calling
+      - /samples/js/tutorial-voice-to-text
+      - /samples/js/verify-winml
+      - /samples/js/web-server-example
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - javascript
+      - samples
+
+  # ----- Python: SDK + samples -----
+  - package-ecosystem: pip
+    directories:
+      - /sdk/python
+      - /samples/python/audio-transcription
+      - /samples/python/embeddings
+      - /samples/python/langchain-integration
+      - /samples/python/live-audio-transcription
+      - /samples/python/native-chat-completions
+      - /samples/python/tool-calling
+      - /samples/python/tutorial-chat-assistant
+      - /samples/python/tutorial-document-summarizer
+      - /samples/python/tutorial-tool-calling
+      - /samples/python/tutorial-voice-to-text
+      - /samples/python/verify-winml
+      - /samples/python/web-server
+      - /samples/python/web-server-responses
+      - /samples/python/web-server-responses-vision
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - python
+
+  # ----- .NET / NuGet: SDK -----
+  - package-ecosystem: nuget
+    directories:
+      - /sdk/cs/src
+      - /sdk/cs/test
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - dotnet
+
+  # ----- Rust: SDK -----
+  - package-ecosystem: cargo
+    directory: /sdk/rust
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - rust

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,55 @@
+# Auto-merge Dependabot PRs.
+#
+# Behavior:
+#   - Security updates of any semver level: auto-approve + enable auto-merge (squash).
+#   - Non-security patch / minor updates: auto-approve + enable auto-merge.
+#   - Major version bumps: only auto-approve; a human reviewer must merge.
+#
+# Requirements (enable in repo settings if not already):
+#   - Settings -> General -> "Allow auto-merge"
+#   - Settings -> Code security -> "Dependabot security updates" = enabled
+#   - A branch protection rule on the default branch with required status checks
+#     so auto-merge waits for CI to pass before merging.
+#
+# Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for security updates
+        if: steps.meta.outputs.alert-state == 'AUTO_DISMISSED' || steps.meta.outputs.ghsa-id != ''
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch/minor version updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -40,15 +40,14 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge for security updates
-        if: steps.meta.outputs.alert-state == 'AUTO_DISMISSED' || steps.meta.outputs.ghsa-id != ''
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable auto-merge for patch/minor version updates
-        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+      # Auto-merge when: patch or minor update (any), OR security update that is NOT a major bump.
+      # Major version bumps (including security) are approved above but must be merged by a human.
+      - name: Enable auto-merge for eligible updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+          (steps.meta.outputs.ghsa-id != '' &&
+           steps.meta.outputs.update-type != 'version-update:semver-major')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/samples/js/electron-chat-application/package.json
+++ b/samples/js/electron-chat-application/package.json
@@ -16,6 +16,6 @@
     "foundry-local-sdk-winml": "latest"
   },
   "devDependencies": {
-    "electron": "^34.5.8"
+    "electron": "^39.8.5"
   }
 }

--- a/samples/js/langchain-integration-example/package.json
+++ b/samples/js/langchain-integration-example/package.json
@@ -7,7 +7,7 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "@langchain/core": "latest",
+    "@langchain/core": "^0.3.80",
     "@langchain/openai": "latest",
     "foundry-local-sdk": "latest"
   },

--- a/sdk_legacy/js/package-lock.json
+++ b/sdk_legacy/js/package-lock.json
@@ -748,19 +748,6 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@rollup/plugin-json": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
@@ -850,19 +837,6 @@
         "rollup": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2542,9 +2516,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4730,9 +4704,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -5063,13 +5037,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -5098,9 +5072,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -5118,7 +5092,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6392,19 +6366,6 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tinypool": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
@@ -6735,9 +6696,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6845,19 +6806,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vitest": {

--- a/sdk_legacy/js/package-lock.json
+++ b/sdk_legacy/js/package-lock.json
@@ -4579,6 +4579,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -6806,6 +6819,19 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vitest": {

--- a/sdk_legacy/js/package.json
+++ b/sdk_legacy/js/package.json
@@ -53,6 +53,9 @@
     "postcss": "^8.5.10",
     "vite": "^6.4.2",
     "defu": "^6.1.5",
-    "picomatch": "^4.0.4"
+    "picomatch": "^2.3.2",
+    "@rollup/plugin-commonjs": { "picomatch": "^4.0.4" },
+    "@rollup/pluginutils": { "picomatch": "^4.0.4" },
+    "tinyglobby": { "picomatch": "^4.0.4" }
   }
 }

--- a/sdk_legacy/js/package.json
+++ b/sdk_legacy/js/package.json
@@ -48,5 +48,11 @@
     "typescript": "^5.2.2",
     "unbuild": "^3.5.0",
     "vitest": "^3.1.3"
+  },
+  "overrides": {
+    "postcss": "^8.5.10",
+    "vite": "^6.4.2",
+    "defu": "^6.1.5",
+    "picomatch": "^4.0.4"
   }
 }

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -2308,9 +2308,9 @@
 			}
 		},
 		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -3186,9 +3186,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {

--- a/www/package.json
+++ b/www/package.json
@@ -52,6 +52,10 @@
 	"dependencies": {
 		"@vercel/analytics": "^2.0.1"
 	},
+	"overrides": {
+		"picomatch": "^4.0.4",
+		"cookie": "^0.7.0"
+	},
 	"keywords": [
 		"microsoft",
 		"azure",
@@ -62,4 +66,3 @@
 		"llm"
 	]
 }
-


### PR DESCRIPTION
Resolves all 26 open Dependabot security alerts and adds ongoing automation.

## Fixes
- **electron** bump ^34->^39.8.5 (15 CVEs in electron-chat-application)
- **postcss** override ^8.5.10, **vite** ^6.4.2, **defu** ^6.1.5, **picomatch** ^4.0.4 (sdk_legacy/js transitive deps)
- **picomatch** ^4.0.4, **cookie** ^0.7.0 (www transitive deps)
- **@langchain/core** pinned ^0.3.80 (langchain-integration-example)

## Automation added
- \.github/dependabot.yml\ — weekly version updates for npm, pip, NuGet, Cargo, GitHub Actions
- \.github/workflows/dependabot-auto-merge.yml\ — auto-approve + auto-merge Dependabot patch/minor/security PRs after CI passes; major bumps require human merge