### PR TITLE
Fix .github/dependabot.yml schema (set package-ecosystem to github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

Fixes the `.github/dependabot.yml` check that has been failing on every PR
opened since 5/27 (e.g. #727).

## Root cause

The Dependabot config file added in commit 33a1a2f (`Add Dependabot configuration file`) contains an unfilled template — `package-ecosystem` is set to the empty string `""`, which fails Dependabot's schema validation:

> The property `'#/updates/0/package-ecosystem'` value `""` did not match
> one of the following values: npm, bundler, composer, devcontainers,
> dotnet-sdk, maven, mix, cargo, gradle, nuget, gomod, docker,
> docker-compose, elm, gitsubmodule, github-actions, pip, terraform, pub,
> rust-toolchain, sbt, swift, bun, uv, vcpkg, helm, conda, julia, bazel,
> opentofu, pre-commit, nix, deno

The validation check is only run on **pull requests**, not on direct commits to `main`, so the broken template slipped in unnoticed and every new PR now hits a red `.github/dependabot.yml` check.

## Change

Replace the empty `package-ecosystem: ""` placeholder with `"github-actions"`. This:

- Makes the file schema-valid → CI check passes on all future PRs.
- Opts in only to GitHub Actions updates (low noise — the repo has 1 workflow file under `.github/workflows/`).
- Leaves all other ecosystems unconfigured. Adding `npm`, `pip`, `cargo`, `nuget`, `vcpkg`, etc. is a separate decision that whoever owns those Dependabot update PRs should make in follow-up changes.

## Diff

```diff
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
```

## Scope

One file, two lines. Intentionally narrow — this is **not** an "enable Dependabot for the whole repo" PR. It is the minimum required to stop blocking unrelated PRs on a schema error.
