### PR TITLE
Add `cli/` folder for the Foundry Local CLI 0.10.0 preview

### DIFF
--- a/cli/LICENSE.txt
+++ b/cli/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,56 @@
+# Foundry Local CLI
+
+> [!IMPORTANT]
+> **Preview.** This is an early build — expect rough edges, missing polish, and changes between releases. Please [file issues](https://github.com/microsoft/Foundry-Local/issues) for anything you hit. For application integration, use the [Foundry Local SDKs](../sdk/) (C#, JavaScript, Python, Rust) — that is the supported surface.
+
+## Install
+
+Binaries are published as assets on the [GitHub Releases](https://github.com/microsoft/Foundry-Local/releases) page.
+
+| Platform | Asset |
+|---|---|
+| Windows x64 | `foundry-<version>-win-x64-winml.msix` (recommended) or `-win-x64.msix` |
+| Windows ARM64 | `foundry-<version>-win-arm64-winml.msix` (recommended) or `-win-arm64.msix` |
+| macOS (Apple Silicon) | `foundry-<version>-osx-arm64.zip` |
+| Linux x64 | `foundry-<version>-linux-x64.tar.gz` |
+| Linux ARM64 | `foundry-<version>-linux-arm64.tar.gz` |
+
+On Windows and macOS you can also double-click the `.msix` or `.zip` to install with the OS installer. The commands below are the scripted equivalents.
+
+```powershell
+# Windows
+Add-AppxPackage .\foundry-<version>-win-x64-winml.msix
+foundry --version
+```
+
+```bash
+# macOS
+unzip foundry-<version>-osx-arm64.zip -d ~/foundry-cli
+~/foundry-cli/foundry --version
+
+# Linux
+tar xzf foundry-<version>-linux-x64.tar.gz
+./foundry/foundry --version
+```
+
+## Quick start
+
+```text
+foundry status                    # daemon + hardware + execution providers
+foundry model list                # available models
+foundry model load qwen3-0.6b     # download (if needed) and load
+foundry chat qwen3-0.6b           # interactive chat
+foundry server stop               # release the daemon when done
+```
+
+Most commands accept `--output json` for scripting. Run `foundry --help` for the full command surface.
+
+## Links
+
+- Docs: <https://aka.ms/foundry-local-docs>
+- Discord: <https://aka.ms/foundry-local-discord>
+- Issues: <https://github.com/microsoft/Foundry-Local/issues> (please tag titles with `[cli]`)
+
+## License
+
+MIT License — see [LICENSE.txt](./LICENSE.txt).

--- a/cli/RELEASE-NOTES-0.10.0.md
+++ b/cli/RELEASE-NOTES-0.10.0.md
@@ -1,0 +1,76 @@
+# Foundry Local CLI 0.10.0 (Preview)
+
+First public preview of the Foundry Local CLI.
+
+> [!IMPORTANT]
+> **Preview.** This is an early build — expect rough edges, missing polish, and changes between releases. Please [file issues](https://github.com/microsoft/Foundry-Local/issues) (tag titles with `[cli]`) for anything you hit. For application integration, use the [Foundry Local SDKs](https://github.com/microsoft/Foundry-Local/tree/main/sdk).
+
+## Coming from the older Foundry Local CLI?
+
+The earlier service-based CLI (required to use Foundry Local before the SDKs shipped) has been replaced. Common commands map roughly as follows:
+
+| Old (service-based CLI) | New |
+|---|---|
+| `foundry service start` / `stop` / `restart` / `ps` / `diag` | `foundry server start` / `stop` / `restart` / `logs` |
+| `foundry cache remove` | `foundry cache rm` |
+| `foundry model run <alias>` | `foundry run <alias>` |
+| `foundry model info <alias>` | `foundry model show <alias>` |
+
+Run `foundry --help` for the full surface.
+
+## New
+
+- `--output json` on `status`, `model list`, `model show`, `cache list`, `complete`, `transcribe`
+- `-f, --force` on `foundry config set` (required for non-interactive use)
+- `-f, --file <path>` on `foundry transcribe`
+- `-p, --port` and `--idle-timeout` on `foundry server start`
+- `foundry config reset <key>`
+
+## Notes
+
+- **PowerShell, UTF-8.** PowerShell's default console encoding (`ibm437`) renders the CLI's status glyphs as mojibake. Run `[Console]::OutputEncoding = [Text.Encoding]::UTF8` once per session, or add it to your `$PROFILE`.
+- **Reasoning models.** For models that emit `<think>` reasoning blocks (e.g. `qwen3-0.6b`), prefer `foundry chat` or `foundry complete ... --output json`. Text-mode `complete` does not render reasoning output well in this release.
+
+## Install
+
+```powershell
+# Windows
+Add-AppxPackage .\foundry-0.10.0-win-x64-winml.msix
+```
+
+```bash
+# macOS
+unzip foundry-0.10.0-osx-arm64.zip -d ~/foundry-cli
+
+# Linux
+tar xzf foundry-0.10.0-linux-x64.tar.gz
+```
+
+The Linux x64 build is ~347 MB because it bundles the CUDA execution provider. All other builds are 25–110 MB.
+
+## Verify
+
+All binaries are signed by Microsoft Corporation. Verify hashes against `SHA256SUMS.txt`:
+
+```powershell
+Get-FileHash .\foundry-0.10.0-win-x64-winml.msix -Algorithm SHA256
+```
+
+```bash
+shasum -a 256 -c SHA256SUMS.txt
+```
+
+## Feedback
+
+File issues at <https://github.com/microsoft/Foundry-Local/issues> with the `[cli]` tag and include the output of `foundry report`.
+
+---
+
+## Appendix — Why the command renames
+
+For users coming from the older service-based CLI, the rationale behind each rename:
+
+- **`service` → `server`.** The component is an HTTP server, not a Windows service or systemd unit. `server` matches what every other OpenAI-compatible tool calls the same thing (e.g. `ollama serve`, `llama-server`, `vllm serve`).
+- **`cache remove` → `cache rm`.** Shorter, and aligns with the `rm` / `del` verbs every shell already uses. `cache clear` (whole-cache) is kept distinct.
+- **`model run` → `run`.** Loading and inferring is the most common reason to launch the CLI; promoting it to a top-level verb avoids the `model run model-name` stutter.
+- **`model info` → `model show`.** Matches the convention used by `kubectl`, `docker`, `git remote`, and most modern CLIs, where `show` is the read verb for a single named resource.


### PR DESCRIPTION
# Add `cli/` folder for the Foundry Local CLI preview

## What this PR does

Adds a new top-level `cli/` folder with documentation for the Foundry Local CLI 0.10.0 preview. **No binaries are committed to the repo** — the 8 signed binaries ship as assets on the GitHub Release tagged `cli-preview-0.10.0` (created separately after this PR merges).

```
cli/
├── README.md                 (~2 KB) — what the CLI is, install per OS, quick start, links
├── RELEASE-NOTES-0.10.0.md   (~3 KB) — body for the GitHub Release page
└── LICENSE.txt               (~1 KB) — MIT (same as the SDKs in this repo)
```

## Why this folder, and why now

The Foundry Local CLI has been an internal tool until now. With 0.10.0 we are publishing a **public preview** so external users can try it directly from the terminal. The folder exists to:

1. Give the binary release a documented home in the public repo
2. Set explicit expectations that this is a preview (rough edges expected, please file issues)
3. Make clear that the **SDKs remain the supported integration surface** — the CLI is an optional companion tool, not a required dependency

## Positioning (important)

- The CLI is preview-tier and the surface may change.
- The CLI is **optional**. The Foundry Local SDKs (C#, JavaScript, Python, Rust) are the supported contract for application integration.
- This preview ships under **MIT** license, matching the SDKs already in this repo.

## Version

`0.10.0` (intentionally sub-1.0 to signal preview status). The corresponding GitHub Release will be tagged `cli-preview-0.10.0` with the `prerelease` flag set, so the repo's "Latest release" pointer continues to reference the SDK GA release.

## What is NOT in this PR

- CLI source code (lives in a separate private tree, not affected by this PR)
- Binary artifacts (will be uploaded to the GitHub Release directly, not committed)
- Changes to existing `sdk/`, `samples/`, `docs/`, etc.
- Top-level README changes (can be a follow-up if you want a pointer added)

## Release follow-up (separate from this PR)

After this PR merges:

1. Tag `cli-preview-0.10.0` on the merge commit
2. Create the GitHub Release with `prerelease` enabled
3. Upload the 8 signed binaries + `SHA256SUMS.txt`:
   - `foundry-0.10.0-win-x64-winml.msix` / `-win-x64.msix`
   - `foundry-0.10.0-win-arm64-winml.msix` / `-win-arm64.msix`
   - `foundry-0.10.0-osx-arm64.pkg` / `.zip`
   - `foundry-0.10.0-linux-x64.tar.gz` / `-linux-arm64.tar.gz`
4. Release body = contents of [`cli/RELEASE-NOTES-0.10.0.md`](./cli/RELEASE-NOTES-0.10.0.md)

## Verification

- All 4 Windows MSIX signed by `CN=Microsoft Corporation`, issuer `Microsoft Code Signing PCA 2024`, Authenticode `Valid`
- macOS `.pkg` and `.zip` produced through the macOS signing/notarization pipeline (see ADO build `1246347`)
- Hashes committed alongside the binaries in `SHA256SUMS.txt`

## Checklist

- [x] Files use the same conventions as existing top-level READMEs in this repo
- [x] License declared (MIT) and matches SDK licensing
- [x] No binaries committed
- [x] Preview status called out prominently in both README and release notes
- [ ] Release branch / tag created (follow-up)
- [ ] Release published with prerelease flag (follow-up)
