### PR TITLE
Cherry-pick [SDKv1] Self-heal catalog cache on BYOM cache-miss (#760)

### DIFF
--- a/sdk/cs/src/Catalog.cs
+++ b/sdk/cs/src/Catalog.cs
@@ -7,6 +7,7 @@
 namespace Microsoft.AI.Foundry.Local;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -102,52 +103,113 @@ internal sealed class Catalog : ICatalog, IDisposable
 
     private async Task<List<IModel>> GetCachedModelsImplAsync(CancellationToken? ct = null)
     {
+        await UpdateModels(ct).ConfigureAwait(false);
+
         var cachedModelIds = await Utils.GetCachedModelIdsAsync(_coreInterop, ct).ConfigureAwait(false);
-
-        List<IModel> cachedModels = [];
-        foreach (var modelId in cachedModelIds)
-        {
-            if (_modelIdToModelVariant.TryGetValue(modelId, out ModelVariant? modelVariant))
-            {
-                cachedModels.Add(modelVariant);
-            }
-        }
-
-        return cachedModels;
+        return await ResolveModelIdsAsync(cachedModelIds, ct).ConfigureAwait(false);
     }
 
     private async Task<List<IModel>> GetLoadedModelsImplAsync(CancellationToken? ct = null)
     {
-        var loadedModelIds = await _modelLoadManager.ListLoadedModelsAsync(ct).ConfigureAwait(false);
-        List<IModel> loadedModels = [];
+        await UpdateModels(ct).ConfigureAwait(false);
 
-        foreach (var modelId in loadedModelIds)
+        var loadedModelIds = await _modelLoadManager.ListLoadedModelsAsync(ct).ConfigureAwait(false);
+        return await ResolveModelIdsAsync(loadedModelIds, ct).ConfigureAwait(false);
+    }
+
+    // Resolve a list of model ids against the in-memory catalog, self-healing once
+    // if any id is unknown (e.g. a manually-added BYOM model the SDK has not yet seen).
+    // Preserves the input order of modelIds (minus unknowns).
+    private async Task<List<IModel>> ResolveModelIdsAsync(string[] modelIds, CancellationToken? ct)
+    {
+        bool needsRefresh = false;
+        using (var disposable = await _lock.LockAsync().ConfigureAwait(false))
         {
-            if (_modelIdToModelVariant.TryGetValue(modelId, out ModelVariant? modelVariant))
+            foreach (var modelId in modelIds)
             {
-                loadedModels.Add(modelVariant);
+                if (!_modelIdToModelVariant.ContainsKey(modelId))
+                {
+                    needsRefresh = true;
+                    break;
+                }
             }
         }
 
-        return loadedModels;
+        if (needsRefresh)
+        {
+            await UpdateModels(ct, force: true).ConfigureAwait(false);
+        }
+
+        List<IModel> resolved = new(modelIds.Length);
+        using (var disposable = await _lock.LockAsync().ConfigureAwait(false))
+        {
+            foreach (var modelId in modelIds)
+            {
+                if (_modelIdToModelVariant.TryGetValue(modelId, out ModelVariant? variant))
+                {
+                    resolved.Add(variant);
+                }
+            }
+        }
+
+        return resolved;
     }
 
     private async Task<Model?> GetModelImplAsync(string modelAlias, CancellationToken? ct = null)
     {
+        if (string.IsNullOrWhiteSpace(modelAlias))
+        {
+            return null;
+        }
+
         await UpdateModels(ct).ConfigureAwait(false);
 
-        using var disposable = await _lock.LockAsync().ConfigureAwait(false);
-        _modelAliasToModel.TryGetValue(modelAlias, out Model? model);
+        Model? model;
+        using (var disposable = await _lock.LockAsync().ConfigureAwait(false))
+        {
+            _modelAliasToModel.TryGetValue(modelAlias, out model);
+        }
+        if (model is not null)
+        {
+            return model;
+        }
 
+        // Self-heal: the alias may belong to a BYOM model added to the cache
+        // directory after our last catalog refresh.
+        await UpdateModels(ct, force: true).ConfigureAwait(false);
+        using (var disposable = await _lock.LockAsync().ConfigureAwait(false))
+        {
+            _modelAliasToModel.TryGetValue(modelAlias, out model);
+        }
         return model;
     }
 
     private async Task<ModelVariant?> GetModelVariantImplAsync(string modelId, CancellationToken? ct = null)
     {
+        if (string.IsNullOrWhiteSpace(modelId))
+        {
+            return null;
+        }
+
         await UpdateModels(ct).ConfigureAwait(false);
 
-        using var disposable = await _lock.LockAsync().ConfigureAwait(false);
-        _modelIdToModelVariant.TryGetValue(modelId, out ModelVariant? modelVariant);
+        ModelVariant? modelVariant;
+        using (var disposable = await _lock.LockAsync().ConfigureAwait(false))
+        {
+            _modelIdToModelVariant.TryGetValue(modelId, out modelVariant);
+        }
+        if (modelVariant is not null)
+        {
+            return modelVariant;
+        }
+
+        // Self-heal: the id may belong to a BYOM model added to the cache
+        // directory after our last catalog refresh.
+        await UpdateModels(ct, force: true).ConfigureAwait(false);
+        using (var disposable = await _lock.LockAsync().ConfigureAwait(false))
+        {
+            _modelIdToModelVariant.TryGetValue(modelId, out modelVariant);
+        }
         return modelVariant;
     }
 
@@ -190,10 +252,13 @@ internal sealed class Catalog : ICatalog, IDisposable
         return latest.Id == modelOrModelVariant.Id ? modelOrModelVariant : latest;
     }
 
-    private async Task UpdateModels(CancellationToken? ct)
+    private async Task UpdateModels(CancellationToken? ct, bool force = false)
     {
         // TODO: make this configurable
-        if (DateTime.Now - _lastFetch < TimeSpan.FromHours(6))
+        // Skip if the cache is still fresh, unless the caller forced a refresh
+        // (e.g. self-heal after a cache miss caused by a manually-added BYOM
+        // model dropped into the cache directory).
+        if (!force && DateTime.Now - _lastFetch < TimeSpan.FromHours(6))
         {
             return;
         }
@@ -215,26 +280,64 @@ internal sealed class Catalog : ICatalog, IDisposable
 
         using var disposable = await _lock.LockAsync().ConfigureAwait(false);
 
-        // TODO: Do we need to clear this out, or can we just add new models?
-        _modelAliasToModel.Clear();
-        _modelIdToModelVariant.Clear();
+        // Incremental refresh: preserve wrapper identity for ids/aliases that
+        // survive the refresh so externally-held IModel references keep
+        // working with up-to-date metadata and (for Model) keep any explicit
+        // SelectVariant() choice. New ids get fresh wrappers; removed ids get
+        // evicted.
 
-        foreach (var modelInfo in models)
+        var freshIds = new HashSet<string>(StringComparer.Ordinal);
+        var freshAliasGroups = new Dictionary<string, List<ModelInfo>>(StringComparer.Ordinal);
+        foreach (var info in models)
         {
-            var variant = new ModelVariant(modelInfo, _modelLoadManager, _coreInterop, _logger);
-
-            var existingModel = _modelAliasToModel.TryGetValue(modelInfo.Alias, out Model? value);
-            if (!existingModel)
+            freshIds.Add(info.Id);
+            if (!freshAliasGroups.TryGetValue(info.Alias, out var group))
             {
-                value = new Model(variant, _logger);
-                _modelAliasToModel[modelInfo.Alias] = value;
+                group = [];
+                freshAliasGroups[info.Alias] = group;
+            }
+            group.Add(info);
+        }
+
+        foreach (var staleId in _modelIdToModelVariant.Keys.Where(id => !freshIds.Contains(id)).ToList())
+        {
+            _modelIdToModelVariant.Remove(staleId);
+        }
+        foreach (var staleAlias in _modelAliasToModel.Keys.Where(a => !freshAliasGroups.ContainsKey(a)).ToList())
+        {
+            _modelAliasToModel.Remove(staleAlias);
+        }
+
+        foreach (var info in models)
+        {
+            if (_modelIdToModelVariant.TryGetValue(info.Id, out var existing))
+            {
+                existing.RefreshInfo(info);
             }
             else
             {
-                value!.AddVariant(variant);
+                _modelIdToModelVariant[info.Id] = new ModelVariant(info, _modelLoadManager, _coreInterop, _logger);
             }
+        }
 
-            _modelIdToModelVariant[variant.Id] = variant;
+        foreach (var kvp in freshAliasGroups)
+        {
+            var alias = kvp.Key;
+            var aliasInfos = kvp.Value;
+            var aliasVariants = aliasInfos.ConvertAll(i => _modelIdToModelVariant[i.Id]);
+            if (_modelAliasToModel.TryGetValue(alias, out var existingModel))
+            {
+                existingModel.RefreshVariants(aliasVariants);
+            }
+            else
+            {
+                var m = new Model(aliasVariants[0], _logger);
+                for (var i = 1; i < aliasVariants.Count; i++)
+                {
+                    m.AddVariant(aliasVariants[i]);
+                }
+                _modelAliasToModel[alias] = m;
+            }
         }
 
         _lastFetch = DateTime.Now;

--- a/sdk/cs/src/Detail/Model.cs
+++ b/sdk/cs/src/Detail/Model.cs
@@ -12,7 +12,7 @@ public class Model : IModel
 {
     private readonly ILogger _logger;
 
-    private readonly List<IModel> _variants;
+    private List<IModel> _variants;
     public IReadOnlyList<IModel> Variants => _variants;
     internal IModel SelectedVariant { get; set; } = default!;
 
@@ -50,13 +50,44 @@ public class Model : IModel
                                             _logger);
         }
 
-        _variants.Add(variant);
+        // Build a fresh list and swap by reference so concurrent readers of
+        // Variants never observe a torn collection mid-mutation.
+        _variants = [.. _variants, variant];
 
         // prefer the highest priority locally cached variant
         if (variant.Info.Cached && !SelectedVariant.Info.Cached)
         {
             SelectedVariant = variant;
         }
+    }
+
+    /// <summary>
+    /// Replace the variant list in place while preserving wrapper identity.
+    /// Called by <see cref="Catalog.UpdateModels"/> during incremental
+    /// refresh so a user's held <see cref="Model"/> reference keeps pointing
+    /// at the same object across refreshes. Because
+    /// <see cref="Catalog.UpdateModels"/> reuses the same
+    /// <see cref="ModelVariant"/> wrappers for ids that survive a refresh,
+    /// any explicit <see cref="SelectVariant"/> choice that survives the
+    /// refresh is preserved without any extra work here.
+    ///
+    /// We swap the backing list by reference rather than mutating it so
+    /// readers iterating <see cref="Variants"/> on another thread cannot
+    /// observe a torn collection.
+    /// </summary>
+    // TODO: tighten the held-reference contract for the case where the
+    // previously selected variant is removed by a refresh; today
+    // SelectedVariant keeps pointing at the dropped wrapper and callers must
+    // explicitly re-select.
+    internal void RefreshVariants(IList<ModelVariant> variants)
+    {
+        if (variants == null || variants.Count == 0)
+        {
+            throw new FoundryLocalException(
+                $"Cannot refresh model {Alias} with an empty variant list", _logger);
+        }
+
+        _variants = [.. variants];
     }
 
     /// <summary>

--- a/sdk/cs/src/Detail/ModelVariant.cs
+++ b/sdk/cs/src/Detail/ModelVariant.cs
@@ -17,12 +17,12 @@ internal class ModelVariant : IModel
     private readonly ICoreInterop _coreInterop;
     private readonly ILogger _logger;
 
-    public ModelInfo Info { get; } // expose the full info record
+    public ModelInfo Info { get; private set; } // expose the full info record
 
     // expose a few common properties directly
     public string Id => Info.Id;
     public string Alias => Info.Alias;
-    public int Version { get; init; }  // parsed from Info.Version if possible, else 0
+    public int Version { get; private set; }  // parsed from Info.Version if possible, else 0
 
     public IReadOnlyList<IModel> Variants => [this];
 
@@ -36,6 +36,23 @@ internal class ModelVariant : IModel
         _coreInterop = coreInterop;
         _logger = logger;
 
+    }
+
+    /// <summary>
+    /// Replace the cached <see cref="ModelInfo"/> snapshot in place.
+    /// Called by <see cref="Catalog.UpdateModels"/> during incremental refresh
+    /// so wrapper identity is preserved across refreshes while still surfacing
+    /// fresh metadata (notably <c>Cached</c>) on held references. <c>Id</c>
+    /// and <c>Alias</c> are immutable for a given variant; callers must only
+    /// invoke this with a <paramref name="modelInfo"/> whose id matches
+    /// <see cref="Id"/>. Reference assignment in CLR is atomic, so concurrent
+    /// readers observe either the old or new snapshot, never a torn
+    /// intermediate.
+    /// </summary>
+    internal void RefreshInfo(ModelInfo modelInfo)
+    {
+        Info = modelInfo;
+        Version = modelInfo.Version;
     }
 
     // simpler and always correct to check if loaded from the model load manager

--- a/sdk/cs/test/FoundryLocal.Tests/CatalogIncrementalRefreshTests.cs
+++ b/sdk/cs/test/FoundryLocal.Tests/CatalogIncrementalRefreshTests.cs
@@ -1,0 +1,194 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright company="Microsoft">
+//   Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Microsoft.AI.Foundry.Local.Tests;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Microsoft.AI.Foundry.Local.Detail;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+/// <summary>
+/// <see cref="Catalog.UpdateModels"/> incremental-refresh behavior.
+///
+/// The refresh path is shared by all Catalog methods. These tests pin down the
+/// contract that externally-held <see cref="IModel"/> references and per-Model
+/// variant selection survive across forced refreshes when the underlying model
+/// id is still present in the fresh catalog.
+/// </summary>
+internal sealed class CatalogIncrementalRefreshTests
+{
+    private static ModelInfo MakeModelInfo(string id, string alias, bool cached, long maxOutputTokens = 1024L)
+    {
+        var version = int.Parse(id.Split(':').Last());
+        return new ModelInfo
+        {
+            Id = id,
+            Name = alias,
+            Version = version,
+            Alias = alias,
+            DisplayName = alias,
+            ProviderType = "local",
+            Uri = $"local://{alias}/{version}",
+            ModelType = "ONNX",
+            Runtime = new Runtime { DeviceType = DeviceType.CPU, ExecutionProvider = "CPUExecutionProvider" },
+            Cached = cached,
+            MaxOutputTokens = maxOutputTokens,
+        };
+    }
+
+    /// <summary>
+    /// Builds a Catalog whose <c>get_model_list</c> IPC returns
+    /// <paramref name="responses"/>[N] on the (N+1)-th call (clamping to the
+    /// last entry). <c>get_cached_models</c> and the load manager's loaded
+    /// list both return empty so only the explicit refresh path runs.
+    /// Force-refreshes are triggered via <see cref="Catalog.InvalidateCache"/>
+    /// followed by a public call (mirrors what <c>UpdateModels(force: true)</c>
+    /// does: bypasses the TTL gate, then re-runs the rebuild).
+    /// </summary>
+    private static async Task<Catalog> CreateCatalogAsync(IReadOnlyList<IReadOnlyList<ModelInfo>> responses)
+    {
+        var call = 0;
+        var mockCoreInterop = new Mock<ICoreInterop>();
+
+        mockCoreInterop.Setup(x => x.ExecuteCommand("get_catalog_name", It.IsAny<CoreInteropRequest?>()))
+            .Returns(new ICoreInterop.Response { Data = "TestCatalog", Error = null });
+
+        mockCoreInterop.Setup(x => x.ExecuteCommandAsync("get_model_list", It.IsAny<CoreInteropRequest?>(),
+                                                         It.IsAny<CancellationToken?>()))
+            .ReturnsAsync(() =>
+            {
+                var idx = Math.Min(call, responses.Count - 1);
+                call++;
+                var data = JsonSerializer.Serialize(
+                    responses[idx].ToList(), JsonSerializationContext.Default.ListModelInfo);
+                return new ICoreInterop.Response { Data = data, Error = null };
+            });
+
+        mockCoreInterop.Setup(x => x.ExecuteCommandAsync("get_cached_models", It.IsAny<CoreInteropRequest?>(),
+                                                         It.IsAny<CancellationToken?>()))
+            .ReturnsAsync(new ICoreInterop.Response { Data = "[]", Error = null });
+
+        var mockLoadManager = new Mock<IModelLoadManager>();
+        mockLoadManager.Setup(x => x.ListLoadedModelsAsync(It.IsAny<CancellationToken?>()))
+            .ReturnsAsync([]);
+
+        return await Catalog.CreateAsync(mockLoadManager.Object, mockCoreInterop.Object,
+                                         NullLogger<Catalog>.Instance, null);
+    }
+
+    private static async Task ForceRefreshAsync(Catalog catalog)
+    {
+        catalog.InvalidateCache();
+        // Any public method that calls UpdateModels works; ListModelsAsync is the cheapest.
+        await catalog.ListModelsAsync();
+    }
+
+    [Test]
+    public async Task PreservesIdentityAndPropagatesInfoOnRefresh()
+    {
+        // A held Model / ModelVariant reference must survive a forced refresh
+        // when the id is still present (identity preserved) AND surface fresh
+        // ModelInfo through the same reference. Mutating Info is the natural
+        // way to prove that the post-refresh wrapper IS the pre-refresh
+        // wrapper, not a fresh one that happens to compare equal.
+        List<ModelInfo> firstState =
+        [
+            MakeModelInfo("a:1", "alpha", cached: false, maxOutputTokens: 1024L),
+        ];
+        List<ModelInfo> secondState =
+        [
+            MakeModelInfo("a:1", "alpha", cached: true, maxOutputTokens: 2048L),
+        ];
+        var catalog = await CreateCatalogAsync([firstState, secondState]);
+
+        var firstModel = await catalog.GetModelAsync("alpha");
+        var firstVariant = await catalog.GetModelVariantAsync("a:1");
+        await Assert.That(firstVariant!.Info.Cached).IsFalse();
+        await Assert.That(firstVariant.Info.MaxOutputTokens).IsEqualTo(1024L);
+
+        await ForceRefreshAsync(catalog);
+
+        var secondModel = await catalog.GetModelAsync("alpha");
+        var secondVariant = await catalog.GetModelVariantAsync("a:1");
+        await Assert.That(ReferenceEquals(firstModel, secondModel)).IsTrue();
+        await Assert.That(ReferenceEquals(firstVariant, secondVariant)).IsTrue();
+        // Same held reference now reflects the fresh ModelInfo.
+        await Assert.That(firstVariant.Info.Cached).IsTrue();
+        await Assert.That(firstVariant.Info.MaxOutputTokens).IsEqualTo(2048L);
+    }
+
+    [Test]
+    public async Task SelectionSurvivesRefresh()
+    {
+        // When the selected variant's id is still present after a refresh,
+        // SelectVariant() survives so subsequent ops (load, unload, ...)
+        // target the user's pick. Wrapper identity is preserved by
+        // Catalog.UpdateModels reusing the same ModelVariant for surviving
+        // ids, so RefreshVariants does not need to touch SelectedVariant.
+        var v1 = MakeModelInfo("multi:1", "multi", cached: true);
+        var v2 = MakeModelInfo("multi:2", "multi", cached: true);
+        List<ModelInfo> both = [v1, v2];
+        var catalog = await CreateCatalogAsync([both, both]);
+
+        var model = (Model)(await catalog.GetModelAsync("multi"))!;
+        var variantV2 = model.Variants.First(v => v.Id == "multi:2");
+        model.SelectVariant(variantV2);
+        await Assert.That(model.Id).IsEqualTo("multi:2");
+
+        await ForceRefreshAsync(catalog);
+        await Assert.That(model.Id).IsEqualTo("multi:2");
+        await Assert.That(model.Variants.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task AppliesAddsAndRemovesOnRefresh()
+    {
+        // Ids no longer present must be evicted from both _modelIdToModelVariant
+        // and _modelAliasToModel; new ids must be inserted as fresh wrappers.
+        // Both directions are symmetric and share setup, so we cover them in
+        // one test against a single refresh that does both at once.
+        List<ModelInfo> firstState =
+        [
+            MakeModelInfo("a:1", "alpha", cached: true),
+            MakeModelInfo("b:1", "beta",  cached: true),
+        ];
+        List<ModelInfo> secondState =
+        [
+            MakeModelInfo("a:1", "alpha", cached: true),
+            MakeModelInfo("byom:1", "byom-new", cached: true),
+        ];
+        var catalog = await CreateCatalogAsync([firstState, secondState]);
+
+        // Warm the catalog and confirm the pre-state. ListModelsAsync does not
+        // trigger self-heal, so it is safe to probe before the forced refresh.
+        var initialAliases = new HashSet<string>(
+            (await catalog.ListModelsAsync()).Select(m => m.Alias));
+        await Assert.That(initialAliases.Contains("alpha")).IsTrue();
+        await Assert.That(initialAliases.Contains("beta")).IsTrue();
+        await Assert.That(initialAliases.Contains("byom-new")).IsFalse();
+
+        await ForceRefreshAsync(catalog);
+
+        var newAliases = new HashSet<string>(
+            (await catalog.ListModelsAsync()).Select(m => m.Alias));
+        await Assert.That(newAliases.Contains("alpha")).IsTrue();
+        await Assert.That(newAliases.Contains("beta")).IsFalse();
+        await Assert.That(newAliases.Contains("byom-new")).IsTrue();
+
+        // Variant-level eviction + insertion mirrors the alias-level change.
+        // GetModelVariantAsync on a known id is a direct hit; on a gone id it
+        // self-heals but the mock has already clamped to secondState, so the
+        // self-heal IPC returns the same data and the assertion still holds.
+        await Assert.That(await catalog.GetModelVariantAsync("byom:1")).IsNotNull();
+        await Assert.That(await catalog.GetModelVariantAsync("b:1")).IsNull();
+    }
+}

--- a/sdk/cs/test/FoundryLocal.Tests/CatalogSelfHealTests.cs
+++ b/sdk/cs/test/FoundryLocal.Tests/CatalogSelfHealTests.cs
@@ -1,0 +1,163 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright company="Microsoft">
+//   Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Microsoft.AI.Foundry.Local.Tests;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Microsoft.AI.Foundry.Local.Detail;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+/// <summary>
+/// Catalog self-heal behavior — when a public lookup (<c>GetModelAsync</c>,
+/// <c>GetModelVariantAsync</c>, <c>GetCachedModelsAsync</c>) misses against
+/// the in-memory cache, the Catalog issues one forced refresh
+/// (<c>UpdateModels(force: true)</c>) bypassing the 6h TTL gate and retries.
+/// This surfaces BYOM (Bring-Your-Own-Model) entries that were dropped into
+/// the cache directory after the SDK warmed up. Empty / whitespace input must
+/// short-circuit without firing the (expensive) forced refresh.
+/// </summary>
+internal sealed class CatalogSelfHealTests
+{
+    internal sealed class CallCounters
+    {
+        public int ModelListCalls;
+    }
+
+    private static ModelInfo MakeModelInfo(string id, string alias, bool cached)
+    {
+        var version = int.Parse(id.Split(':').Last());
+        return new ModelInfo
+        {
+            Id = id,
+            Name = alias,
+            Version = version,
+            Alias = alias,
+            DisplayName = alias,
+            ProviderType = "local",
+            Uri = $"local://{alias}/{version}",
+            ModelType = "ONNX",
+            Runtime = new Runtime { DeviceType = DeviceType.CPU, ExecutionProvider = "CPUExecutionProvider" },
+            Cached = cached,
+        };
+    }
+
+    /// <summary>
+    /// Build a Catalog whose <c>get_model_list</c> IPC returns
+    /// <paramref name="modelListResponses"/>[N] on the (N+1)-th call (clamping
+    /// to the last entry) and whose <c>get_cached_models</c> IPC returns
+    /// <paramref name="cachedModelIds"/>. The shared <see cref="CallCounters"/>
+    /// exposes the model-list IPC call count for the test to assert against.
+    /// </summary>
+    private static async Task<(Catalog Catalog, CallCounters Counters)> CreateCatalogAsync(
+        IReadOnlyList<IReadOnlyList<ModelInfo>> modelListResponses,
+        string[]? cachedModelIds = null)
+    {
+        var counters = new CallCounters();
+        var mockCoreInterop = new Mock<ICoreInterop>();
+
+        mockCoreInterop.Setup(x => x.ExecuteCommand("get_catalog_name", It.IsAny<CoreInteropRequest?>()))
+            .Returns(new ICoreInterop.Response { Data = "TestCatalog", Error = null });
+
+        mockCoreInterop.Setup(x => x.ExecuteCommandAsync("get_model_list", It.IsAny<CoreInteropRequest?>(),
+                                                         It.IsAny<CancellationToken?>()))
+            .ReturnsAsync(() =>
+            {
+                var idx = Math.Min(counters.ModelListCalls, modelListResponses.Count - 1);
+                counters.ModelListCalls++;
+                var data = JsonSerializer.Serialize(
+                    modelListResponses[idx].ToList(), JsonSerializationContext.Default.ListModelInfo);
+                return new ICoreInterop.Response { Data = data, Error = null };
+            });
+
+        var cachedJson = JsonSerializer.Serialize(cachedModelIds ?? []);
+        mockCoreInterop.Setup(x => x.ExecuteCommandAsync("get_cached_models", It.IsAny<CoreInteropRequest?>(),
+                                                         It.IsAny<CancellationToken?>()))
+            .ReturnsAsync(new ICoreInterop.Response { Data = cachedJson, Error = null });
+
+        var mockLoadManager = new Mock<IModelLoadManager>();
+        mockLoadManager.Setup(x => x.ListLoadedModelsAsync(It.IsAny<CancellationToken?>()))
+            .ReturnsAsync([]);
+
+        var catalog = await Catalog.CreateAsync(mockLoadManager.Object, mockCoreInterop.Object,
+                                                NullLogger<Catalog>.Instance, null);
+        return (catalog, counters);
+    }
+
+    [Test]
+    public async Task SelfHealsGetModelAndGetModelVariantOnCacheMiss()
+    {
+        // Warm catalog returns no models; the forced self-heal refresh from
+        // the public miss path returns the BYOM that was dropped into the
+        // cache after the SDK warmed up. CreateAsync auto-warms (1 call), the
+        // first GetModelAsync miss forces the second call (the self-heal),
+        // and the subsequent GetModelVariantAsync hits the now-populated map
+        // directly — the inner TTL-gated UpdateModels short-circuits.
+        ModelInfo[] byom = [MakeModelInfo("byom-self-heal:1", "byom-self-heal", cached: true)];
+        var (catalog, counters) = await CreateCatalogAsync(
+        [
+            [],
+            byom,
+        ]);
+
+        var model = await catalog.GetModelAsync("byom-self-heal");
+        await Assert.That(model).IsNotNull();
+        await Assert.That(model!.Alias).IsEqualTo("byom-self-heal");
+
+        var variant = await catalog.GetModelVariantAsync("byom-self-heal:1");
+        await Assert.That(variant).IsNotNull();
+        await Assert.That(variant!.Id).IsEqualTo("byom-self-heal:1");
+
+        await Assert.That(counters.ModelListCalls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task SelfHealsGetCachedModelsOnUnknownId()
+    {
+        // Core always reports the BYOM as cached; the SDK has to self-heal in
+        // ResolveModelIdsAsync (force-refresh) to learn the id exists in the
+        // catalog and surface it from GetCachedModelsAsync. CreateAsync warms
+        // with an empty model list (1 call); GetCachedModelsAsync sees the
+        // unknown id and forces a second refresh (now byom).
+        ModelInfo[] byom = [MakeModelInfo("byom-cached:1", "byom-cached", cached: true)];
+        var (catalog, counters) = await CreateCatalogAsync(
+            [[], byom],
+            cachedModelIds: ["byom-cached:1"]);
+
+        var cached = await catalog.GetCachedModelsAsync();
+
+        await Assert.That(cached.Count).IsEqualTo(1);
+        await Assert.That(cached[0].Id).IsEqualTo("byom-cached:1");
+        await Assert.That(counters.ModelListCalls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task DoesNotRefreshCatalogOnEmptyOrWhitespaceInput()
+    {
+        // Empty / whitespace / null input to GetModelAsync / GetModelVariantAsync
+        // must short-circuit and return null WITHOUT firing the expensive
+        // forced refresh that powers the self-heal path. Without the guard, a
+        // tight loop that sometimes passes "" would trigger a recursive disk
+        // scan in Core on every call.
+        var (catalog, counters) = await CreateCatalogAsync([[]]);
+
+        // After CreateAsync there is exactly one model-list IPC (the warm).
+        await Assert.That(counters.ModelListCalls).IsEqualTo(1);
+
+        foreach (var invalid in new[] { string.Empty, "   ", null })
+        {
+            await Assert.That(await catalog.GetModelAsync(invalid!)).IsNull();
+            await Assert.That(await catalog.GetModelVariantAsync(invalid!)).IsNull();
+        }
+
+        await Assert.That(counters.ModelListCalls).IsEqualTo(1);
+    }
+}

--- a/sdk/js/src/catalog.ts
+++ b/sdk/js/src/catalog.ts
@@ -38,14 +38,33 @@ export class Catalog {
         this.lastFetch = 0;
     }
 
-    private async updateModels(): Promise<void> {
+    private async updateModels(force: boolean = false): Promise<void> {
         // TODO: make this configurable
-        if ((Date.now() - this.lastFetch) < 6 * 60 * 60 * 1000) { // 6 hours
+        // Skip if the cache is still fresh, unless the caller forced a refresh
+        // (e.g. self-heal after a cache miss caused by a manually-added BYOM
+        // model dropped into the cache directory).
+        if (!force && (Date.now() - this.lastFetch) < 6 * 60 * 60 * 1000) { // 6 hours
             return;
         }
         if (this.updatePromise) {
+            // If a non-forced refresh is in flight and the caller asked for a
+            // forced refresh (e.g. BYOM self-heal), the in-flight result may
+            // pre-date the change that prompted the force. Chain a fresh
+            // refresh after the current one so the force is not silently
+            // dropped — the inner TTL re-check short-circuits if the chained
+            // refresh started after our deadline.
+            if (force) {
+                const chained = this.updatePromise
+                    .catch(() => undefined)
+                    .then(() => this.runRefreshExclusive());
+                return chained;
+            }
             return this.updatePromise;
         }
+        return this.runRefreshExclusive();
+    }
+
+    private runRefreshExclusive(): Promise<void> {
         this.updatePromise = this.fetchAndPopulateModels()
             .finally(() => { this.updatePromise = undefined; });
         return this.updatePromise;
@@ -60,25 +79,65 @@ export class Catalog {
             throw new Error(`Failed to parse model list JSON: ${error}`);
         }
 
-        this.modelAliasToModel.clear();
-        this.modelIdToModelVariant.clear();
-        this._models = [];
+        // Incremental refresh: preserve wrapper identity for ids/aliases that
+        // survive the refresh so externally-held IModel references keep
+        // working with up-to-date metadata and (for Model) keep any explicit
+        // selectVariant() choice. New ids get fresh wrappers; removed ids get
+        // evicted.
 
+        const freshIds = new Set<string>();
+        const freshAliasGroups = new Map<string, ModelInfo[]>();
         for (const info of modelsInfo) {
-            const variant = new ModelVariant(info, this.coreInterop, this.modelLoadManager);
-            let model = this.modelAliasToModel.get(info.alias);
-
-            if (!model) {
-                model = new Model(variant);
-                this.modelAliasToModel.set(info.alias, model);
-                this._models.push(model);
+            freshIds.add(info.id);
+            const group = freshAliasGroups.get(info.alias);
+            if (group) {
+                group.push(info);
             } else {
-                model.addVariant(variant);
+                freshAliasGroups.set(info.alias, [info]);
             }
-
-            this.modelIdToModelVariant.set(variant.id, variant);
         }
 
+        for (const staleId of [...this.modelIdToModelVariant.keys()]) {
+            if (!freshIds.has(staleId)) {
+                this.modelIdToModelVariant.delete(staleId);
+            }
+        }
+        for (const staleAlias of [...this.modelAliasToModel.keys()]) {
+            if (!freshAliasGroups.has(staleAlias)) {
+                this.modelAliasToModel.delete(staleAlias);
+            }
+        }
+
+        for (const info of modelsInfo) {
+            const existing = this.modelIdToModelVariant.get(info.id);
+            if (existing) {
+                existing._refreshInfo(info);
+            } else {
+                this.modelIdToModelVariant.set(
+                    info.id,
+                    new ModelVariant(info, this.coreInterop, this.modelLoadManager)
+                );
+            }
+        }
+
+        const refreshedAliasOrder: Model[] = [];
+        for (const [alias, infos] of freshAliasGroups) {
+            const variants = infos.map(i => this.modelIdToModelVariant.get(i.id)!);
+            const existingModel = this.modelAliasToModel.get(alias);
+            if (existingModel) {
+                existingModel._refreshVariants(variants);
+                refreshedAliasOrder.push(existingModel);
+            } else {
+                const m = new Model(variants[0]);
+                for (let i = 1; i < variants.length; i++) {
+                    m.addVariant(variants[i]);
+                }
+                this.modelAliasToModel.set(alias, m);
+                refreshedAliasOrder.push(m);
+            }
+        }
+
+        this._models = refreshedAliasOrder;
         this.lastFetch = Date.now();
     }
 
@@ -104,7 +163,13 @@ export class Catalog {
             throw new Error('Model alias must be a non-empty string.');
         }
         await this.updateModels();
-        const model = this.modelAliasToModel.get(alias);
+        let model = this.modelAliasToModel.get(alias);
+        if (!model) {
+            // Self-heal: the alias may belong to a BYOM model added to the
+            // cache directory after our last catalog refresh.
+            await this.updateModels(true);
+            model = this.modelAliasToModel.get(alias);
+        }
         if (!model) {
             const availableAliases = Array.from(this.modelAliasToModel.keys()).join(', ');
             throw new Error(`Model with alias '${alias}' not found. Available models: ${availableAliases || '(none)'}`);
@@ -126,7 +191,13 @@ export class Catalog {
             throw new Error('Model ID must be a non-empty string.');
         }
         await this.updateModels();
-        const variant = this.modelIdToModelVariant.get(modelId);
+        let variant = this.modelIdToModelVariant.get(modelId);
+        if (!variant) {
+            // Self-heal: the id may belong to a BYOM model added to the cache
+            // directory after our last catalog refresh.
+            await this.updateModels(true);
+            variant = this.modelIdToModelVariant.get(modelId);
+        }
         if (!variant) {
             const availableIds = Array.from(this.modelIdToModelVariant.keys()).join(', ');
             throw new Error(`Model variant with ID '${modelId}' not found. Available variants: ${availableIds || '(none)'}`);
@@ -148,15 +219,7 @@ export class Catalog {
         } catch (error) {
             throw new Error(`Failed to parse cached model list JSON: ${error}`);
         }
-        const cachedModels: Set<IModel> = new Set();
-        
-        for (const modelId of cachedModelIds) {
-            const variant = this.modelIdToModelVariant.get(modelId);
-            if (variant) {
-                cachedModels.add(variant);
-            }
-        }
-        return Array.from(cachedModels);
+        return this.resolveModelIds(cachedModelIds);
     }
 
     /**
@@ -173,15 +236,29 @@ export class Catalog {
         } catch (error) {
             throw new Error(`Failed to list loaded models: ${error}`);
         }
-        const loadedModels: IModel[] = [];
-        
-        for (const modelId of loadedModelIds) {
+        return this.resolveModelIds(loadedModelIds);
+    }
+
+    /**
+     * Resolve a list of model ids against the in-memory catalog, self-healing once
+     * if any id is unknown (e.g. a manually-added BYOM model the SDK has not yet seen).
+     * Preserves the input order of `modelIds` (minus unknowns), deduplicating variants.
+     */
+    private async resolveModelIds(modelIds: string[]): Promise<IModel[]> {
+        if (modelIds.some(id => !this.modelIdToModelVariant.has(id))) {
+            await this.updateModels(true);
+        }
+
+        const resolved: IModel[] = [];
+        const seen = new Set<IModel>();
+        for (const modelId of modelIds) {
             const variant = this.modelIdToModelVariant.get(modelId);
-            if (variant) {
-                loadedModels.push(variant);
+            if (variant && !seen.has(variant)) {
+                resolved.push(variant);
+                seen.add(variant);
             }
         }
-        return loadedModels;
+        return resolved;
     }
 
     /**

--- a/sdk/js/src/detail/model.ts
+++ b/sdk/js/src/detail/model.ts
@@ -36,10 +36,35 @@ export class Model implements IModel {
         }
         this._variants.push(variant);
 
-        // prefer the highest priority locally cached variant
-        if (variant.isCached && !this.selectedVariant.isCached) {
+        // Prefer the highest priority locally cached variant.
+        if (variant.info.cached && !this.selectedVariant.info.cached) {
             this.selectedVariant = variant;
         }
+    }
+
+    /**
+     * Replace the variant list in place while preserving wrapper identity.
+     *
+     * Called by `Catalog.fetchAndPopulateModels` during incremental refresh
+     * so a user's held `Model` reference keeps pointing at the same object
+     * across refreshes. Because `Catalog.fetchAndPopulateModels` reuses the
+     * same `ModelVariant` wrappers for ids that survive a refresh, any
+     * explicit `selectVariant()` choice that survives the refresh is
+     * preserved without any extra work here.
+     *
+     * TODO: tighten the held-reference contract for the case where the
+     * previously selected variant is removed by a refresh; today
+     * `selectedVariant` keeps pointing at the dropped wrapper and callers
+     * must explicitly re-select.
+     *
+     * @internal
+     */
+    public _refreshVariants(variants: ModelVariant[]): void {
+        if (!variants || variants.length === 0) {
+            throw new Error(`Cannot refresh model ${this._alias} with an empty variant list`);
+        }
+
+        this._variants = variants.slice();
     }
 
     /**

--- a/sdk/js/src/detail/modelVariant.ts
+++ b/sdk/js/src/detail/modelVariant.ts
@@ -25,6 +25,22 @@ export class ModelVariant implements IModel {
     }
 
     /**
+     * Replace the cached ModelInfo snapshot in place.
+     *
+     * Called by `Catalog.fetchAndPopulateModels` during incremental refresh so
+     * wrapper identity is preserved across refreshes while still surfacing
+     * fresh metadata (notably `cached`) on held references. `id` and `alias`
+     * are immutable for a given variant; the caller must only invoke this with
+     * a `modelInfo` whose id matches `this.id`. JS is single-threaded so no
+     * torn-read concerns.
+     *
+     * @internal
+     */
+    public _refreshInfo(modelInfo: ModelInfo): void {
+        this._modelInfo = modelInfo;
+    }
+
+    /**
      * Gets the unique identifier of the model variant.
      * @returns The model ID.
      */

--- a/sdk/js/test/catalog.test.ts
+++ b/sdk/js/test/catalog.test.ts
@@ -201,4 +201,304 @@ describe('Catalog Tests', () => {
         const resultFromModel = await catalog.getLatestVersion(model);
         expect(resultFromModel).to.equal(model);
     });
+
+    it('should self-heal getModel and getModelVariant on cache miss', async function() {
+        // Mirrors the Python self-heal test: warm catalog returns no models;
+        // the second (forced) refresh from getModel/getModelVariant surfaces
+        // the BYOM that was dropped into the cache after the SDK warmed up.
+        const byomModelInfos: ModelInfo[] = [
+            {
+                id: 'byom-self-heal:1',
+                name: 'byom-self-heal',
+                version: 1,
+                alias: 'byom-self-heal',
+                displayName: 'BYOM Self Heal',
+                providerType: 'local',
+                uri: 'local://byom-self-heal/1',
+                modelType: 'ONNX',
+                runtime: { deviceType: DeviceType.CPU, executionProvider: 'CPUExecutionProvider' },
+                cached: true,
+                createdAtUnix: 1700000001
+            }
+        ];
+
+        let modelListCalls = 0;
+
+        const mockCoreInterop = {
+            executeCommand(command: string): string {
+                if (command === 'get_catalog_name') {
+                    return 'TestCatalog';
+                }
+                throw new Error(`Unexpected sync command: ${command}`);
+            },
+            executeCommandAsync(command: string): Promise<string> {
+                if (command === 'get_model_list') {
+                    modelListCalls += 1;
+                    return Promise.resolve(modelListCalls > 1 ? JSON.stringify(byomModelInfos) : '[]');
+                }
+                if (command === 'get_cached_models') {
+                    return Promise.resolve('[]');
+                }
+                return Promise.reject(new Error(`Unexpected async command: ${command}`));
+            }
+        } as any;
+
+        const mockLoadManager = {
+            listLoaded: async () => []
+        } as any;
+
+        const catalog = new Catalog(mockCoreInterop, mockLoadManager, 'TestCatalog');
+
+        const model = await catalog.getModel('byom-self-heal');
+        expect(model).to.not.be.undefined;
+        expect(model.alias).to.equal('byom-self-heal');
+
+        const variant = await catalog.getModelVariant('byom-self-heal:1');
+        expect(variant).to.not.be.undefined;
+        expect(variant.id).to.equal('byom-self-heal:1');
+
+        // First lookup: warm + forced refresh (2 calls).
+        // Second lookup finds the now-populated alias/variant map; the inner
+        // TTL-gated updateModels() short-circuits, so no extra fetches.
+        expect(modelListCalls).to.equal(2);
+    });
+
+    it('should self-heal getCachedModels when core returns an unknown id', async function() {
+        // Core always reports the BYOM as cached; the SDK has to self-heal in
+        // resolveModelIds (forced updateModels) to learn it exists in the
+        // catalog and surface it from getCachedModels.
+        const byomModelInfos: ModelInfo[] = [
+            {
+                id: 'byom-cached:1',
+                name: 'byom-cached',
+                version: 1,
+                alias: 'byom-cached',
+                displayName: 'BYOM Cached',
+                providerType: 'local',
+                uri: 'local://byom-cached/1',
+                modelType: 'ONNX',
+                runtime: { deviceType: DeviceType.CPU, executionProvider: 'CPUExecutionProvider' },
+                cached: true,
+                createdAtUnix: 1700000001
+            }
+        ];
+
+        let modelListCalls = 0;
+
+        const mockCoreInterop = {
+            executeCommand(command: string): string {
+                if (command === 'get_catalog_name') {
+                    return 'TestCatalog';
+                }
+                throw new Error(`Unexpected sync command: ${command}`);
+            },
+            executeCommandAsync(command: string): Promise<string> {
+                if (command === 'get_model_list') {
+                    modelListCalls += 1;
+                    return Promise.resolve(modelListCalls > 1 ? JSON.stringify(byomModelInfos) : '[]');
+                }
+                if (command === 'get_cached_models') {
+                    return Promise.resolve('["byom-cached:1"]');
+                }
+                return Promise.reject(new Error(`Unexpected async command: ${command}`));
+            }
+        } as any;
+
+        const mockLoadManager = {
+            listLoaded: async () => []
+        } as any;
+
+        const catalog = new Catalog(mockCoreInterop, mockLoadManager, 'TestCatalog');
+
+        const cached = await catalog.getCachedModels();
+        expect(cached).to.have.length(1);
+        expect(cached[0].id).to.equal('byom-cached:1');
+        expect(modelListCalls).to.equal(2);
+    });
+
+    describe('Incremental refresh', () => {
+        // Catalog.updateModels incremental-refresh behavior. The refresh path
+        // is shared by all Catalog methods. These tests pin down the contract
+        // that externally-held IModel references and per-Model variant
+        // selection survive across forced refreshes when the underlying model
+        // id is still present in the fresh catalog. They guard against
+        // regressing to the clear-and-rebuild pattern that churned wrapper
+        // identity on every refresh.
+
+        const makeInfo = (
+            id: string, alias: string, cached: boolean, contextLength: number = 1024
+        ): ModelInfo => ({
+            id,
+            name: alias,
+            version: Number(id.split(':')[1]),
+            alias,
+            displayName: alias,
+            providerType: 'local',
+            uri: `local://${alias}/${id.split(':')[1]}`,
+            modelType: 'ONNX',
+            runtime: { deviceType: DeviceType.CPU, executionProvider: 'CPUExecutionProvider' },
+            cached,
+            createdAtUnix: 1700000001,
+            contextLength
+        });
+
+        const makeCatalog = (states: ModelInfo[][]) => {
+            const state = { call: 0 };
+            const mockCoreInterop = {
+                executeCommand(command: string): string {
+                    if (command === 'get_catalog_name') {
+                        return 'TestCatalog';
+                    }
+                    throw new Error(`Unexpected sync command: ${command}`);
+                },
+                executeCommandAsync(command: string): Promise<string> {
+                    if (command === 'get_model_list') {
+                        const idx = Math.min(state.call, states.length - 1);
+                        state.call += 1;
+                        return Promise.resolve(JSON.stringify(states[idx]));
+                    }
+                    if (command === 'get_cached_models') {
+                        return Promise.resolve('[]');
+                    }
+                    return Promise.reject(new Error(`Unexpected async command: ${command}`));
+                }
+            } as any;
+            const mockLoadManager = { listLoaded: async () => [] } as any;
+            return new Catalog(mockCoreInterop, mockLoadManager, 'TestCatalog');
+        };
+
+        // Reach into private members via `as any` so the tests can probe the
+        // internal maps without triggering the public self-heal paths.
+        const internals = (c: Catalog) => c as any;
+
+        it('should preserve identity and propagate info on refresh', async function() {
+            // A held IModel / ModelVariant reference must survive a forced
+            // refresh when the id is still present (identity preserved) AND
+            // surface fresh ModelInfo through the same reference (in-place
+            // info refresh, not replace-and-rebuild). Mutating info is the
+            // natural way to prove the post-refresh wrapper IS the pre-refresh
+            // wrapper, not a fresh one that compares equal.
+            const firstState = [makeInfo('a:1', 'alpha', false, 1024)];
+            const secondState = [makeInfo('a:1', 'alpha', true, 2048)];
+            const catalog = makeCatalog([firstState, secondState]);
+
+            const firstModel = await catalog.getModel('alpha');
+            const firstVariant = await catalog.getModelVariant('a:1');
+            expect(firstVariant.info.cached).to.equal(false);
+            expect(firstVariant.info.contextLength).to.equal(1024);
+
+            await internals(catalog).updateModels(true);
+
+            const secondModel = await catalog.getModel('alpha');
+            const secondVariant = await catalog.getModelVariant('a:1');
+            expect(firstModel === secondModel).to.equal(true);
+            expect(firstVariant === secondVariant).to.equal(true);
+            // Same held reference now reflects the fresh ModelInfo.
+            expect(firstVariant.info.cached).to.equal(true);
+            expect(firstVariant.info.contextLength).to.equal(2048);
+        });
+
+        it('selection survives refresh', async function() {
+            // When the selected variant's id is still present after a
+            // refresh, selectVariant() survives so subsequent ops target the
+            // user's pick. Wrapper identity is preserved by
+            // Catalog.fetchAndPopulateModels reusing the same ModelVariant
+            // for surviving ids, so _refreshVariants does not need to touch
+            // selectedVariant.
+            const v1 = makeInfo('multi:1', 'multi', true);
+            const v2 = makeInfo('multi:2', 'multi', true);
+            const both = [v1, v2];
+            const catalog = makeCatalog([both, both]);
+
+            const model = await catalog.getModel('multi');
+            const variantV2 = model.variants.find(v => v.id === 'multi:2')!;
+            model.selectVariant(variantV2);
+            expect(model.id).to.equal('multi:2');
+
+            await internals(catalog).updateModels(true);
+            expect(model.id).to.equal('multi:2');
+            expect(model.variants.length).to.equal(2);
+        });
+
+        it('should apply adds and removes on refresh', async function() {
+            // Ids no longer present must be evicted from both
+            // modelIdToModelVariant and modelAliasToModel; new ids must be
+            // inserted as fresh wrappers. Both directions are symmetric and
+            // share setup, so we cover them in one test against a single
+            // refresh that does both at once. We probe the internal maps
+            // directly to avoid triggering the public self-heal paths.
+            const firstState = [
+                makeInfo('a:1', 'alpha', true),
+                makeInfo('b:1', 'beta', true)
+            ];
+            const secondState = [
+                makeInfo('a:1', 'alpha', true),
+                makeInfo('byom:1', 'byom-new', true)
+            ];
+            const catalog = makeCatalog([firstState, secondState]);
+
+            // Warm the catalog and confirm the pre-state.
+            await catalog.getModels();
+            expect(internals(catalog).modelAliasToModel.has('alpha')).to.equal(true);
+            expect(internals(catalog).modelAliasToModel.has('beta')).to.equal(true);
+            expect(internals(catalog).modelAliasToModel.has('byom-new')).to.equal(false);
+
+            await internals(catalog).updateModels(true);
+
+            expect(internals(catalog).modelAliasToModel.has('alpha')).to.equal(true);
+            expect(internals(catalog).modelAliasToModel.has('beta')).to.equal(false);
+            expect(internals(catalog).modelIdToModelVariant.has('b:1')).to.equal(false);
+            expect(internals(catalog).modelAliasToModel.has('byom-new')).to.equal(true);
+            expect(internals(catalog).modelIdToModelVariant.has('byom:1')).to.equal(true);
+        });
+
+        it('should not swallow a forced refresh that arrives during a non-forced refresh', async function() {
+            // The Catalog can have a non-forced updateModels() in flight when
+            // a different caller (e.g. _resolveModelIds self-heal) asks for
+            // force=true. Previously updateModels(true) returned the in-flight
+            // promise, dropping the force on the floor. We now chain a fresh
+            // refresh so the force is honored. JS-only — Python serializes
+            // _update_models under a single lock, C# does the same.
+            const firstState = [makeInfo('a:1', 'alpha', true)];
+            const secondState = [
+                makeInfo('a:1', 'alpha', true),
+                makeInfo('byom:1', 'byom-new', true)
+            ];
+            const state = { call: 0, gateRelease: undefined as (() => void) | undefined };
+            const gate = new Promise<void>((res) => { state.gateRelease = res; });
+
+            const mockCoreInterop = {
+                executeCommand(command: string): string {
+                    if (command === 'get_catalog_name') return 'TestCatalog';
+                    throw new Error(`Unexpected sync command: ${command}`);
+                },
+                executeCommandAsync(command: string): Promise<string> {
+                    if (command === 'get_model_list') {
+                        const idx = Math.min(state.call, 1);
+                        state.call += 1;
+                        const data = idx === 0 ? firstState : secondState;
+                        if (idx === 0) {
+                            return gate.then(() => JSON.stringify(data));
+                        }
+                        return Promise.resolve(JSON.stringify(data));
+                    }
+                    if (command === 'get_cached_models') return Promise.resolve('[]');
+                    return Promise.reject(new Error(`Unexpected async command: ${command}`));
+                }
+            } as any;
+            const mockLoadManager = { listLoaded: async () => [] } as any;
+            const catalog = new Catalog(mockCoreInterop, mockLoadManager, 'TestCatalog');
+
+            const inFlight = internals(catalog).updateModels(false);
+            const forced = internals(catalog).updateModels(true);
+            state.gateRelease!();
+            await Promise.all([inFlight, forced]);
+
+            // Two fetches must have happened — the first gated one, plus the
+            // chained forced one. If the force were swallowed, state.call
+            // would be 1 and the byom would not be visible.
+            expect(state.call).to.equal(2);
+            expect(internals(catalog).modelIdToModelVariant.has('byom:1')).to.equal(true);
+        });
+    });
 });

--- a/sdk/python/src/catalog.py
+++ b/sdk/python/src/catalog.py
@@ -51,10 +51,12 @@ class Catalog():
 
         self.name = response.data
 
-    def _update_models(self):
+    def _update_models(self, force: bool = False):
         with self._lock:
-            # refresh every 6 hours
-            if (datetime.datetime.now() - self._last_fetch) < datetime.timedelta(hours=6):
+            # refresh every 6 hours, or immediately when forced (e.g. self-heal
+            # after a get_cached_models / get_model cache miss caused by a
+            # manually-added (BYOM) model dropped into the cache directory).
+            if not force and (datetime.datetime.now() - self._last_fetch) < datetime.timedelta(hours=6):
                 return
 
             response = self._core_interop.execute_command("get_model_list")
@@ -66,20 +68,42 @@ class Catalog():
             adapter = TypeAdapter(list[ModelInfo])
             models: List[ModelInfo] = adapter.validate_json(model_list_json)
 
-            self._model_alias_to_model.clear()
-            self._model_id_to_model_variant.clear()
+            # Incremental refresh: preserve wrapper identity for ids/aliases
+            # that survive the refresh so externally-held ``IModel`` references
+            # keep working with up-to-date metadata and (for ``Model``) keep
+            # any explicit ``select_variant()`` choice. New ids get fresh
+            # wrappers; removed ids get evicted.
+
+            fresh_ids: set[str] = set()
+            fresh_alias_groups: dict[str, List[ModelInfo]] = {}
+            for model_info in models:
+                fresh_ids.add(model_info.id)
+                fresh_alias_groups.setdefault(model_info.alias, []).append(model_info)
+
+            for stale_id in [mid for mid in self._model_id_to_model_variant if mid not in fresh_ids]:
+                del self._model_id_to_model_variant[stale_id]
+            for stale_alias in [a for a in self._model_alias_to_model if a not in fresh_alias_groups]:
+                del self._model_alias_to_model[stale_alias]
 
             for model_info in models:
-                variant = ModelVariant(model_info, self._model_load_manager, self._core_interop)
-
-                value = self._model_alias_to_model.get(model_info.alias)
-                if value is None:
-                    value = Model(variant, self._core_interop)
-                    self._model_alias_to_model[model_info.alias] = value
+                existing_variant = self._model_id_to_model_variant.get(model_info.id)
+                if existing_variant is not None:
+                    existing_variant._refresh_info(model_info)
                 else:
-                    value._add_variant(variant)
+                    self._model_id_to_model_variant[model_info.id] = ModelVariant(
+                        model_info, self._model_load_manager, self._core_interop
+                    )
 
-                self._model_id_to_model_variant[variant.id] = variant
+            for alias, alias_infos in fresh_alias_groups.items():
+                alias_variants = [self._model_id_to_model_variant[mi.id] for mi in alias_infos]
+                existing_model = self._model_alias_to_model.get(alias)
+                if existing_model is None:
+                    new_model = Model(alias_variants[0], self._core_interop)
+                    for variant in alias_variants[1:]:
+                        new_model._add_variant(variant)
+                    self._model_alias_to_model[alias] = new_model
+                else:
+                    existing_model._refresh_variants(alias_variants)
 
             self._models = models
             self._last_fetch = datetime.datetime.now()
@@ -102,7 +126,17 @@ class Catalog():
         :param model_alias: Model alias.
         :return: IModel if found.
         """
+        if not model_alias or not model_alias.strip():
+            return None
+
         self._update_models()
+        model = self._model_alias_to_model.get(model_alias)
+        if model is not None:
+            return model
+
+        # Self-heal: the alias may belong to a BYOM model added to the cache
+        # directory after our last catalog refresh.
+        self._update_models(force=True)
         return self._model_alias_to_model.get(model_alias)
 
     def get_model_variant(self, model_id: str) -> Optional[IModel]:
@@ -113,7 +147,17 @@ class Catalog():
         :param model_id: Model id.
         :return: IModel if found.
         """
+        if not model_id or not model_id.strip():
+            return None
+
         self._update_models()
+        variant = self._model_id_to_model_variant.get(model_id)
+        if variant is not None:
+            return variant
+
+        # Self-heal: the id may belong to a BYOM model added to the cache
+        # directory after our last catalog refresh.
+        self._update_models(force=True)
         return self._model_id_to_model_variant.get(model_id)
 
     def get_latest_version(self, model_or_model_variant: IModel) -> IModel:
@@ -152,14 +196,7 @@ class Catalog():
         self._update_models()
 
         cached_model_ids = get_cached_model_ids(self._core_interop)
-
-        cached_models: List[IModel] = []
-        for model_id in cached_model_ids:
-            model_variant = self._model_id_to_model_variant.get(model_id)
-            if model_variant is not None:
-                cached_models.append(model_variant)
-
-        return cached_models
+        return self._resolve_model_ids(cached_model_ids)
 
     def get_loaded_models(self) -> List[IModel]:
         """
@@ -169,11 +206,20 @@ class Catalog():
         self._update_models()
 
         loaded_model_ids = self._model_load_manager.list_loaded()
-        loaded_models: List[IModel] = []
-        
-        for model_id in loaded_model_ids:
-            model_variant = self._model_id_to_model_variant.get(model_id)
-            if model_variant is not None:
-                loaded_models.append(model_variant)
-        
-        return loaded_models
+        return self._resolve_model_ids(loaded_model_ids)
+
+    def _resolve_model_ids(self, model_ids: List[str]) -> List[IModel]:
+        """Resolve a list of model ids against the in-memory catalog,
+        self-healing once if any id is unknown (e.g. a manually-added BYOM
+        model the SDK has not yet seen). Preserves the input order of
+        ``model_ids`` (minus unknowns).
+        """
+        if any(model_id not in self._model_id_to_model_variant for model_id in model_ids):
+            self._update_models(force=True)
+
+        resolved: List[IModel] = []
+        for model_id in model_ids:
+            variant = self._model_id_to_model_variant.get(model_id)
+            if variant is not None:
+                resolved.append(variant)
+        return resolved

--- a/sdk/python/src/detail/model.py
+++ b/sdk/python/src/detail/model.py
@@ -45,6 +45,31 @@ class Model(IModel):
         if variant.info.cached and not self._selected_variant.info.cached:
             self._selected_variant = variant
 
+    def _refresh_variants(self, variants: List[ModelVariant]) -> None:
+        """Replace the variant list in place while preserving wrapper identity.
+
+        Called by ``Catalog._update_models`` during incremental refresh so a
+        user's held ``Model`` reference keeps pointing at the same object
+        across refreshes. Because ``Catalog._update_models`` reuses the same
+        ``ModelVariant`` wrappers for ids that survive a refresh, any
+        explicit ``select_variant()`` choice that survives the refresh is
+        preserved without any extra work here.
+
+        ``variants`` must be a non-empty list of ModelVariants all sharing
+        ``self._alias``.
+
+        TODO: tighten the held-reference contract for the case where the
+        previously selected variant is removed by a refresh; today
+        ``_selected_variant`` keeps pointing at the dropped wrapper and
+        callers must explicitly re-select.
+        """
+        if not variants:
+            raise FoundryLocalException(
+                f"Cannot refresh model {self._alias} with an empty variant list"
+            )
+
+        self._variants = list(variants)
+
     def select_variant(self, variant: IModel) -> None:
         """
         Select a specific model variant to use for IModel operations.

--- a/sdk/python/src/detail/model_variant.py
+++ b/sdk/python/src/detail/model_variant.py
@@ -44,6 +44,20 @@ class ModelVariant(IModel):
         self._id = model_info.id
         self._alias = model_info.alias
 
+    def _refresh_info(self, model_info: ModelInfo) -> None:
+        """Update the cached ``ModelInfo`` snapshot in place.
+
+        Called by ``Catalog._update_models`` when refreshing the catalog so
+        wrapper identity is preserved across refreshes while still surfacing
+        fresh metadata (notably ``cached``) on held references.
+
+        ``id`` and ``alias`` are immutable for a given variant; callers must
+        only invoke this with a ``model_info`` whose id matches ``self.id``.
+        Pointer reassignment is atomic under the GIL, so concurrent readers
+        observe either the old or new snapshot, never a torn intermediate.
+        """
+        self._model_info = model_info
+
     @property
     def id(self) -> str:
         """Unique model variant ID (e.g. ``name:version``)."""

--- a/sdk/python/test/test_catalog.py
+++ b/sdk/python/test/test_catalog.py
@@ -165,3 +165,275 @@ class TestCatalog:
         model.select_variant(latest_variant)
         result4 = catalog.get_latest_version(model)
         assert result4 is model
+
+    def test_should_self_heal_get_model_on_cache_miss(self):
+        """get_model() must trigger a forced refresh when the alias is unknown
+        in the cached map, surfacing BYOM models added to the cache directory
+        after the SDK was warmed up.
+        """
+        byom_model_infos = [
+            {
+                "id": "byom-self-heal:1",
+                "name": "byom-self-heal",
+                "version": 1,
+                "alias": "byom-self-heal",
+                "displayName": "BYOM Self Heal",
+                "providerType": "local",
+                "uri": "local://byom-self-heal/1",
+                "modelType": "ONNX",
+                "runtime": {"deviceType": "CPU", "executionProvider": "CPUExecutionProvider"},
+                "cached": True,
+                "createdAt": 1700000001,
+            }
+        ]
+
+        state = {"model_list_calls": 0}
+
+        class _MockCoreInterop:
+            def execute_command(self, command_name, command_input=None):
+                if command_name == "get_catalog_name":
+                    return Response(data="TestCatalog", error=None)
+                if command_name == "get_model_list":
+                    state["model_list_calls"] += 1
+                    # Warm path returns no models; the forced self-heal refresh
+                    # returns the BYOM.
+                    models = byom_model_infos if state["model_list_calls"] > 1 else []
+                    return Response(data=json.dumps(models), error=None)
+                return Response(data=None, error=f"Unexpected command: {command_name}")
+
+        class _MockModelLoadManager:
+            def list_loaded(self):
+                return []
+
+        catalog = Catalog(_MockModelLoadManager(), _MockCoreInterop())
+
+        model = catalog.get_model("byom-self-heal")
+        assert model is not None
+        assert model.alias == "byom-self-heal"
+
+        variant = catalog.get_model_variant("byom-self-heal:1")
+        assert variant is not None
+        assert variant.id == "byom-self-heal:1"
+
+        # First lookup: warm + forced refresh (2 calls).
+        # Second lookup hits the now-populated cache map directly; the inner
+        # TTL-gated _update_models() short-circuits, so no extra fetches.
+        assert state["model_list_calls"] == 2
+
+    def test_should_self_heal_get_cached_models_on_unknown_id(self):
+        """get_cached_models() must trigger a forced refresh when core returns
+        an id that the cached alias/variant maps do not yet know about.
+        """
+        byom_model_infos = [
+            {
+                "id": "byom-cached:1",
+                "name": "byom-cached",
+                "version": 1,
+                "alias": "byom-cached",
+                "displayName": "BYOM Cached",
+                "providerType": "local",
+                "uri": "local://byom-cached/1",
+                "modelType": "ONNX",
+                "runtime": {"deviceType": "CPU", "executionProvider": "CPUExecutionProvider"},
+                "cached": True,
+                "createdAt": 1700000001,
+            }
+        ]
+
+        state = {"model_list_calls": 0}
+
+        class _MockCoreInterop:
+            def execute_command(self, command_name, command_input=None):
+                if command_name == "get_catalog_name":
+                    return Response(data="TestCatalog", error=None)
+                if command_name == "get_model_list":
+                    state["model_list_calls"] += 1
+                    models = byom_model_infos if state["model_list_calls"] > 1 else []
+                    return Response(data=json.dumps(models), error=None)
+                if command_name == "get_cached_models":
+                    # Core always reports the BYOM as cached; the SDK has to
+                    # self-heal to learn it exists.
+                    return Response(data='["byom-cached:1"]', error=None)
+                return Response(data=None, error=f"Unexpected command: {command_name}")
+
+        class _MockModelLoadManager:
+            def list_loaded(self):
+                return []
+
+        catalog = Catalog(_MockModelLoadManager(), _MockCoreInterop())
+
+        cached = catalog.get_cached_models()
+        assert len(cached) == 1
+        assert cached[0].id == "byom-cached:1"
+        assert state["model_list_calls"] == 2
+
+    def test_should_not_refresh_catalog_on_empty_or_whitespace_input(self):
+        """get_model() / get_model_variant() must short-circuit on
+        empty / whitespace / None input without triggering the (expensive)
+        forced catalog refresh that powers the self-heal path.
+        """
+        state = {"model_list_calls": 0}
+
+        class _MockCoreInterop:
+            def execute_command(self, command_name, command_input=None):
+                if command_name == "get_catalog_name":
+                    return Response(data="TestCatalog", error=None)
+                if command_name == "get_model_list":
+                    state["model_list_calls"] += 1
+                    return Response(data="[]", error=None)
+                return Response(data=None, error=f"Unexpected command: {command_name}")
+
+        class _MockModelLoadManager:
+            def list_loaded(self):
+                return []
+
+        catalog = Catalog(_MockModelLoadManager(), _MockCoreInterop())
+
+        # Warm the catalog so the inner TTL-gated _update_models() would not
+        # itself fetch for a valid input either — any increment of
+        # model_list_calls below would prove an unwanted forced refresh.
+        catalog.list_models()
+        assert state["model_list_calls"] == 1
+
+        for invalid in ("", "   ", None):
+            assert catalog.get_model(invalid) is None
+            assert catalog.get_model_variant(invalid) is None
+
+        assert state["model_list_calls"] == 1
+
+
+class TestIncrementalRefresh:
+    """Catalog._update_models incremental-refresh behavior.
+
+    The refresh path is shared by all Catalog methods. These tests pin down
+    the contract that externally-held IModel references and per-Model variant
+    selection survive across forced refreshes when the underlying model id is
+    still present in the fresh catalog. They guard against regressing back to
+    the clear-and-rebuild pattern that churned wrapper identity on every
+    refresh.
+    """
+
+    @staticmethod
+    def _model_info(model_id: str, alias: str, cached: bool, context_length: int = 1024) -> dict:
+        return {
+            "id": model_id,
+            "name": alias,
+            "version": int(model_id.split(":")[-1]),
+            "alias": alias,
+            "displayName": alias,
+            "providerType": "local",
+            "uri": f"local://{alias}/{model_id.split(':')[-1]}",
+            "modelType": "ONNX",
+            "runtime": {"deviceType": "CPU", "executionProvider": "CPUExecutionProvider"},
+            "cached": cached,
+            "createdAt": 1700000001,
+            "contextLength": context_length,
+        }
+
+    def _make_catalog(self, responses: list[list[dict]]):
+        """Build a Catalog whose ``get_model_list`` IPC returns ``responses[N]``
+        on the (N+1)-th call. ``get_cached_models`` and ``list_loaded_models``
+        return empty.
+        """
+        state = {"call": 0}
+
+        class _MockCoreInterop:
+            def execute_command(self, command_name, command_input=None):
+                if command_name == "get_catalog_name":
+                    return Response(data="TestCatalog", error=None)
+                if command_name == "get_model_list":
+                    idx = min(state["call"], len(responses) - 1)
+                    state["call"] += 1
+                    return Response(data=json.dumps(responses[idx]), error=None)
+                if command_name == "get_cached_models":
+                    return Response(data="[]", error=None)
+                return Response(data=None, error=f"Unexpected command: {command_name}")
+
+        class _MockModelLoadManager:
+            def list_loaded(self):
+                return []
+
+        return Catalog(_MockModelLoadManager(), _MockCoreInterop()), state
+
+    def test_should_preserve_identity_and_propagate_info_on_refresh(self):
+        """A held IModel / ModelVariant reference must survive a forced refresh
+        when the id is still present (identity preserved) AND surface fresh
+        ModelInfo through the same reference (in-place info refresh, not
+        replace-and-rebuild). Mutating info is the natural way to prove the
+        post-refresh wrapper IS the pre-refresh wrapper, not a fresh one that
+        compares equal.
+        """
+        first_state = [self._model_info("a:1", "alpha", cached=False, context_length=1024)]
+        second_state = [self._model_info("a:1", "alpha", cached=True, context_length=2048)]
+        catalog, _ = self._make_catalog([first_state, second_state])
+
+        first_model = catalog.get_model("alpha")
+        first_variant = catalog.get_model_variant("a:1")
+        assert first_variant.info.cached is False
+        assert first_variant.info.context_length == 1024
+
+        catalog._update_models(force=True)
+
+        second_model = catalog.get_model("alpha")
+        second_variant = catalog.get_model_variant("a:1")
+        assert first_model is second_model
+        assert first_variant is second_variant
+        # Same held reference now reflects the fresh ModelInfo.
+        assert first_variant.info.cached is True
+        assert first_variant.info.context_length == 2048
+
+    def test_selection_survives_refresh(self):
+        """When the selected variant's id is still present after a refresh,
+        ``select_variant()`` survives so subsequent ops (``load``, ``unload``,
+        ...) target the user's pick. Wrapper identity is preserved by
+        ``Catalog._update_models`` reusing the same ``ModelVariant`` for
+        surviving ids, so ``_refresh_variants`` does not need to touch
+        ``_selected_variant``.
+        """
+        v1 = self._model_info("multi:1", "multi", cached=True)
+        v2 = self._model_info("multi:2", "multi", cached=True)
+        both = [v1, v2]
+        catalog, _ = self._make_catalog([both, both])
+
+        model = catalog.get_model("multi")
+        variant_v2 = next(v for v in model.variants if v.id == "multi:2")
+        model.select_variant(variant_v2)
+        assert model.id == "multi:2"
+
+        catalog._update_models(force=True)
+        assert model.id == "multi:2"
+        assert len(model.variants) == 2
+
+    def test_should_apply_adds_and_removes_on_refresh(self):
+        """Ids no longer present must be evicted from both
+        ``_model_id_to_model_variant`` and ``_model_alias_to_model``; new ids
+        must be inserted as fresh wrappers. Both directions are symmetric and
+        share setup, so we cover them in one test against a single refresh
+        that does both at once. We probe the internal maps directly to avoid
+        triggering the public self-heal paths.
+        """
+        first_state = [
+            self._model_info("a:1", "alpha", cached=True),
+            self._model_info("b:1", "beta", cached=True),
+        ]
+        second_state = [
+            self._model_info("a:1", "alpha", cached=True),
+            self._model_info("byom:1", "byom-new", cached=True),
+        ]
+        catalog, _ = self._make_catalog([first_state, second_state])
+
+        # Warm the catalog and confirm the pre-state via internal maps so we
+        # don't trip the public self-heal paths.
+        catalog.list_models()
+        assert "alpha" in catalog._model_alias_to_model
+        assert "beta" in catalog._model_alias_to_model
+        assert "byom-new" not in catalog._model_alias_to_model
+        assert "byom:1" not in catalog._model_id_to_model_variant
+
+        catalog._update_models(force=True)
+
+        assert "alpha" in catalog._model_alias_to_model
+        assert "beta" not in catalog._model_alias_to_model
+        assert "b:1" not in catalog._model_id_to_model_variant
+        assert "byom-new" in catalog._model_alias_to_model
+        assert "byom:1" in catalog._model_id_to_model_variant

--- a/sdk/rust/src/catalog.rs
+++ b/sdk/rust/src/catalog.rs
@@ -138,6 +138,14 @@ impl Catalog {
             });
         }
         self.update_models().await?;
+        if let Some(model) = self.lock_state()?.models_by_alias.get(alias).cloned() {
+            return Ok(model);
+        }
+
+        // Self-heal: the alias may belong to a BYOM model added to the cache
+        // directory after our last catalog refresh.
+        self.invalidator.invalidate();
+        self.update_models().await?;
         let s = self.lock_state()?;
         s.models_by_alias.get(alias).cloned().ok_or_else(|| {
             let available: Vec<&str> = s.models_by_alias.keys().map(|k| k.as_str()).collect();
@@ -159,6 +167,14 @@ impl Catalog {
             });
         }
         self.update_models().await?;
+        if let Some(variant) = self.lock_state()?.variants_by_id.get(id).cloned() {
+            return Ok(variant);
+        }
+
+        // Self-heal: the id may belong to a BYOM model added to the cache
+        // directory after our last catalog refresh.
+        self.invalidator.invalidate();
+        self.update_models().await?;
         let s = self.lock_state()?;
         s.variants_by_id.get(id).cloned().ok_or_else(|| {
             let available: Vec<&str> = s.variants_by_id.keys().map(|k| k.as_str()).collect();
@@ -179,19 +195,34 @@ impl Catalog {
             return Ok(Vec::new());
         }
         let cached_ids: Vec<String> = serde_json::from_str(&raw)?;
-        let s = self.lock_state()?;
-        Ok(cached_ids
-            .iter()
-            .filter_map(|id| s.variants_by_id.get(id).cloned())
-            .collect())
+        self.resolve_model_ids(&cached_ids).await
     }
 
     /// Return model variants that are currently loaded into memory.
     pub async fn get_loaded_models(&self) -> Result<Vec<Arc<Model>>> {
         self.update_models().await?;
         let loaded_ids = self.model_load_manager.list_loaded().await?;
+        self.resolve_model_ids(&loaded_ids).await
+    }
+
+    /// Resolve a list of model ids against the in-memory catalog, self-healing
+    /// once if any id is unknown (e.g. a manually-added BYOM model the SDK has
+    /// not yet seen). Preserves the input order of `model_ids` (minus unknowns).
+    async fn resolve_model_ids(&self, model_ids: &[String]) -> Result<Vec<Arc<Model>>> {
+        let needs_refresh = {
+            let s = self.lock_state()?;
+            model_ids
+                .iter()
+                .any(|id| !s.variants_by_id.contains_key(id))
+        };
+
+        if needs_refresh {
+            self.invalidator.invalidate();
+            self.update_models().await?;
+        }
+
         let s = self.lock_state()?;
-        Ok(loaded_ids
+        Ok(model_ids
             .iter()
             .filter_map(|id| s.variants_by_id.get(id).cloned())
             .collect())
@@ -269,15 +300,47 @@ impl Catalog {
                 .add_variant(variant);
         }
 
-        let alias_map: HashMap<String, Arc<Model>> = alias_map_build
+        let fresh_alias_map: HashMap<String, Arc<Model>> = alias_map_build
             .into_iter()
             .map(|(k, v)| (k, Arc::new(v)))
             .collect();
 
-        // Atomic swap under a single lock — no split-brain reads.
+        // Incremental refresh: hold the data lock for the entire compare-and-
+        // swap so the merged maps are computed against the same `old` snapshot
+        // they will replace. Reuse the existing `Arc<Model>` whenever the
+        // per-key `(id, cached)` fingerprint is unchanged so externally held
+        // references keep working with up-to-date metadata and (for aliased
+        // models) keep any explicit `select_variant` choice across refreshes.
         let mut s = self.lock_state()?;
-        s.models_by_alias = alias_map;
-        s.variants_by_id = id_map;
+
+        let merged_alias_map: HashMap<String, Arc<Model>> = fresh_alias_map
+            .into_iter()
+            .map(|(alias, fresh_arc)| {
+                let reuse = s
+                    .models_by_alias
+                    .get(&alias)
+                    .filter(|old_arc| alias_fingerprint(old_arc) == alias_fingerprint(&fresh_arc))
+                    .map(Arc::clone);
+                (alias, reuse.unwrap_or(fresh_arc))
+            })
+            .collect();
+
+        let merged_id_map: HashMap<String, Arc<Model>> = id_map
+            .into_iter()
+            .map(|(id, fresh_arc)| {
+                let reuse = s
+                    .variants_by_id
+                    .get(&id)
+                    .filter(|old_arc| {
+                        variant_fingerprint(old_arc) == variant_fingerprint(&fresh_arc)
+                    })
+                    .map(Arc::clone);
+                (id, reuse.unwrap_or(fresh_arc))
+            })
+            .collect();
+
+        s.models_by_alias = merged_alias_map;
+        s.variants_by_id = merged_id_map;
         s.last_refresh = Some(Instant::now());
 
         Ok(())
@@ -288,4 +351,23 @@ impl Catalog {
             reason: "catalog state mutex poisoned".into(),
         })
     }
+}
+
+/// Fingerprint of an alias-grouped `Model`: the `(id, cached)` of every
+/// variant in catalog order. Two fingerprints are equal exactly when reusing
+/// the old `Arc<Model>` would surface the same `ModelInfo` data as a freshly
+/// built one — i.e. no variants were added, removed, reordered, or had their
+/// `cached` flag flipped. Per the [crate::types::ModelInfo] contract, all
+/// other fields on a given `id` are treated as immutable.
+fn alias_fingerprint(model: &Model) -> Vec<(String, bool)> {
+    model
+        .variants()
+        .iter()
+        .map(|v| (v.info().id.clone(), v.info().cached))
+        .collect()
+}
+
+/// Fingerprint of a single-variant `Model`: just its `(id, cached)`.
+fn variant_fingerprint(model: &Model) -> (String, bool) {
+    (model.info().id.clone(), model.info().cached)
 }


### PR DESCRIPTION
The SDKs cache the catalog in memory with a 6-hour TTL. When a user manually drops a model directory (BYOM) into the cache while the SDK is running, the SDK''s in-memory map is stale: Core returns the BYOM id from `get_cached_models` and `get_model_list` IPCs, but the SDK filters it out for getModel/getModelVariant because its `modelIdToModelVariant` map is still stale.

## Self-heal on cache-miss

Force-refresh path in the four user-facing entry points:
- `get_cached_models` / `get_loaded_models`: when any id in the fresh list returned by Core does not resolve against the local map, force a catalog refresh and re-resolve only the unresolved ids.
- `get_model(alias)` / `get_model_variant(id)`: on miss, force a refresh and retry the lookup once.

A `UpdateModels(ct)` warm-up call was added to the C# `get_model` / `get_model_variant` paths for consistency with the other SDKs (not strictly required for BYOM).

## Catalog refresh is now incremental

Previously every catalog refresh was clear-and-rebuild, which orphaned every `Model` / `ModelVariant` wrapper a caller was holding. After this PR, refresh preserves wrapper identity for ids that survive:
- C# / JS / Python: `Catalog.UpdateModels` reuses existing `ModelVariant` wrappers and calls `RefreshInfo(info)` to surface fresh metadata in place. `Model` wrappers are reused per alias and `RefreshVariants` swaps the backing variant list by reference (no torn reads). Evicted ids are dropped from the maps.
- Rust: `apply_model_list` reuses the same `Arc<Model>` across refreshes when the `(id, cached)` fingerprint is unchanged, so the inner `AtomicUsize` selected-variant index survives.

Explicit `SelectVariant()` choices are preserved trivially because the wrapper identity is preserved.

## Limitations

If the previously-selected variant is removed by a refresh, `SelectedVariant` keeps pointing at the dropped wrapper and callers must explicitly re-select - pre-existing issue that would take ~30 lines per SDK to fix, but unlikely to happen.
## Tests

New `CatalogSelfHealTests` and `CatalogIncrementalRefreshTests` (+ JS / Python equivalents) cover: self-heal on cache miss, no refresh on empty/whitespace input, identity + info propagation across refreshes, selection survival, and add/remove transitions.

Validated against a real BYOM directory dropped into the cache at runtime.

=================


More detailed description:
_cachedModels (disk) and _cachedInfo (Azure metadata) are always populated at the start

FLCore Changes:
- Disk gets scanned in 
- `RefreshLocalCachedModelsAsync` (thread-safe function bc lock) in `AzureModelCatalog.cs` — refreshes the in-memory `_cachedModels` dictionary from disk.
- *"We expect users will not manually delete an Azure-cataloged model, so we do not make a new trip to Azure Catalog or invalidate `_cachedInfo` here."*
- New BYOM ids get inserted with `Model = null` (we assume they do not match a model in Azure Catalog), so no Azure call.
- `GetCurrentCachedModelsAndPaths` (existing) to extract `modelId`.



In FLCore, `RefreshLocalCachedModelsAsync` is called by `GetCachedModelsAsync`, `GetModelsAsync`, and `RemoveCachedModelAsync`. It will be called by `GetModelInfoAsync` only if we have not created a BYOM model stub for the catalog, but it will be cached after that.

| Core method | When RefreshLocalCachedModelsAsync is called |

|------------------------------------------|------------------------------------------------------------|
| `GetCachedModelsAsync`                   | Always |
| `GetModelsAsync`                         | Always |
| `RemoveCachedModelAsync`                 | Always |
| `GetModelInfoAsync` | At most once each time we see a new BYOM model |

`GetModelInfoAsync` ONLY calls `RefreshLocalCachedModelsAsync` if we looked up a BYOM model by calling (`get_model_path`, `load_model`, `unload_model` IPC handlers called by SDKs or OpenAI API and by `GetChatClientAsync` on every chat completion), and we have not created a BYOM model stub for the catalog. Once we have created a BYOM model stub, it is cached for the rest of the session, so we only validate `Directory.Exists` for the BYOM model (1 syscall is much quicker than scanning whole directory) after that to ensure it has not been deleted. (If it has been deleted, we return `null` for AzureFoundryLocalModel)

HTTP Method changes:
| HTTP endpoint | Core method backing it |

|------------------------------------------------|--------------------------------------------------------------------------------------------------------------| | `GET /v1/models` | `GetCachedModelsAsync()` (always rescans disk after this PR) + then will only check if directory for BYOM model exists in `GetModelInfoAsync` |
| `GET /openai/models` | `GetCachedModelsAsync()` (always rescans disk after this PR) |
| `POST /v1/chat/completions` (and friends) |
`GetModelInfoAsync(id_or_alias)` — validates `Directory.Exists`, falls through to refresh + synth if needed |
| `GET /openai/load/{model}` | same `GetModelInfoAsync` lookup | | `GET /openai/unload/{model}` | same `GetModelInfoAsync` lookup |


SDK changes:

| SDK method                              | Scan disk trigger |

|-----------------------------------------|------------------------------------------------------------| | `catalog.GetModelAsync(alias)` | Alias not in local map and if we exceed TTL of 6 hours* |
| `catalog.GetModelVariantAsync(id)` | Id not in local map and if we exceed TTL of 6 hours* |
| `catalog.GetCachedModelsAsync()`        | Always **|
| `catalog.GetLoadedModelsAsync()` | If load-manager's list contains an
id missing from local map (unlikely, but may be possible if multiple
processes using SDK) |
| `model.IsCachedAsync()` | Always, bc this is fresher than
model.Info.Cached |


\* we may end up scanning twice if we have a. once if we have hit the TTL and would have anyway and b. because of this PR, after scanning, if we still can't find the model (likely bc of a typo), we will scan again due to force refresh after cache miss

** - we will end up scanning twice - once to get the model name (string) for GetCachedModels, another time because we call `UpdateModels(ct, force: true)` to get the ModelInfo


Flow for GetModelAsync

```
Program.cs
  └─ catalog.GetModelAsync(byomAlias)
       │  sdk/cs/src/Catalog.cs:73 → GetModelImplAsync at line 157
       │   ├─ UpdateModels(ct, force: false)                # within 6h TTL → no-op
       │   ├─ _modelAliasToModel.TryGetValue(alias, …)→null # cache miss
       │   ├─ UpdateModels(ct, force: true)                 # SELF-HEAL
       │   │    └─ _coreInterop.ExecuteCommandAsync("get_model_list")
       │   │         │  IPC → foundry-local-service
       │   │         ▼
       │   │       Core AzureModelCatalog.GetModelsAsync(ct)
       │   │         ├─ base.GetModelsAsync(ct)                       # uses 4h Azure cache; no extra catalog calls
       │   │         ├─ RefreshLocalCachedModelsAsync(ct)             # ALWAYS re-scans disk
       │   │         │    └─ GetCurrentCachedModelsAndPaths()
       │   │         │         └─ Directory.GetDirectories(_cacheDirectory, *, AllDirectories)
       │   │         │              + for each dir: read inference_model.json → modelId
       │   │         ├─ drop stale Local stubs whose dir was deleted
       │   │         ├─ append cache-only stubs for new BYOMs
       │   │         └─ return combined list
       │   ▼
       └─ _modelAliasToModel.TryGetValue(alias, …) → Model
```

Flow for GetModelVariantAsync is similar; we just access a different map

```
Program.cs
  └─ catalog.GetModelVariantAsync(byomId)
       │  sdk/cs/src/Catalog.cs:81 → GetModelVariantImplAsync at line 187
       │   ├─ UpdateModels(ct, force: false)                # within 6h TTL → no-op
       │   ├─ _modelIdToModelVariant.TryGetValue(id, …) → null # cache miss
       │   ├─ UpdateModels(ct, force: true)                 # SELF-HEAL (same IPC + disk rescan as A1)
       │   ▼
       └─ _modelIdToModelVariant.TryGetValue(id, …) → Model 
```

Flow for GetCachedModelsAsync must scan the disk twice - once to return strings for model names from FLCore's GetCachedModelsAsync and once to fetch latest GetModelsAsync (which has Model information). GetLoadedModelsAsync is similar.

```
Program.cs
  └─ catalog.GetCachedModelsAsync(byomId)
       │  sdk/cs/src/Catalog.cs:73 → GetModelImplAsync at line 157
       │   ├─ UpdateModels(ct, force: false)                # within 6h TTL → no-op
       │   ├─ _modelAliasToModel.TryGetValue(alias, …)→null # cache miss
       │   ├─ UpdateModels(ct, force: true)                 # SELF-HEAL
       │   │    └─ _coreInterop.ExecuteCommandAsync("get_model_list")
       │   │         │  IPC → foundry-local-service
       │   │         ▼
       │   │       Core AzureModelCatalog.GetModelsAsync(ct)
       │   │         ├─ base.GetModelsAsync(ct)                       # uses 4h Azure cache; no extra catalog calls
       │   │         ├─ RefreshLocalCachedModelsAsync(ct)             # ALWAYS re-scans disk
       │   │         │    └─ GetCurrentCachedModelsAndPaths()
       │   │         │         └─ Directory.GetDirectories(_cacheDirectory, *, AllDirectories)
       │   │         │              + for each dir: read inference_model.json → modelId
       │   │         ├─ drop stale Local stubs whose dir was deleted
       │   │         ├─ append cache-only stubs for new BYOMs
       │   │         └─ return combined list
       │   ▼
       └─ _modelAliasToModel.TryGetValue(alias, …) → Model
```

Get Loaded models
```
Program.cs
  └─ model.LoadAsync(ct)                                    # sdk/cs/src/Detail/Model.cs:153
       └─ SelectedVariant.LoadAsync(ct)                     # sdk/cs/src/Detail/ModelVariant.cs:95
            └─ _modelLoadManager.LoadModelAsync(modelId, customPath=null, ct)  # ModelManager.cs:65
                ├─ _modelCatalog.GetModelInfoAsync(modelId)
                │    │  AzureModelCatalog.GetModelInfoAsync override
                │    ├─ base.GetModelInfoAsync(modelId)             # miss for new BYOM
                │    ├─ RefreshLocalCachedModelsAsync(ct)           # SELF-HEAL: rescan disk
                │    │    └─ GetCurrentCachedModelsAndPaths()       # finds the new BYOM dir
                │    └─ TrySynthesizeByomStubAsync(modelId)         # writes stub into _cachedInfo
                │         └─ returns stub                           # cached for next time
                ├─ modelInfo != null → proceed to load
                └─ _modelCatalog.GetModelPathAsync(modelId)         # re-uses cached stub
                        → InferenceModel constructed from dir
                        returns Status.Success  ✓ FIX_ACTIVE
```

---------