### PR TITLE
Cherry-pick #775 to rel-1.2.1: Bump FLCore to 1.2.1 / ORT-GenAI to 0.14.1

### DIFF
--- a/sdk/cpp/CMakeLists.txt
+++ b/sdk/cpp/CMakeLists.txt
@@ -81,9 +81,9 @@ endif()
 # -----------------------------
 if(WIN32)
 
-set(FL_CORE_VERSION "1.2.0" CACHE STRING "Microsoft.AI.Foundry.Local.Core NuGet version")
+set(FL_CORE_VERSION "1.2.1" CACHE STRING "Microsoft.AI.Foundry.Local.Core NuGet version")
 set(FL_ORT_VERSION "1.26.0" CACHE STRING "Microsoft.ML.OnnxRuntime.Foundry NuGet version")
-set(FL_ORTGENAI_VERSION "0.14.0" CACHE STRING "Microsoft.ML.OnnxRuntimeGenAI.Foundry NuGet version")
+set(FL_ORTGENAI_VERSION "0.14.1" CACHE STRING "Microsoft.ML.OnnxRuntimeGenAI.Foundry NuGet version")
 set(FL_NATIVE_DEPS_DIR "${CMAKE_CURRENT_BINARY_DIR}/_native_deps")
 
 function(fl_ensure_nuget_package PKG_NAME PKG_VERSION)

--- a/sdk/cpp/README.md
+++ b/sdk/cpp/README.md
@@ -61,9 +61,9 @@ This uses the `x64-debug` preset which:
 - Resolves C++ dependencies via **vcpkg** (`nlohmann-json`, `ms-gsl`, `gtest`)
 - Builds with the `x64-windows-static-md` triplet
 - Auto-downloads native runtime DLLs via **NuGet**:
-  - `Microsoft.AI.Foundry.Local.Core` (1.2.0) — Foundry Local core runtime
+  - `Microsoft.AI.Foundry.Local.Core` (1.2.1) — Foundry Local core runtime
   - `Microsoft.ML.OnnxRuntime.Foundry` (1.26.0) — ONNX Runtime
-  - `Microsoft.ML.OnnxRuntimeGenAI.Foundry` (0.14.0) — ONNX Runtime GenAI
+  - `Microsoft.ML.OnnxRuntimeGenAI.Foundry` (0.14.1) — ONNX Runtime GenAI
 
 NuGet packages are cached in `out/build/<preset>/_native_deps/` and only downloaded on first configure. Runtime DLLs are automatically copied next to executables via post-build steps.
 

--- a/sdk/deps_versions.json
+++ b/sdk/deps_versions.json
@@ -1,12 +1,12 @@
 {
   "foundry-local-core": {
-    "nuget": "1.2.0",
-    "python": "1.2.0"
+    "nuget": "1.2.1",
+    "python": "1.2.1"
   },
   "onnxruntime": {
     "version": "1.26.0"
   },
   "onnxruntime-genai": {
-    "version": "0.14.0"
+    "version": "0.14.1"
   }
 }

--- a/sdk/deps_versions_winml.json
+++ b/sdk/deps_versions_winml.json
@@ -1,7 +1,7 @@
 {
   "foundry-local-core": {
-    "nuget": "1.2.0",
-    "python": "1.2.0"
+    "nuget": "1.2.1",
+    "python": "1.2.1"
   },
   "windows-ai-machinelearning": {
     "version": "2.1.1"
@@ -10,6 +10,6 @@
     "version": "1.26.0"
   },
   "onnxruntime-genai": {
-    "version": "0.14.0"
+    "version": "0.14.1"
   }
 }

--- a/sdk/python/requirements-winml.txt
+++ b/sdk/python/requirements-winml.txt
@@ -2,6 +2,6 @@ pydantic>=2.0.0
 requests>=2.32.4
 openai>=2.24.0
 # WinML native binary packages from the ORT-Nightly PyPI feed.
-foundry-local-core-winml==1.2.0
+foundry-local-core-winml==1.2.1
 onnxruntime-core==1.26.0
-onnxruntime-genai-core==0.14.0
+onnxruntime-genai-core==0.14.1

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -5,10 +5,10 @@ openai>=2.24.0
 # - Linux x86_64:   onnxruntime-gpu / onnxruntime-genai-cuda (CUDA-enabled wheels).
 # - Linux aarch64:  onnxruntime / onnxruntime-genai (the CUDA variants do not ship aarch64 binaries).
 # - Other platforms: onnxruntime-core / onnxruntime-genai-core (cross-platform variants).
-foundry-local-core==1.2.0
+foundry-local-core==1.2.1
 onnxruntime-core==1.26.0; sys_platform != "linux"
 onnxruntime-gpu==1.26.0; sys_platform == "linux" and platform_machine == "x86_64"
 onnxruntime==1.26.0; sys_platform == "linux" and platform_machine == "aarch64"
-onnxruntime-genai-core==0.14.0; sys_platform != "linux"
-onnxruntime-genai-cuda==0.14.0; sys_platform == "linux" and platform_machine == "x86_64"
-onnxruntime-genai==0.14.0; sys_platform == "linux" and platform_machine == "aarch64"
+onnxruntime-genai-core==0.14.1; sys_platform != "linux"
+onnxruntime-genai-cuda==0.14.1; sys_platform == "linux" and platform_machine == "x86_64"
+onnxruntime-genai==0.14.1; sys_platform == "linux" and platform_machine == "aarch64"


### PR DESCRIPTION
Cherry-picks #775 (commit 7710b972) onto `releases/rel-1.2.1`.

Bumps `sdk/` pins to FLCore `1.2.1` + ORT-GenAI `0.14.1`; ORT stays at `1.26.0`. Clean cherry-pick, no conflicts.

Original PR: #775
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>