### PR TITLE
migrates SDK from Microsoft.ML.OnnxRuntime.Foundry to Microsoft.ML.OnnxRuntime

### DIFF
--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -53,18 +53,7 @@ parameters:
 
 variables:
 - group: FoundryLocal-ESRP-Signing
-# C++ SDK (sdk_v2/cpp) native dependency versions. Must match cmake defaults
-# in sdk_v2/deps_versions.json and sdk_v2/deps_versions_winml.json.
-- name: cppOrtVersion
-  value: '1.25.1'
-- name: cppOrtVersionWinml
-  # Pinned to the WinML-aligned ORT line so foundry_local.dll's ORT ABI matches
-  # the WinML EP catalog plugins it loads. See FindOnnxRuntime.cmake.
-  value: '1.23.2.3'
-- name: cppGenaiVersion
-  value: '0.13.2'
-- name: cppWinmlVersion
-  value: '1.8.2192'
+# All ORT/GenAI/WinML versions are read from sdk_v2/deps_versions.json at runtime.
 - name: cppBuildConfig
   value: 'RelWithDebInfo'
 
@@ -268,7 +257,3 @@ extends:
     - template: v2/templates/stages-sdk-v2.yml
       parameters:
         buildConfig: $(cppBuildConfig)
-        ortVersion: $(cppOrtVersion)
-        ortVersionWinml: $(cppOrtVersionWinml)
-        genaiVersion: $(cppGenaiVersion)
-        winmlVersion: $(cppWinmlVersion)

--- a/.pipelines/v2/sdk_v2-pipeline-plan.md
+++ b/.pipelines/v2/sdk_v2-pipeline-plan.md
@@ -254,7 +254,7 @@ purposes:
 
 Versions are pipeline-level variables, currently:
 
-* `ortVersion`        `1.25.1`   (`Microsoft.ML.OnnxRuntime.Foundry`)
+* `ortVersion`        `1.25.1`   (`Microsoft.ML.OnnxRuntime`)
 * `ortVersionWinml`   `1.23.2.3` (WinML-aligned ORT line, used by the WinML build stages)
 * `genaiVersion`      `0.13.2`   (`Microsoft.ML.OnnxRuntimeGenAI.Foundry`)
 * `winmlVersion`      `1.8.2192` (`Microsoft.WindowsAppSDK.ML`)

--- a/.pipelines/v2/templates/stages-build-native.yml
+++ b/.pipelines/v2/templates/stages-build-native.yml
@@ -8,17 +8,11 @@
 #                       (win-x64, win-arm64, linux-x64, osx-arm64)
 #   pack_nuget_winml  – Microsoft.AI.Foundry.Local.Runtime.WinML
 #                       (win-x64, win-arm64; both built with --use_winml)
+#
+# ORT/GenAI versions are read from sdk_v2/deps_versions.json at runtime.
 
 parameters:
 - name: buildConfig
-  type: string
-- name: ortVersion
-  type: string
-- name: ortVersionWinml
-  type: string
-- name: genaiVersion
-  type: string
-- name: winmlVersion
   type: string
 
 stages:
@@ -52,9 +46,6 @@ stages:
         parameters:
           arch: x64
           buildConfig: ${{ parameters.buildConfig }}
-          ortVersion: ${{ parameters.ortVersion }}
-          genaiVersion: ${{ parameters.genaiVersion }}
-          winmlVersion: ${{ parameters.winmlVersion }}
           runTests: true
           stageHeaders: true
 
@@ -84,14 +75,11 @@ stages:
         parameters:
           arch: arm64
           buildConfig: ${{ parameters.buildConfig }}
-          ortVersion: ${{ parameters.ortVersion }}
-          genaiVersion: ${{ parameters.genaiVersion }}
-          winmlVersion: ${{ parameters.winmlVersion }}
           runTests: false
           stageHeaders: false
 
   # ====================================================================
-  # Linux x64 — build + test
+  # Linux x64— build + test
   # ====================================================================
   - stage: cpp_build_linux_x64
     displayName: 'C++ Native: Linux x64'
@@ -115,8 +103,6 @@ stages:
       - template: steps-build-linux.yml
         parameters:
           buildConfig: ${{ parameters.buildConfig }}
-          ortVersion: ${{ parameters.ortVersion }}
-          genaiVersion: ${{ parameters.genaiVersion }}
           runTests: true
 
   # ====================================================================
@@ -146,8 +132,6 @@ stages:
       - template: steps-build-macos.yml
         parameters:
           buildConfig: ${{ parameters.buildConfig }}
-          ortVersion: ${{ parameters.ortVersion }}
-          genaiVersion: ${{ parameters.genaiVersion }}
           runTests: true
 
   # ====================================================================
@@ -181,9 +165,6 @@ stages:
         parameters:
           arch: x64
           buildConfig: ${{ parameters.buildConfig }}
-          ortVersion: ${{ parameters.ortVersionWinml }}
-          genaiVersion: ${{ parameters.genaiVersion }}
-          winmlVersion: ${{ parameters.winmlVersion }}
           useWinml: true
           runTests: true
           stageHeaders: false
@@ -214,9 +195,6 @@ stages:
         parameters:
           arch: arm64
           buildConfig: ${{ parameters.buildConfig }}
-          ortVersion: ${{ parameters.ortVersionWinml }}
-          genaiVersion: ${{ parameters.genaiVersion }}
-          winmlVersion: ${{ parameters.winmlVersion }}
           useWinml: true
           runTests: false
           stageHeaders: false
@@ -261,8 +239,6 @@ stages:
       steps:
       - template: steps-pack-nuget.yml
         parameters:
-          ortVersion: ${{ parameters.ortVersion }}
-          genaiVersion: ${{ parameters.genaiVersion }}
           variant: base
 
   # ====================================================================
@@ -297,6 +273,4 @@ stages:
       steps:
       - template: steps-pack-nuget.yml
         parameters:
-          ortVersion: ${{ parameters.ortVersionWinml }}
-          genaiVersion: ${{ parameters.genaiVersion }}
           variant: winml

--- a/.pipelines/v2/templates/stages-sdk-v2.yml
+++ b/.pipelines/v2/templates/stages-sdk-v2.yml
@@ -9,19 +9,14 @@
 # publishes the `version-info` pipeline artifact (containing sdkVersion.txt
 # and pyVersion.txt). All downstream stages read from that artifact rather
 # than recomputing a timestamp.
+#
+# ORT/GenAI/WinML versions are read from sdk_v2/deps_versions.json at runtime
+# by each build job — no version parameters needed here.
 
 parameters:
 - name: buildConfig
   type: string
   default: 'RelWithDebInfo'
-- name: ortVersion
-  type: string
-- name: ortVersionWinml
-  type: string
-- name: genaiVersion
-  type: string
-- name: winmlVersion
-  type: string
 
 stages:
 
@@ -29,10 +24,6 @@ stages:
 - template: stages-build-native.yml
   parameters:
     buildConfig: ${{ parameters.buildConfig }}
-    ortVersion: ${{ parameters.ortVersion }}
-    ortVersionWinml: ${{ parameters.ortVersionWinml }}
-    genaiVersion: ${{ parameters.genaiVersion }}
-    winmlVersion: ${{ parameters.winmlVersion }}
 
 # ── C# SDK (base) ──
 - template: stages-cs.yml

--- a/.pipelines/v2/templates/steps-build-linux.yml
+++ b/.pipelines/v2/templates/steps-build-linux.yml
@@ -27,7 +27,6 @@ steps:
 
 - template: steps-prefetch-nuget.yml
   parameters:
-    winmlVersion: ''
     includeWinml: false
     includeOrtGpuLinux: true
     shell: bash

--- a/.pipelines/v2/templates/steps-build-linux.yml
+++ b/.pipelines/v2/templates/steps-build-linux.yml
@@ -3,13 +3,11 @@
 # Pool: onnxruntime-Ubuntu2404-AMD-CPU. Has the toolchain pre-installed but we
 # still bootstrap vcpkg and pre-download NuGet packages from the aiinfra feed
 # for version pinning.
+#
+# Reads ORT/GenAI versions from sdk_v2/deps_versions.json (single source of truth).
 
 parameters:
 - name: buildConfig
-  type: string
-- name: ortVersion
-  type: string
-- name: genaiVersion
   type: string
 - name: runTests
   type: boolean
@@ -23,10 +21,12 @@ steps:
     "$(Build.BinariesDirectory)/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
   displayName: 'Bootstrap vcpkg'
 
+- template: steps-read-deps-versions.yml
+  parameters:
+    shell: bash
+
 - template: steps-prefetch-nuget.yml
   parameters:
-    ortVersion: ${{ parameters.ortVersion }}
-    genaiVersion: ${{ parameters.genaiVersion }}
     winmlVersion: ''
     includeWinml: false
     includeOrtGpuLinux: true

--- a/.pipelines/v2/templates/steps-build-macos.yml
+++ b/.pipelines/v2/templates/steps-build-macos.yml
@@ -1,13 +1,11 @@
 # Reusable macOS build steps for the Foundry Local C++ SDK.
 #
 # Pool: AcesShared (Sequoia, Apple Silicon). Builds and tests natively.
+#
+# Reads ORT/GenAI versions from sdk_v2/deps_versions.json (single source of truth).
 
 parameters:
 - name: buildConfig
-  type: string
-- name: ortVersion
-  type: string
-- name: genaiVersion
   type: string
 - name: runTests
   type: boolean
@@ -32,10 +30,12 @@ steps:
     pkg-config --version
   displayName: 'Verify build tools'
 
+- template: steps-read-deps-versions.yml
+  parameters:
+    shell: bash
+
 - template: steps-prefetch-nuget.yml
   parameters:
-    ortVersion: ${{ parameters.ortVersion }}
-    genaiVersion: ${{ parameters.genaiVersion }}
     winmlVersion: ''
     includeWinml: false
     shell: bash

--- a/.pipelines/v2/templates/steps-build-macos.yml
+++ b/.pipelines/v2/templates/steps-build-macos.yml
@@ -36,7 +36,6 @@ steps:
 
 - template: steps-prefetch-nuget.yml
   parameters:
-    winmlVersion: ''
     includeWinml: false
     shell: bash
 

--- a/.pipelines/v2/templates/steps-build-windows.yml
+++ b/.pipelines/v2/templates/steps-build-windows.yml
@@ -7,7 +7,7 @@
 # Parameters:
 #   arch           – 'x64' or 'arm64' (arm64 is cross-compiled, no tests)
 #   buildConfig    – CMake config (Debug, Release, RelWithDebInfo, MinSizeRel)
-#   ortVersion     – Microsoft.ML.OnnxRuntime.Foundry version
+#   ortVersion     – Microsoft.ML.OnnxRuntime version
 #   genaiVersion   – Microsoft.ML.OnnxRuntimeGenAI.Foundry version
 #   winmlVersion   – Microsoft.WindowsAppSDK.ML version
 #   useWinml       – Build the WinML variant (--use_winml). Caller is responsible

--- a/.pipelines/v2/templates/steps-build-windows.yml
+++ b/.pipelines/v2/templates/steps-build-windows.yml
@@ -54,7 +54,6 @@ steps:
 
 - template: steps-prefetch-nuget.yml
   parameters:
-    includeWinml: ${{ parameters.useWinml }}
     shell: pwsh
 
 # Bake the pipeline-computed version into the binary so FoundryLocalGetVersionString()

--- a/.pipelines/v2/templates/steps-build-windows.yml
+++ b/.pipelines/v2/templates/steps-build-windows.yml
@@ -4,14 +4,12 @@
 # builds, optionally tests, and stages artifacts for the parent stage's
 # templateContext.outputs.
 #
+# Reads all dependency versions from sdk_v2/deps_versions.json (single source of truth).
+#
 # Parameters:
 #   arch           – 'x64' or 'arm64' (arm64 is cross-compiled, no tests)
 #   buildConfig    – CMake config (Debug, Release, RelWithDebInfo, MinSizeRel)
-#   ortVersion     – Microsoft.ML.OnnxRuntime version
-#   genaiVersion   – Microsoft.ML.OnnxRuntimeGenAI.Foundry version
-#   winmlVersion   – Microsoft.WindowsAppSDK.ML version
-#   useWinml       – Build the WinML variant (--use_winml). Caller is responsible
-#                    for passing the WinML-aligned ortVersion (e.g. 1.23.2.3).
+#   useWinml       – Build the WinML variant (--use_winml).
 #   runTests       – Whether to run tests
 #   stageHeaders   – Whether to stage public headers as a separate artifact
 
@@ -20,12 +18,6 @@ parameters:
   type: string
   values: ['x64', 'arm64']
 - name: buildConfig
-  type: string
-- name: ortVersion
-  type: string
-- name: genaiVersion
-  type: string
-- name: winmlVersion
   type: string
 - name: useWinml
   type: boolean
@@ -49,6 +41,10 @@ steps:
     versionSpec: '3.12'
     architecture: 'x64'
 
+- template: steps-read-deps-versions.yml
+  parameters:
+    shell: pwsh
+
 - script: |
     git clone https://github.com/microsoft/vcpkg.git $(Build.BinariesDirectory)\vcpkg
     call $(Build.BinariesDirectory)\vcpkg\bootstrap-vcpkg.bat -disableMetrics
@@ -58,9 +54,6 @@ steps:
 
 - template: steps-prefetch-nuget.yml
   parameters:
-    ortVersion: ${{ parameters.ortVersion }}
-    genaiVersion: ${{ parameters.genaiVersion }}
-    winmlVersion: ${{ parameters.winmlVersion }}
     includeWinml: ${{ parameters.useWinml }}
     shell: pwsh
 
@@ -103,7 +96,7 @@ steps:
       --configure --build
       --config ${{ parameters.buildConfig }}
       --cmake_generator "Visual Studio 17 2022"
-      --use_winml --winml_sdk_version ${{ parameters.winmlVersion }}
+      --use_winml --winml_sdk_version $(winmlVersion)
       --cmake_extra_defines $(cmakeFetchDefines)
     displayName: 'Configure and build (x64, WinML)'
     workingDirectory: $(Build.SourcesDirectory)/sdk_v2/cpp
@@ -130,7 +123,7 @@ steps:
       --configure --build --arm64
       --config ${{ parameters.buildConfig }}
       --cmake_generator "Visual Studio 17 2022"
-      --use_winml --winml_sdk_version ${{ parameters.winmlVersion }}
+      --use_winml --winml_sdk_version $(winmlVersion)
       --cmake_extra_defines $(cmakeFetchDefines)
     displayName: 'Configure and build (arm64 cross-compile, WinML)'
     workingDirectory: $(Build.SourcesDirectory)/sdk_v2/cpp

--- a/.pipelines/v2/templates/steps-pack-nuget.yml
+++ b/.pipelines/v2/templates/steps-pack-nuget.yml
@@ -4,6 +4,9 @@
 # Inputs are downloaded by the parent job's templateContext.inputs into
 # $(Pipeline.Workspace)/<artifactName>/.
 #
+# Reads ortVersion and genaiVersion from sdk_v2/deps_versions.json at runtime
+# (set as job variables by an inline step below).
+#
 # Variants:
 #   base  -> Microsoft.AI.Foundry.Local.Runtime
 #            (win-x64, win-arm64, linux-x64, osx-arm64)
@@ -11,10 +14,6 @@
 #            (win-x64, win-arm64 only — both built with --use_winml)
 
 parameters:
-- name: ortVersion
-  type: string
-- name: genaiVersion
-  type: string
 - name: variant
   type: string
   default: 'base'
@@ -29,6 +28,10 @@ steps:
   displayName: 'Use Python 3.x'
   inputs:
     versionSpec: '3.x'
+
+- template: steps-read-deps-versions.yml
+  parameters:
+    shell: pwsh
 
 # List downloaded pipeline artifacts so we can diagnose missing/misplaced files.
 - task: PowerShell@2
@@ -63,8 +66,8 @@ steps:
         python "$(Build.SourcesDirectory)/sdk_v2/cpp/nuget/pack.py" `
           --version       "$version" `
           --package_id    "Microsoft.AI.Foundry.Local.Runtime" `
-          --ort_version   "${{ parameters.ortVersion }}" `
-          --genai_version "${{ parameters.genaiVersion }}" `
+          --ort_version   "$(ortVersion)" `
+          --genai_version "$(genaiVersion)" `
           --win_x64       "$(Pipeline.Workspace)/cpp-native-win-x64" `
           --win_arm64     "$(Pipeline.Workspace)/cpp-native-win-arm64" `
           --linux_x64     "$(Pipeline.Workspace)/cpp-native-linux-x64" `
@@ -92,8 +95,8 @@ steps:
         python "$(Build.SourcesDirectory)/sdk_v2/cpp/nuget/pack.py" `
           --version       "$version" `
           --package_id    "Microsoft.AI.Foundry.Local.Runtime.WinML" `
-          --ort_version   "${{ parameters.ortVersion }}" `
-          --genai_version "${{ parameters.genaiVersion }}" `
+          --ort_version   "$(ortVersion)" `
+          --genai_version "$(genaiVersion)" `
           --win_x64       "$(Pipeline.Workspace)/cpp-native-win-x64-winml" `
           --win_arm64     "$(Pipeline.Workspace)/cpp-native-win-arm64-winml" `
           --output_dir    "$outDir"

--- a/.pipelines/v2/templates/steps-prefetch-nuget.yml
+++ b/.pipelines/v2/templates/steps-prefetch-nuget.yml
@@ -4,22 +4,15 @@
 # Sets the pipeline variable `cmakeFetchDefines` containing the space-separated
 # `KEY=PATH` pairs to pass to build.py --cmake_extra_defines.
 #
+# Reads ortVersion, genaiVersion, and winmlVersion from job-level variables
+# set by steps-read-deps-versions.yml (which must run first).
+#
 # Parameters:
-#   ortVersion     – Microsoft.ML.OnnxRuntime version
-#   genaiVersion   – Microsoft.ML.OnnxRuntimeGenAI.Foundry version
-#   winmlVersion   – Microsoft.WindowsAppSDK.ML version (Windows only)
 #   includeWinml   – Download WinML and emit WINML_EP_CATALOG_FETCH_URL
 #   includeOrtGpuLinux – Also download Microsoft.ML.OnnxRuntime.Gpu.Linux (Linux only)
 #   shell          – 'pwsh' (Windows/macOS) or 'bash' (Linux)
 
 parameters:
-- name: ortVersion
-  type: string
-- name: genaiVersion
-  type: string
-- name: winmlVersion
-  type: string
-  default: ''
 - name: includeWinml
   type: boolean
   default: false
@@ -50,11 +43,11 @@ steps:
         $feed = "https://www.nuget.org/api/v2/package"
 
         $packages = @(
-          @{ key = 'genai'; id = 'Microsoft.ML.OnnxRuntimeGenAI.Foundry'; version = '${{ parameters.genaiVersion }}' },
-          @{ key = 'ort';   id = 'Microsoft.ML.OnnxRuntime';             version = '${{ parameters.ortVersion }}'   }
+          @{ key = 'genai'; id = 'Microsoft.ML.OnnxRuntimeGenAI.Foundry'; version = '$(genaiVersion)' },
+          @{ key = 'ort';   id = 'Microsoft.ML.OnnxRuntime';             version = '$(ortVersion)'   }
         )
         if ($${{ parameters.includeOrtGpuLinux }}) {
-          $packages += @{ key = 'ort_gpu_linux'; id = 'Microsoft.ML.OnnxRuntime.Gpu.Linux'; version = '${{ parameters.ortVersion }}' }
+          $packages += @{ key = 'ort_gpu_linux'; id = 'Microsoft.ML.OnnxRuntime.Gpu.Linux'; version = '$(ortVersion)' }
         }
 
         $defines = @()
@@ -81,9 +74,9 @@ steps:
           $winmlDir = "$cacheDir/winml-resolved"
           if (Test-Path $winmlDir) { Remove-Item -Recurse -Force $winmlDir }
           New-Item -ItemType Directory -Force -Path $winmlDir | Out-Null
-          Write-Host "Resolving Microsoft.WindowsAppSDK.ML ${{ parameters.winmlVersion }} via nuget install"
+          Write-Host "Resolving Microsoft.WindowsAppSDK.ML $(winmlVersion) via nuget install"
           nuget install Microsoft.WindowsAppSDK.ML `
-            -Version '${{ parameters.winmlVersion }}' `
+            -Version '$(winmlVersion)' `
             -OutputDirectory $winmlDir `
             -Source 'https://api.nuget.org/v3/index.json' `
             -DependencyVersion Lowest `
@@ -121,8 +114,8 @@ steps:
       feed="https://www.nuget.org/api/v2/package"
 
       declare -a entries=(
-        "genai:Microsoft.ML.OnnxRuntimeGenAI.Foundry:${{ parameters.genaiVersion }}"
-        "ort:Microsoft.ML.OnnxRuntime:${{ parameters.ortVersion }}"
+        "genai:Microsoft.ML.OnnxRuntimeGenAI.Foundry:$(genaiVersion)"
+        "ort:Microsoft.ML.OnnxRuntime:$(ortVersion)"
       )
       if [ "${{ parameters.includeWinml }}" = "True" ]; then
         # WinML is Windows-only; the bash branch should never receive includeWinml=true.
@@ -132,7 +125,7 @@ steps:
         exit 1
       fi
       if [ "${{ parameters.includeOrtGpuLinux }}" = "True" ]; then
-        entries+=("ort_gpu_linux:Microsoft.ML.OnnxRuntime.Gpu.Linux:${{ parameters.ortVersion }}")
+        entries+=("ort_gpu_linux:Microsoft.ML.OnnxRuntime.Gpu.Linux:$(ortVersion)")
       fi
 
       defines=()

--- a/.pipelines/v2/templates/steps-prefetch-nuget.yml
+++ b/.pipelines/v2/templates/steps-prefetch-nuget.yml
@@ -5,7 +5,7 @@
 # `KEY=PATH` pairs to pass to build.py --cmake_extra_defines.
 #
 # Parameters:
-#   ortVersion     – Microsoft.ML.OnnxRuntime.Foundry version
+#   ortVersion     – Microsoft.ML.OnnxRuntime version
 #   genaiVersion   – Microsoft.ML.OnnxRuntimeGenAI.Foundry version
 #   winmlVersion   – Microsoft.WindowsAppSDK.ML version (Windows only)
 #   includeWinml   – Download WinML and emit WINML_EP_CATALOG_FETCH_URL
@@ -51,7 +51,7 @@ steps:
 
         $packages = @(
           @{ key = 'genai'; id = 'Microsoft.ML.OnnxRuntimeGenAI.Foundry'; version = '${{ parameters.genaiVersion }}' },
-          @{ key = 'ort';   id = 'Microsoft.ML.OnnxRuntime.Foundry';     version = '${{ parameters.ortVersion }}'   }
+          @{ key = 'ort';   id = 'Microsoft.ML.OnnxRuntime';             version = '${{ parameters.ortVersion }}'   }
         )
         if ($${{ parameters.includeOrtGpuLinux }}) {
           $packages += @{ key = 'ort_gpu_linux'; id = 'Microsoft.ML.OnnxRuntime.Gpu.Linux'; version = '${{ parameters.ortVersion }}' }
@@ -122,7 +122,7 @@ steps:
 
       declare -a entries=(
         "genai:Microsoft.ML.OnnxRuntimeGenAI.Foundry:${{ parameters.genaiVersion }}"
-        "ort:Microsoft.ML.OnnxRuntime.Foundry:${{ parameters.ortVersion }}"
+        "ort:Microsoft.ML.OnnxRuntime:${{ parameters.ortVersion }}"
       )
       if [ "${{ parameters.includeWinml }}" = "True" ]; then
         # WinML is Windows-only; the bash branch should never receive includeWinml=true.

--- a/.pipelines/v2/templates/steps-read-deps-versions.yml
+++ b/.pipelines/v2/templates/steps-read-deps-versions.yml
@@ -1,0 +1,54 @@
+# Reads sdk_v2/deps_versions.json and sets ortVersion, genaiVersion, and
+# winmlVersion as job-level pipeline variables for use in subsequent steps.
+#
+# Must run after source checkout. Outputs:
+#   $(ortVersion)   – Microsoft.ML.OnnxRuntime version
+#   $(genaiVersion) – Microsoft.ML.OnnxRuntimeGenAI.Foundry version
+#   $(winmlVersion) – Microsoft.WindowsAppSDK.ML version
+#
+# Parameters:
+#   shell – 'pwsh' (Windows) or 'bash' (Linux/macOS)
+
+parameters:
+- name: shell
+  type: string
+  values: ['pwsh', 'bash']
+
+steps:
+
+- ${{ if eq(parameters.shell, 'pwsh') }}:
+  - task: PowerShell@2
+    displayName: 'Read versions from deps_versions.json'
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        $depsFile = '$(Build.SourcesDirectory)/sdk_v2/deps_versions.json'
+        if (-not (Test-Path $depsFile)) {
+          throw "deps_versions.json not found at $depsFile"
+        }
+        $deps = Get-Content $depsFile -Raw | ConvertFrom-Json
+        $ortVer   = $deps.onnxruntime.'version'
+        $genaiVer = $deps.'onnxruntime-genai'.'version'
+        $winmlVer = $deps.'winappsdk-ml'.'version'
+        Write-Host "ortVersion=$ortVer, genaiVersion=$genaiVer, winmlVersion=$winmlVer"
+        Write-Host "##vso[task.setvariable variable=ortVersion]$ortVer"
+        Write-Host "##vso[task.setvariable variable=genaiVersion]$genaiVer"
+        Write-Host "##vso[task.setvariable variable=winmlVersion]$winmlVer"
+
+- ${{ if eq(parameters.shell, 'bash') }}:
+  - bash: |
+      set -euo pipefail
+      depsFile="$(Build.SourcesDirectory)/sdk_v2/deps_versions.json"
+      if [ ! -f "$depsFile" ]; then
+        echo "ERROR: deps_versions.json not found at $depsFile" >&2
+        exit 1
+      fi
+      ortVer=$(python3   -c "import json; d=json.load(open('$depsFile')); print(d['onnxruntime']['version'])")
+      genaiVer=$(python3 -c "import json; d=json.load(open('$depsFile')); print(d['onnxruntime-genai']['version'])")
+      winmlVer=$(python3 -c "import json; d=json.load(open('$depsFile')); print(d['winappsdk-ml']['version'])")
+      echo "ortVersion=$ortVer, genaiVersion=$genaiVer, winmlVersion=$winmlVer"
+      echo "##vso[task.setvariable variable=ortVersion]$ortVer"
+      echo "##vso[task.setvariable variable=genaiVersion]$genaiVer"
+      echo "##vso[task.setvariable variable=winmlVersion]$winmlVer"
+    displayName: 'Read versions from deps_versions.json'

--- a/sdk_v2/DEVELOPMENT.md
+++ b/sdk_v2/DEVELOPMENT.md
@@ -103,6 +103,6 @@ See `pwsh ./build_and_test_all.ps1 -?` for the full parameter list.
   `sdk_v2/cpp/build/<Platform>/<Config>/`; bypassing `build.py` puts the
   binary somewhere else.
 * **Switching between WinML and non-WinML** — the C++ FetchContent NuGet
-  packages (`Microsoft.ML.OnnxRuntime.Foundry` vs `.WinML`) are cached and
+  packages (`Microsoft.ML.OnnxRuntime` vs `.WinML`) are cached and
   do not auto-refresh on variant flip. If you hit linker errors after
   toggling `-UseWinml`, wipe `sdk_v2/cpp/build/` and rerun.

--- a/sdk_v2/cpp/CMakeLists.txt
+++ b/sdk_v2/cpp/CMakeLists.txt
@@ -433,8 +433,12 @@ if(TARGET OnnxRuntime::OnnxRuntime)
         # macOS: copy dylibs so consumers that only link libfoundry_local.dylib (e.g. cache_only_tests) find the correct
         # ORT version instead of any system-installed ORT, which would cause an Ort::InitApi() version mismatch.
         #
-        # The ORT nupkg's libonnxruntime.dylib has LC_ID_DYLIB @rpath/libonnxruntime.<version>.dylib, so we copy it to
-        # the versioned filename that dependents (e.g. libonnxruntime-genai.dylib) look up via @rpath.
+        # The ORT nupkg's libonnxruntime.dylib has LC_ID_DYLIB @rpath/libonnxruntime.1.dylib (major version only,
+        # same pattern as libonnxruntime.so.1 on Linux). GenAI's LC_LOAD_DYLIB entry references that major-version
+        # name, so dyld looks for libonnxruntime.1.dylib at runtime. We must provide all three names:
+        #   libonnxruntime.${ORT_VERSION}.dylib  — the actual file (full version)
+        #   libonnxruntime.1.dylib               — major-version symlink (what dyld resolves via LC_LOAD_DYLIB)
+        #   libonnxruntime.dylib                 — unversioned symlink (for -lonnxruntime at link time)
         add_custom_command(TARGET foundry_local POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 "${ORT_GENAI_LIB_DIR}/libonnxruntime-genai.dylib"
@@ -442,6 +446,13 @@ if(TARGET OnnxRuntime::OnnxRuntime)
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 "${ORT_LIB_DIR}/libonnxruntime.dylib"
                 "$<TARGET_FILE_DIR:foundry_local>/libonnxruntime.${ORT_VERSION}.dylib"
+        )
+
+        # Major-version symlink — matches LC_ID_DYLIB / LC_LOAD_DYLIB embedded in libonnxruntime-genai.dylib.
+        add_custom_command(TARGET foundry_local POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E create_symlink
+                libonnxruntime.${ORT_VERSION}.dylib
+                $<TARGET_FILE_DIR:foundry_local>/libonnxruntime.1.dylib
         )
 
         # Conventional unversioned symlink so -lonnxruntime resolves at link time.

--- a/sdk_v2/cpp/build.py
+++ b/sdk_v2/cpp/build.py
@@ -163,7 +163,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--use_winml", action="store_true",
         help="Enable the WinML EP catalog (Microsoft.WindowsAppSDK.ML) for hardware EP "
-             "discovery. ORT itself still comes from Microsoft.ML.OnnxRuntime.Foundry; "
+             "discovery. ORT itself still comes from Microsoft.ML.OnnxRuntime; "
              "this flag only adds the WinML EP catalog client.",
     )
     parser.add_argument(

--- a/sdk_v2/cpp/cmake/FindOnnxRuntime.cmake
+++ b/sdk_v2/cpp/cmake/FindOnnxRuntime.cmake
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft. All rights reserved.
 # Find/acquire ONNX Runtime.
 #
-# ORT is always sourced from Microsoft.ML.OnnxRuntime.Foundry (or
-# Microsoft.ML.OnnxRuntime on Android) via FetchContent — nuget.org for releases,
+# ORT is always sourced from Microsoft.ML.OnnxRuntime via FetchContent —
+# nuget.org for releases,
 # the ORT-Nightly ADO feed for -dev- versions. The FOUNDRY_LOCAL_USE_WINML flag
 # does NOT change the ORT package source; it only:
 #   - selects a WinML-compatible ORT version (see version branch below), and
@@ -50,7 +50,7 @@ endif()
 if(FOUNDRY_LOCAL_USE_WINML)
     # FOUNDRY_LOCAL_USE_WINML opts in to the WinML EP catalog (see FindWinMLEpCatalog.cmake) but
     # does NOT change where ORT comes from. We always link against our own ORT
-    # (Microsoft.ML.OnnxRuntime.Foundry) because it enables CUDA and WebGPU EPs.
+    # (Microsoft.ML.OnnxRuntime) because it enables CUDA and WebGPU EPs.
     #
     # Which onnxruntime.dll the process actually binds to at runtime is determined by the
     # binding-side preload contract (see sdk_v2/cpp/docs/OrtRuntimeLoading.md), not by build
@@ -58,7 +58,7 @@ if(FOUNDRY_LOCAL_USE_WINML)
     # tests and examples zero-config, but is not a correctness guarantee for arbitrary
     # deployments — bindings preload the intended onnxruntime.dll by absolute path before
     # loading foundry_local.
-    message(STATUS "FOUNDRY_LOCAL_USE_WINML=ON: WinML EP catalog enabled; ORT still sourced from Microsoft.ML.OnnxRuntime.Foundry")
+    message(STATUS "FOUNDRY_LOCAL_USE_WINML=ON: WinML EP catalog enabled; ORT still sourced from Microsoft.ML.OnnxRuntime")
 endif()
 
 if(ORT_HOME)
@@ -96,13 +96,7 @@ else()
         message(STATUS "ORT_VERSION=${ORT_VERSION} (from ${_DEPS_FILE})")
     endif()
     if(NOT ORT_PACKAGE_NAME)
-        if(ANDROID)
-            # The Foundry meta-package may not contain Android binaries;
-            # use the base ORT package which includes the AAR.
-            set(ORT_PACKAGE_NAME "Microsoft.ML.OnnxRuntime")
-        else()
-            set(ORT_PACKAGE_NAME "Microsoft.ML.OnnxRuntime.Foundry")
-        endif()
+        set(ORT_PACKAGE_NAME "Microsoft.ML.OnnxRuntime")
     endif()
 
     # ORT_FETCH_URL can be set externally (e.g. for CI where nuget.org is blocked).

--- a/sdk_v2/cpp/cmake/FindOnnxRuntime.cmake
+++ b/sdk_v2/cpp/cmake/FindOnnxRuntime.cmake
@@ -80,14 +80,10 @@ else()
     # Standard path: FetchContent from nuget.org (releases) or ORT-Nightly ADO feed (dev builds)
     # -----------------------------------------------------------------------
     if(NOT ORT_VERSION)
-        # Single source of truth: sdk_v2/deps_versions[_winml].json. The Python
-        # SDK build backend reads the same files so wheel deps and native ABI
+        # Single source of truth: sdk_v2/deps_versions.json. The Python
+        # SDK build backend reads the same file so wheel deps and native ABI
         # always agree. Override at the cmake command line with -DORT_VERSION=...
-        if(FOUNDRY_LOCAL_USE_WINML)
-            set(_DEPS_FILE "${CMAKE_CURRENT_LIST_DIR}/../../deps_versions_winml.json")
-        else()
-            set(_DEPS_FILE "${CMAKE_CURRENT_LIST_DIR}/../../deps_versions.json")
-        endif()
+        set(_DEPS_FILE "${CMAKE_CURRENT_LIST_DIR}/../../deps_versions.json")
         if(NOT EXISTS "${_DEPS_FILE}")
             message(FATAL_ERROR "Required versions file not found: ${_DEPS_FILE}")
         endif()

--- a/sdk_v2/cpp/cmake/FindOnnxRuntime.cmake
+++ b/sdk_v2/cpp/cmake/FindOnnxRuntime.cmake
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft. All rights reserved.
 # Find/acquire ONNX Runtime.
 #
-# ORT is always sourced from Microsoft.ML.OnnxRuntime via FetchContent —
-# nuget.org for releases,
-# the ORT-Nightly ADO feed for -dev- versions. The FOUNDRY_LOCAL_USE_WINML flag
+# ORT is sourced from Microsoft.ML.OnnxRuntime via FetchContent — nuget.org for releases,
+# the ORT-Nightly ADO feed for -dev- versions. On Linux, runtime binaries are fetched from
+# Microsoft.ML.OnnxRuntime.Gpu.Linux while headers still come from Microsoft.ML.OnnxRuntime.
 # does NOT change the ORT package source; it only:
 #   - selects a WinML-compatible ORT version (see version branch below), and
 #   - opts in to the WinML EP catalog (handled by FindWinMLEpCatalog.cmake).

--- a/sdk_v2/cpp/cmake/FindOnnxRuntimeGenAI.cmake
+++ b/sdk_v2/cpp/cmake/FindOnnxRuntimeGenAI.cmake
@@ -1,10 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 # Find/acquire ONNX Runtime GenAI.
 #
-# Windows + FOUNDRY_LOCAL_USE_WINML=ON:  Microsoft.ML.OnnxRuntimeGenAI.WinML
-# Windows + FOUNDRY_LOCAL_USE_WINML=OFF: Microsoft.ML.OnnxRuntimeGenAI.Foundry
-# Linux:                   Microsoft.ML.OnnxRuntimeGenAI.Foundry
-# macOS:                   Microsoft.ML.OnnxRuntimeGenAI.Foundry
+# All platforms: Microsoft.ML.OnnxRuntimeGenAI.Foundry
 #
 # When ORT_GENAI_HOME is set, uses the local ORT GenAI build instead of NuGet.
 # Otherwise uses FetchContent from nuget.org.
@@ -111,14 +108,10 @@ else()
 endif()
 
 if(NOT ORT_GENAI_VERSION)
-    # Single source of truth: sdk_v2/deps_versions[_winml].json. The Python
-    # SDK build backend reads the same files. Override at the cmake command
+    # Single source of truth: sdk_v2/deps_versions.json. The Python
+    # SDK build backend reads the same file. Override at the cmake command
     # line with -DORT_GENAI_VERSION=...
-    if(FOUNDRY_LOCAL_USE_WINML)
-        set(_GENAI_DEPS_FILE "${CMAKE_CURRENT_LIST_DIR}/../../deps_versions_winml.json")
-    else()
-        set(_GENAI_DEPS_FILE "${CMAKE_CURRENT_LIST_DIR}/../../deps_versions.json")
-    endif()
+    set(_GENAI_DEPS_FILE "${CMAKE_CURRENT_LIST_DIR}/../../deps_versions.json")
     if(NOT EXISTS "${_GENAI_DEPS_FILE}")
         message(FATAL_ERROR "Required versions file not found: ${_GENAI_DEPS_FILE}")
     endif()

--- a/sdk_v2/cpp/cmake/FindWinMLEpCatalog.cmake
+++ b/sdk_v2/cpp/cmake/FindWinMLEpCatalog.cmake
@@ -24,15 +24,16 @@ endif()
 
 # Latest stable Microsoft.WindowsAppSDK.ML 1.8.x on nuget.org. Anything older
 # than 1.8.2141 silently disables EP detection (no WinMLEpCatalog.h).
-set(_WINML_EP_CATALOG_MIN_VERSION "1.8.2192")
-
-# WINML_EP_CATALOG_VERSION may be set explicitly; otherwise pick the minimum
-# known-good version. We deliberately do NOT inherit WINML_SDK_VERSION here:
-# the WinML SDK and the EP catalog package have independent compatibility
-# requirements (the EP catalog ships only in newer WindowsAppSDK.ML packages,
-# and our build no longer uses the WinML-bundled ORT regardless).
+# Single source of truth: sdk_v2/deps_versions.json. Override at the cmake
+# command line with -DWINML_EP_CATALOG_VERSION=...
 if(NOT WINML_EP_CATALOG_VERSION)
-    set(WINML_EP_CATALOG_VERSION "${_WINML_EP_CATALOG_MIN_VERSION}")
+    set(_DEPS_FILE "${CMAKE_CURRENT_LIST_DIR}/../../deps_versions.json")
+    if(NOT EXISTS "${_DEPS_FILE}")
+        message(FATAL_ERROR "Required versions file not found: ${_DEPS_FILE}")
+    endif()
+    file(READ "${_DEPS_FILE}" _DEPS_JSON)
+    string(JSON WINML_EP_CATALOG_VERSION GET "${_DEPS_JSON}" "winappsdk-ml" "version")
+    message(STATUS "WINML_EP_CATALOG_VERSION=${WINML_EP_CATALOG_VERSION} (from ${_DEPS_FILE})")
 endif()
 
 include(cmake/nuget.cmake)

--- a/sdk_v2/cpp/nuget/Microsoft.AI.Foundry.Local.Runtime.nuspec
+++ b/sdk_v2/cpp/nuget/Microsoft.AI.Foundry.Local.Runtime.nuspec
@@ -18,7 +18,7 @@
 
     <dependencies>
       <group>
-        <dependency id="Microsoft.ML.OnnxRuntime.Foundry" version="$ort_version$" />
+        <dependency id="Microsoft.ML.OnnxRuntime" version="$ort_version$" />
         <dependency id="Microsoft.ML.OnnxRuntimeGenAI.Foundry" version="$genai_version$" />
       </group>
     </dependencies>

--- a/sdk_v2/cpp/nuget/pack.py
+++ b/sdk_v2/cpp/nuget/pack.py
@@ -73,7 +73,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--version", required=True,
                         help="Package version (e.g. 0.1.0 or 0.1.0-dev.20260419).")
     parser.add_argument("--ort_version", required=True,
-                        help="Minimum Microsoft.ML.OnnxRuntime.Foundry version.")
+                        help="Minimum Microsoft.ML.OnnxRuntime version.")
     parser.add_argument("--genai_version", required=True,
                         help="Minimum Microsoft.ML.OnnxRuntimeGenAI.Foundry version.")
     parser.add_argument("--package_id", default="Microsoft.AI.Foundry.Local.Runtime",

--- a/sdk_v2/deps_versions.json
+++ b/sdk_v2/deps_versions.json
@@ -1,5 +1,5 @@
 {
   "_comment": "Single source of truth for ORT and ORT-GenAI versions in sdk_v2. Read by sdk_v2/cpp/cmake/FindOnnxRuntime*.cmake and sdk_v2/python/_build_backend/__init__.py.",
-  "onnxruntime":       { "version": "1.25.1" },
-  "onnxruntime-genai": { "version": "0.13.2" }
+  "onnxruntime":       { "version": "1.26.0" },
+  "onnxruntime-genai": { "version": "0.14.0" }
 }

--- a/sdk_v2/deps_versions.json
+++ b/sdk_v2/deps_versions.json
@@ -1,5 +1,6 @@
 {
-  "_comment": "Single source of truth for ORT and ORT-GenAI versions in sdk_v2. Read by sdk_v2/cpp/cmake/FindOnnxRuntime*.cmake and sdk_v2/python/_build_backend/__init__.py.",
+  "_comment": "Single source of truth for ORT, ORT-GenAI, and WinML EP catalog versions in sdk_v2. Read by sdk_v2/cpp/cmake/FindOnnxRuntime*.cmake, FindWinMLEpCatalog.cmake, sdk_v2/python/_build_backend/__init__.py, and .pipelines/v2/templates/steps-read-deps-versions.yml.",
   "onnxruntime":       { "version": "1.26.0" },
-  "onnxruntime-genai": { "version": "0.14.0" }
+  "onnxruntime-genai": { "version": "0.14.0" },
+  "winappsdk-ml":      { "version": "1.8.2192" }
 }

--- a/sdk_v2/deps_versions_winml.json
+++ b/sdk_v2/deps_versions_winml.json
@@ -1,5 +1,0 @@
-{
-  "_comment": "WinML variant of sdk_v2/deps_versions.json. Selected by FOUNDRY_LOCAL_USE_WINML=ON (cmake) and FL_PYTHON_PACKAGE_NAME=foundry-local-sdk-winml (python build backend).",
-  "onnxruntime":       { "version": "1.26.0" },
-  "onnxruntime-genai": { "version": "0.14.0" }
-}

--- a/sdk_v2/deps_versions_winml.json
+++ b/sdk_v2/deps_versions_winml.json
@@ -1,5 +1,5 @@
 {
   "_comment": "WinML variant of sdk_v2/deps_versions.json. Selected by FOUNDRY_LOCAL_USE_WINML=ON (cmake) and FL_PYTHON_PACKAGE_NAME=foundry-local-sdk-winml (python build backend).",
-  "onnxruntime":       { "version": "1.23.2.3" },
-  "onnxruntime-genai": { "version": "0.13.2" }
+  "onnxruntime":       { "version": "1.26.0" },
+  "onnxruntime-genai": { "version": "0.14.0" }
 }

--- a/sdk_v2/js/script/copy-native.mjs
+++ b/sdk_v2/js/script/copy-native.mjs
@@ -59,7 +59,7 @@ const wanted = (() => {
     ];
   }
   if (process.platform === "darwin") {
-    return ["libfoundry_local.dylib", "libonnxruntime.dylib", "libonnxruntime-genai.dylib"];
+    return ["libfoundry_local.dylib", "libonnxruntime.dylib", "libonnxruntime.1.dylib", "libonnxruntime-genai.dylib"];
   }
   return ["libfoundry_local.so", "libonnxruntime.so", "libonnxruntime.so.1", "libonnxruntime-genai.so"];
 })();

--- a/sdk_v2/js/script/copy-native.mjs
+++ b/sdk_v2/js/script/copy-native.mjs
@@ -80,6 +80,24 @@ for (const file of wanted) {
   copied += 1;
 }
 
+// macOS: the Microsoft.ML.OnnxRuntime package ships the file unversioned as
+// libonnxruntime.dylib, but its install name (LC_ID_DYLIB) is the versioned
+// @rpath/libonnxruntime.1.dylib. foundry_local (and onnxruntime-genai) therefore
+// record a load-time dependency on libonnxruntime.1.dylib, which otherwise has no
+// matching file on disk. Materialize the versioned alias next to the addon so the
+// @rpath lookup resolves. (Linux gets the equivalent libonnxruntime.so.1 via a
+// symlink created in FindOnnxRuntime.cmake; the macOS branch has no such symlink.)
+if (process.platform === "darwin") {
+  const unversioned = resolve(destDir, "libonnxruntime.dylib");
+  const versioned = resolve(destDir, "libonnxruntime.1.dylib");
+  if (existsSync(unversioned) && !existsSync(versioned)) {
+    copyFileSync(unversioned, versioned);
+    const size = statSync(versioned).size;
+    console.log(`[copy-native] libonnxruntime.1.dylib (alias of libonnxruntime.dylib, ${size} bytes)`);
+    copied += 1;
+  }
+}
+
 if (copied === 0) {
   console.error(`[copy-native] No expected files found in ${sourceDir}`);
   process.exit(1);

--- a/sdk_v2/js/script/install-native.cjs
+++ b/sdk_v2/js/script/install-native.cjs
@@ -67,7 +67,7 @@ const genaiVersion = deps['onnxruntime-genai'].version;
 // libfoundry_local.{so,dylib} actually requests at load time.
 function expectedOrt() {
     if (os.platform() === 'linux') return 'libonnxruntime.so.1';
-    if (os.platform() === 'darwin') return `libonnxruntime.${ortVersion}.dylib`;
+    if (os.platform() === 'darwin') return 'libonnxruntime.1.dylib';
     return 'onnxruntime.dll';
 }
 function expectedGenai() {
@@ -226,7 +226,7 @@ async function installPackage(artifact, tempDir, binDir) {
 // unversioned `libonnxruntime.{so,dylib}`, but our libfoundry_local records
 // versioned SONAME/install_name dependencies, so we have to create the
 // matching alias next to it.
-function applyOrtPlatformAliases(binDir, ortVersion) {
+function applyOrtPlatformAliases(binDir) {
     if (os.platform() === 'linux') {
         const unv = path.join(binDir, 'libonnxruntime.so');
         const soname = path.join(binDir, 'libonnxruntime.so.1');
@@ -240,21 +240,21 @@ function applyOrtPlatformAliases(binDir, ortVersion) {
             }
         }
     } else if (os.platform() === 'darwin') {
-        const unv = path.join(binDir, 'libonnxruntime.dylib');
-        const versioned = path.join(binDir, `libonnxruntime.${ortVersion}.dylib`);
-        if (fs.existsSync(unv) && !fs.existsSync(versioned)) {
-            // libfoundry_local.dylib references @rpath/libonnxruntime.<ver>.dylib
-            // (the LC_ID_DYLIB baked into the nupkg's dylib). Provide that file.
-            fs.renameSync(unv, versioned);
-            console.log(`  Renamed libonnxruntime.dylib -> libonnxruntime.${ortVersion}.dylib`);
-            // Keep an unversioned symlink so `-lonnxruntime` link-time lookups still work.
+        const unversioned = path.join(binDir, 'libonnxruntime.dylib');
+        const majorSoname = path.join(binDir, 'libonnxruntime.1.dylib');
+
+        // Newer ORT packages can carry an install_name of @rpath/libonnxruntime.1.dylib.
+        // Always materialize that major-soname filename so dlopen can resolve it.
+        if (fs.existsSync(unversioned) && !fs.existsSync(majorSoname)) {
             try {
-                fs.symlinkSync(`libonnxruntime.${ortVersion}.dylib`, unv);
-                console.log(`  Created symlink libonnxruntime.dylib -> libonnxruntime.${ortVersion}.dylib`);
+                fs.symlinkSync('libonnxruntime.dylib', majorSoname);
+                console.log('  Created symlink libonnxruntime.1.dylib -> libonnxruntime.dylib');
             } catch (err) {
-                console.warn(`  Could not create libonnxruntime.dylib symlink: ${err.message}`);
+                fs.copyFileSync(unversioned, majorSoname);
+                console.log(`  Copied libonnxruntime.dylib -> libonnxruntime.1.dylib (symlink failed: ${err.message})`);
             }
         }
+
     }
 }
 
@@ -267,7 +267,7 @@ function applyOrtPlatformAliases(binDir, ortVersion) {
         for (const artifact of ARTIFACTS) {
             await installPackage(artifact, tempDir, BIN_DIR);
         }
-        applyOrtPlatformAliases(BIN_DIR, ortVersion);
+        applyOrtPlatformAliases(BIN_DIR);
         console.log('[foundry-local] Native runtime install complete.');
     } catch (err) {
         console.error('[foundry-local] Installation failed:', err instanceof Error ? err.message : err);

--- a/sdk_v2/js/script/install-native.cjs
+++ b/sdk_v2/js/script/install-native.cjs
@@ -57,7 +57,7 @@ if (!fs.existsSync(depsPath)) {
 const deps = JSON.parse(fs.readFileSync(depsPath, 'utf8'));
 
 const isLinuxX64 = os.platform() === 'linux' && os.arch() === 'x64';
-const ortPackageName = isLinuxX64 ? 'Microsoft.ML.OnnxRuntime.Gpu.Linux' : 'Microsoft.ML.OnnxRuntime.Foundry';
+const ortPackageName = isLinuxX64 ? 'Microsoft.ML.OnnxRuntime.Gpu.Linux' : 'Microsoft.ML.OnnxRuntime';
 
 const ortVersion = deps.onnxruntime.version;
 const genaiVersion = deps['onnxruntime-genai'].version;

--- a/sdk_v2/python/_build_backend/__init__.py
+++ b/sdk_v2/python/_build_backend/__init__.py
@@ -3,10 +3,7 @@
 # Delegates every hook to ``setuptools.build_meta``. The only added
 # behavior is a temporary patch of ``pyproject.toml`` when the
 # ``FL_PYTHON_PACKAGE_NAME`` environment variable is set, so the same
-# source tree can produce two differently-named wheels:
-#
-#   * unset                    -> foundry-local-sdk           (default)
-#   * foundry-local-sdk-winml  -> foundry-local-sdk-winml     (WinML SKU)
+# source tree can produce differently-named wheels.
 #
 # This is wired into pyproject.toml via::
 #
@@ -50,11 +47,9 @@ except ImportError:  # pragma: no cover - newer setuptools only
 
 
 _ENV_VAR = "FL_PYTHON_PACKAGE_NAME"
-_WINML_PKG_NAME = "foundry-local-sdk-winml"
 _PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
 _SDK_V2_ROOT = _PYPROJECT.resolve().parent.parent
 _DEPS_JSON_STD = _SDK_V2_ROOT / "deps_versions.json"
-_DEPS_JSON_WINML = _SDK_V2_ROOT / "deps_versions_winml.json"
 
 # Match ``name = "..."`` only inside the [project] table. The regex is
 # anchored to the first ``name = "foundry-local-sdk"`` occurrence which
@@ -108,13 +103,12 @@ def _patch_pyproject_text(original: str, *, override_name: str | None, deps_file
 def _maybe_patch_name() -> Generator[None, None, None]:
     """Context manager that rewrites pyproject.toml during PEP 517 hook execution.
 
-    Always rewrites ORT/GenAI version pins from the appropriate deps JSON
+    Always rewrites ORT/GenAI version pins from deps_versions.json
     (single source of truth). Conditionally rewrites the project name when
-    ``FL_PYTHON_PACKAGE_NAME`` selects the WinML variant.
+    ``FL_PYTHON_PACKAGE_NAME`` overrides the default.
     """
     override = os.environ.get(_ENV_VAR, "").strip() or None
-    is_winml = override == _WINML_PKG_NAME
-    deps_file = _DEPS_JSON_WINML if is_winml else _DEPS_JSON_STD
+    deps_file = _DEPS_JSON_STD
 
     original = _PYPROJECT.read_text(encoding="utf-8")
     patched = _patch_pyproject_text(original, override_name=override, deps_file=deps_file)

--- a/sdk_v2/python/pyproject.toml
+++ b/sdk_v2/python/pyproject.toml
@@ -38,10 +38,9 @@ classifiers = [
 ]
 
 # ORT/GenAI version pins below use sentinel ``0.0.0``. The real versions
-# come from sdk_v2/deps_versions.json (or deps_versions_winml.json for the
-# WinML variant) — the _build_backend rewrites these pins from JSON at
-# wheel-build time. JSON is the single source of truth; bumping ORT
-# versions is a one-file edit.
+# come from sdk_v2/deps_versions.json — the _build_backend rewrites these
+# pins from JSON at wheel-build time. JSON is the single source of truth;
+# bumping ORT versions is a one-file edit.
 #
 # If a wheel ever ships with ``==0.0.0`` it means the backend wasn't
 # invoked (e.g. raw setuptools bypass) — pip install will fail loudly


### PR DESCRIPTION
Eliminates the need for a foundry-specific ORT package and fixes pipeline to read versions from `deps_versions.json`

NOTE: blocked on WebGPU/CUDA being fully plug-in