### PR TITLE
Fix homepage accessibility color contrast

### DIFF
--- a/www/src/lib/components/home/features.svelte
+++ b/www/src/lib/components/home/features.svelte
@@ -201,7 +201,7 @@
 						<div
 							class="hw-card hw-2 border-border bg-secondary/50 flex flex-col items-center rounded-xl border p-3"
 						>
-							<div class="text-2xl font-bold text-cyan-500">GPU</div>
+							<div class="text-2xl font-bold text-cyan-600">GPU</div>
 							<div class="text-muted-foreground text-xs whitespace-nowrap">Graphics Card</div>
 						</div>
 						<div
@@ -391,7 +391,7 @@
 						PY
 					</div>
 					<div
-						class="lang-badge lang-2 flex size-8 items-center justify-center rounded-lg bg-yellow-500/10 text-xs font-bold text-yellow-600 dark:text-yellow-400"
+						class="lang-badge lang-2 flex size-8 items-center justify-center rounded-lg bg-yellow-500/10 text-xs font-bold text-yellow-700 dark:text-yellow-400"
 					>
 						JS
 					</div>
@@ -401,7 +401,7 @@
 						C#
 					</div>
 					<div
-						class="lang-badge lang-4 flex size-8 items-center justify-center rounded-lg bg-orange-500/10 text-xs font-bold text-orange-600 dark:text-orange-400"
+						class="lang-badge lang-4 flex size-8 items-center justify-center rounded-lg bg-orange-500/10 text-xs font-bold text-orange-700 dark:text-orange-400"
 					>
 						RS
 					</div>

--- a/www/src/lib/components/install-command.svelte
+++ b/www/src/lib/components/install-command.svelte
@@ -307,7 +307,7 @@ let response = client.complete_chat(&messages, None).await?;`,
 					>
 					<Code2 class="text-muted-foreground/60 size-4 shrink-0" aria-hidden="true" />
 					<span class="font-medium">Load a model</span>
-					<span class="text-muted-foreground/50 ml-auto hidden shrink-0 sm:inline"
+					<span class="text-muted-foreground ml-auto hidden shrink-0 sm:inline"
 						>copy step 1 or click to reveal</span
 					>
 				</span>
@@ -363,7 +363,7 @@ let response = client.complete_chat(&messages, None).await?;`,
 					>
 					<Bot class="text-muted-foreground/60 size-4 shrink-0" aria-hidden="true" />
 					<span class="font-medium">Run chat inference</span>
-					<span class="text-muted-foreground/50 ml-auto hidden shrink-0 sm:inline"
+					<span class="text-muted-foreground ml-auto hidden shrink-0 sm:inline"
 						>copy step 2 or click to reveal</span
 					>
 				</span>


### PR DESCRIPTION
## Summary
- Increases contrast for the collapsed install command helper text on the homepage.
- Darkens the GPU, JS, and RS homepage badge colors to meet WCAG AA contrast thresholds while preserving the existing visual treatment.

## Validation
- `npx prettier --check src\lib\components\install-command.svelte src\lib\components\home\features.svelte`
- `npm run build`
- Confirmed updated color contrast ratios meet the required thresholds for the five reported failures.

Note: `npm run lint` and `npm run check` currently fail on the existing baseline outside these changes: repo-wide Prettier warnings and unrelated Svelte/type errors in UI primitives/model components.