### PR TITLE
Remove website alert banner

### DIFF
--- a/www/src/routes/+layout.svelte
+++ b/www/src/routes/+layout.svelte
@@ -4,7 +4,6 @@
 	import { Toaster } from '$lib/components/ui/sonner';
 	import { onNavigate } from '$app/navigation';
 	import { inject } from '@vercel/analytics';
-	import { AlertTriangle } from 'lucide-svelte';
 
 	let { children } = $props();
 
@@ -27,18 +26,5 @@
 <Toaster />
 <ModeWatcher />
 <div class="h-dvh">
-	<div
-		role="region"
-		aria-label="Model download notice"
-		class="border-b border-warning/30 bg-warning/15 px-4 py-2.5 text-sm text-foreground shadow-sm sm:px-6 lg:px-8"
-	>
-		<div class="mx-auto flex w-full max-w-[85rem] items-start justify-center gap-2.5 sm:items-center">
-			<AlertTriangle class="mt-0.5 size-4 shrink-0 text-warning sm:mt-0" aria-hidden="true" />
-			<p class="max-w-4xl font-medium leading-6">
-				We’re currently experiencing intermittent model download issues due to high demand and are
-				actively working on a fix.
-			</p>
-		</div>
-	</div>
 	{@render children()}
 </div>


### PR DESCRIPTION
## Summary
- Remove the global model download notice banner from the Foundry Local website layout.
- Remove the now-unused AlertTriangle icon import.

## Validation
- npm run build (from www) passed.
- npm run check currently reports pre-existing Svelte type errors in shared UI/model components unrelated to this layout change.