### PR TITLE
Updated "Load a model" Step For Python Setup

### DIFF
--- a/www/src/lib/components/install-command.svelte
+++ b/www/src/lib/components/install-command.svelte
@@ -27,7 +27,7 @@
 	const setupSnippets: Record<SdkLanguage, Snippet> = {
 		python: {
 			raw: `from foundry_local_sdk import Configuration, FoundryLocalManager
-			
+	
 FoundryLocalManager.initialize(Configuration(app_name="my-app"))
 model = FoundryLocalManager.instance.catalog.get_model("qwen2.5-0.5b")
 model.download(); model.load()

--- a/www/src/lib/components/install-command.svelte
+++ b/www/src/lib/components/install-command.svelte
@@ -26,7 +26,9 @@
 
 	const setupSnippets: Record<SdkLanguage, Snippet> = {
 		python: {
-			raw: `FoundryLocalManager.initialize(Configuration(app_name="my-app"))
+			raw: `from foundry_local_sdk import Configuration, FoundryLocalManager
+			
+FoundryLocalManager.initialize(Configuration(app_name="my-app"))
 model = FoundryLocalManager.instance.catalog.get_model("qwen2.5-0.5b")
 model.download(); model.load()
 client = model.get_chat_client()`,

--- a/www/src/lib/components/install-command.svelte
+++ b/www/src/lib/components/install-command.svelte
@@ -32,7 +32,7 @@ FoundryLocalManager.initialize(Configuration(app_name="my-app"))
 model = FoundryLocalManager.instance.catalog.get_model("qwen2.5-0.5b")
 model.download(); model.load()
 client = model.get_chat_client()`,
-			html: `<span class="code-keyword">from</span> foundry_local_sdk <span class="code-keyword">import</span> <span class="code-type">Configuration</span>, <span class="code-type">FoundryLocalManager</span>
+			html: `<span class="code-keyword">from</span> <span class="code-type">foundry_local_sdk</span> <span class="code-keyword">import</span> <span class="code-type">Configuration</span>, <span class="code-type">FoundryLocalManager</span>
 
 <span class="code-type">FoundryLocalManager</span>.<span class="code-call">initialize</span>(<span class="code-type">Configuration</span>(app_name=<span class="code-string">"my-app"</span>))
 model = <span class="code-type">FoundryLocalManager</span>.instance.catalog.<span class="code-call">get_model</span>(<span class="code-string">"qwen2.5-0.5b"</span>)

--- a/www/src/lib/components/install-command.svelte
+++ b/www/src/lib/components/install-command.svelte
@@ -32,7 +32,9 @@ FoundryLocalManager.initialize(Configuration(app_name="my-app"))
 model = FoundryLocalManager.instance.catalog.get_model("qwen2.5-0.5b")
 model.download(); model.load()
 client = model.get_chat_client()`,
-			html: `<span class="code-type">FoundryLocalManager</span>.<span class="code-call">initialize</span>(<span class="code-type">Configuration</span>(app_name=<span class="code-string">"my-app"</span>))
+			html: `<span class="code-keyword">from</span> foundry_local_sdk <span class="code-keyword">import</span> <span class="code-type">Configuration</span>, <span class="code-type">FoundryLocalManager</span>
+
+<span class="code-type">FoundryLocalManager</span>.<span class="code-call">initialize</span>(<span class="code-type">Configuration</span>(app_name=<span class="code-string">"my-app"</span>))
 model = <span class="code-type">FoundryLocalManager</span>.instance.catalog.<span class="code-call">get_model</span>(<span class="code-string">"qwen2.5-0.5b"</span>)
 model.<span class="code-call">download</span>(); model.<span class="code-call">load</span>()
 client = model.<span class="code-call">get_chat_client</span>()`


### PR DESCRIPTION
Old setup code for Python did not include importing necessary packages when loading a model. I added the line required to import the packages and run the python snippet.