### PR TITLE
Fix --list-models in JS vision sample

### DIFF
--- a/samples/js/web-server-responses-vision-example/app.js
+++ b/samples/js/web-server-responses-vision-example/app.js
@@ -49,7 +49,7 @@ if (currentEp !== '') process.stdout.write('\n');
 // </init>
 
 if (listModels) {
-    const allModels = await manager.catalog.listModels();
+    const allModels = await manager.catalog.getModels();
     const visionModels = allModels
         .filter((m) => (m.info?.task ?? '').toLowerCase().includes('vision'))
         .sort((a, b) => a.alias.localeCompare(b.alias));
@@ -85,7 +85,7 @@ if (listModels) {
             const device = v.info?.runtime?.deviceType ?? '';
             const ep = v.info?.runtime?.executionProvider ?? '';
             const size = v.info?.fileSizeMb != null ? String(v.info.fileSizeMb).padStart(10) : ''.padStart(10);
-            const cached = (await v.isCached()) ? 'yes' : 'no';
+            const cached = v.isCached ? 'yes' : 'no';
             console.log(`      ${v.id.padEnd(54)}  ${device.padEnd(6)}  ${ep.padEnd(32)}  ${size}  ${cached}`);
         }
     }
@@ -98,7 +98,7 @@ if (!model) {
     model = await manager.catalog.getModelVariant(modelIdentifier);
 }
 if (!model) {
-    const allModels = await manager.catalog.listModels();
+    const allModels = await manager.catalog.getModels();
     console.error(`\nModel '${modelIdentifier}' not found in catalog (tried alias and variant id).`);
     console.error(`Available aliases: ${allModels.map((m) => m.alias).join(', ')}`);
     console.error('Run with --list-models to see variant ids.');


### PR DESCRIPTION
The `--list-models` branch in `samples/js/web-server-responses-vision-example/app.js` called `manager.catalog.listModels()`, which does not exist on the SDK catalog (the correct method is `getModels()`). It also awaited `variant.isCached` as if it were an async method, but it is a synchronous getter property.

This PR fixes both call sites of `listModels()` and the `isCached()` invocation so that `--list-models` actually prints the vision-model table instead of throwing.

Tested locally against the Qwen3.5 VL family with `node app.js --list-models` — output now renders the expected table.