### PR TITLE
Update Foundry CORS proxy endpoint to foundry-cors-proxy

### DIFF
--- a/www/.env.example
+++ b/www/.env.example
@@ -7,7 +7,7 @@
 
 # Public API Endpoint (already configured in code)
 # This is the Azure Function proxy endpoint for CORS
-# PUBLIC_FOUNDRY_API_ENDPOINT=https://onnxruntime-foundry-proxy-hpape7gzf2haesef.eastus-01.azurewebsites.net/api/foundryproxy
+# PUBLIC_FOUNDRY_API_ENDPOINT=https://foundry-cors-proxy.azurewebsites.net/api/foundryproxy
 
 # Build-time variables
 # NODE_ENV=production

--- a/www/src/routes/models/service.ts
+++ b/www/src/routes/models/service.ts
@@ -15,7 +15,7 @@ import type { FoundryModel, GroupedFoundryModel } from './types';
 
 // Azure Function endpoint for CORS proxy
 const FOUNDRY_API_ENDPOINT =
-	'https://onnxruntime-foundry-proxy-hpape7gzf2haesef.eastus-01.azurewebsites.net/api/foundryproxy';
+	'https://foundry-cors-proxy.azurewebsites.net/api/foundryproxy';
 
 export interface ApiFilters {
 	device?: string;


### PR DESCRIPTION
## What

Repoints the website's model catalog CORS proxy from the old Function App to the newly deployed one:

- **Old:** `https://onnxruntime-foundry-proxy-hpape7gzf2haesef.eastus-01.azurewebsites.net/api/foundryproxy`
- **New:** `https://foundry-cors-proxy.azurewebsites.net/api/foundryproxy`

## Why

The proxy was redeployed to a new Azure Function App (`foundry-cors-proxy`) in an enterprise subscription. The new app is live and serving the same anonymous CORS proxy to the Azure AI Foundry model catalog API.

## Changes

- `www/src/routes/models/service.ts` — update the hardcoded `FOUNDRY_API_ENDPOINT`.
- `www/.env.example` — update the commented `PUBLIC_FOUNDRY_API_ENDPOINT` example to match.

## Verification

The new endpoint was smoke-tested after deployment:

- `OPTIONS` preflight → `200` with CORS headers (`Access-Control-Allow-Origin: *`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`).
- `POST` → forwards to Foundry and returns the upstream response verbatim (confirmed the proxy reaches `ai.azure.com`).

Anonymous access only — no auth token required, consistent with the previous deployment.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>