### PR TITLE
Fix a shutdown issue and make debugging of CUDA or WebGPU EPs easier

### DIFF
--- a/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.cc
+++ b/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.cc
@@ -18,11 +18,6 @@
 #include <filesystem>
 #include <string>
 
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif
-
 namespace {
 
 constexpr const char* kPackageFileName = "cuda-ep.zip";
@@ -99,6 +94,10 @@ bool CudaEpBootstrapper::DownloadAndRegister(bool force,
       if (progress_cb) {
         progress_cb(name_, 90.0f);
       }
+
+      // Prepend the override directory to PATH so sibling dependency DLLs are discoverable,
+      // matching the normal install path. The provider DLL delay-loads CUDA/cuDNN dependencies.
+      PrependDirToProcessPath(provider_path.parent_path());
 
       if (!register_ep_(kRegistrationName, provider_path)) {
         logger.Log(LogLevel::Warning,
@@ -190,18 +189,7 @@ bool CudaEpBootstrapper::DownloadAndRegister(bool force,
     //   - onnxruntime_providers_cuda.dll delay-loads some dependencies
     //   - onnxruntime-genai-cuda.dll is loaded later at model-load time
     //   - ORT creates CUDA sessions after registration
-    {
-      DWORD len = GetEnvironmentVariableW(L"PATH", nullptr, 0);
-      std::wstring prev_path;
-      if (len > 0) {
-        prev_path.resize(len);
-        GetEnvironmentVariableW(L"PATH", prev_path.data(), len);
-        prev_path.resize(len - 1);  // remove trailing null
-      }
-
-      std::wstring new_path = ep_dir.wstring() + L";" + prev_path;
-      SetEnvironmentVariableW(L"PATH", new_path.c_str());
-    }
+    PrependDirToProcessPath(ep_dir);
 #endif
 
     auto cuda_dll_path = ep_dir / kCudaProviderDll;

--- a/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.cc
+++ b/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.cc
@@ -5,6 +5,7 @@
 #include "ep_detection/ep_utils.h"
 #include "logger.h"
 #include "util/file_lock.h"
+#include "utils.h"
 #include "http/http_download.h"
 #include "util/zip_extract.h"
 
@@ -12,6 +13,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
 #include <cstdio>
 #include <filesystem>
 #include <string>
@@ -44,6 +46,7 @@ constexpr ExpectedBinary kExpectedBinaries[] = {
 
 constexpr const char* kRegistrationName = "Foundry.CUDA";
 constexpr const char* kCudaProviderDll = "onnxruntime_providers_cuda.dll";
+constexpr const char* kCudaProviderOverrideEnv = "FOUNDRY_LOCAL_CUDA_EP_LIBRARY";
 
 }  // anonymous namespace
 
@@ -82,6 +85,40 @@ bool CudaEpBootstrapper::DownloadAndRegister(bool force,
   auto zip_path = ep_dir.parent_path() / kPackageFileName;
 
   try {
+    auto override_path = Utils::GetEnv(kCudaProviderOverrideEnv);
+    if (override_path.has_value() && !override_path->empty()) {
+      std::filesystem::path provider_path(*override_path);
+
+      if (!std::filesystem::exists(provider_path)) {
+        logger.Log(LogLevel::Warning,
+                   fmt::format("CUDA EP: {} set but file does not exist ({})",
+                               kCudaProviderOverrideEnv, provider_path.string()));
+        return false;
+      }
+
+      if (progress_cb) {
+        progress_cb(name_, 90.0f);
+      }
+
+      if (!register_ep_(kRegistrationName, provider_path)) {
+        logger.Log(LogLevel::Warning,
+                   fmt::format("CUDA EP: ORT registration failed for override {}={}",
+                               kCudaProviderOverrideEnv, provider_path.string()));
+        return false;
+      }
+
+      registered_ = true;
+
+      if (progress_cb) {
+        progress_cb(name_, 100.0f);
+      }
+
+      logger.Log(LogLevel::Information,
+                 fmt::format("CUDA EP: ready (override_env={} install_path={})",
+                             kCudaProviderOverrideEnv, provider_path.string()));
+      return true;
+    }
+
     // Cross-process lock to prevent concurrent installs
     FileLock lock(lock_path);
 

--- a/sdk_v2/cpp/src/ep_detection/ep_utils.cc
+++ b/sdk_v2/cpp/src/ep_detection/ep_utils.cc
@@ -11,6 +11,11 @@
 #include <cctype>
 #include <string>
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
 namespace fl {
 
 bool VerifyEpPackage(
@@ -38,6 +43,21 @@ bool VerifyEpPackage(
   }
 
   return true;
+}
+
+void PrependDirToProcessPath([[maybe_unused]] const std::filesystem::path& dir) {
+#ifdef _WIN32
+  DWORD len = GetEnvironmentVariableW(L"PATH", nullptr, 0);
+  std::wstring prev_path;
+  if (len > 0) {
+    prev_path.resize(len);
+    GetEnvironmentVariableW(L"PATH", prev_path.data(), len);
+    prev_path.resize(len - 1);  // remove trailing null
+  }
+
+  std::wstring new_path = dir.wstring() + L";" + prev_path;
+  SetEnvironmentVariableW(L"PATH", new_path.c_str());
+#endif
 }
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/ep_detection/ep_utils.h
+++ b/sdk_v2/cpp/src/ep_detection/ep_utils.h
@@ -24,4 +24,14 @@ bool VerifyEpPackage(
     std::string_view ep_name,
     ILogger& logger);
 
+/// Prepend @p dir to the process `PATH` environment variable for the lifetime of the process.
+///
+/// EP provider libraries (CUDA, WebGPU) delay-load sibling dependency DLLs from their own directory,
+/// and `RegisterExecutionProviderLibrary` loads the provider DLL eagerly. The directory must be on
+/// `PATH` before registration so those dependencies are discoverable. This is a no-op on non-Windows
+/// platforms.
+///
+/// @param dir Directory to prepend to `PATH`.
+void PrependDirToProcessPath(const std::filesystem::path& dir);
+
 }  // namespace fl

--- a/sdk_v2/cpp/src/ep_detection/webgpu_ep_bootstrapper.cc
+++ b/sdk_v2/cpp/src/ep_detection/webgpu_ep_bootstrapper.cc
@@ -21,11 +21,6 @@
 #include <filesystem>
 #include <string>
 
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif
-
 namespace {
 
 constexpr const char* kPackageFileName = "webgpu-ep.zip";
@@ -157,6 +152,10 @@ bool WebGpuEpBootstrapper::DownloadAndRegister(bool force,
         progress_cb(name_, 90.0f);
       }
 
+      // Prepend the override directory to PATH so sibling dependency DLLs are discoverable,
+      // matching the normal install path. The WebGPU EP may delay-load dependencies.
+      PrependDirToProcessPath(provider_path.parent_path());
+
       if (!register_ep_(kRegistrationName, provider_path)) {
         logger.Log(LogLevel::Warning,
                    fmt::format("WebGPU EP: ORT registration failed for override {}={}",
@@ -269,18 +268,7 @@ bool WebGpuEpBootstrapper::DownloadAndRegister(bool force,
 #ifdef _WIN32
     // Prepend the EP directory to PATH for the process lifetime.
     // WebGPU EP may delay-load additional dependencies from the same directory.
-    {
-      DWORD len = GetEnvironmentVariableW(L"PATH", nullptr, 0);
-      std::wstring prev_path;
-      if (len > 0) {
-        prev_path.resize(len);
-        GetEnvironmentVariableW(L"PATH", prev_path.data(), len);
-        prev_path.resize(len - 1);  // remove trailing null
-      }
-
-      std::wstring new_path = ep_dir.wstring() + L";" + prev_path;
-      SetEnvironmentVariableW(L"PATH", new_path.c_str());
-    }
+    PrependDirToProcessPath(ep_dir);
 #endif
 
     auto provider_path = ep_dir / kWebGpuProviderLib;

--- a/sdk_v2/cpp/src/ep_detection/webgpu_ep_bootstrapper.cc
+++ b/sdk_v2/cpp/src/ep_detection/webgpu_ep_bootstrapper.cc
@@ -8,6 +8,7 @@
 #include "logger.h"
 #include "util/file_lock.h"
 #include "util/sha256.h"
+#include "utils.h"
 #include "util/zip_extract.h"
 
 #include <fmt/format.h>
@@ -16,6 +17,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cctype>
+#include <cstdlib>
 #include <filesystem>
 #include <string>
 
@@ -57,6 +59,7 @@ constexpr const char* kWebGpuProviderLib = "libonnxruntime_providers_webgpu.so";
 #endif
 
 constexpr const char* kRegistrationName = "Foundry.WebGPU";
+constexpr const char* kWebGpuProviderOverrideEnv = "FOUNDRY_LOCAL_WEBGPU_EP_LIBRARY";
 
 /// Parsed manifest entry for a single platform.
 struct ManifestPackageInfo {
@@ -139,6 +142,40 @@ bool WebGpuEpBootstrapper::DownloadAndRegister(bool force,
   auto parent_dir = ep_dir.parent_path();
 
   try {
+    auto override_path = Utils::GetEnv(kWebGpuProviderOverrideEnv);
+    if (override_path.has_value() && !override_path->empty()) {
+      std::filesystem::path provider_path(*override_path);
+
+      if (!std::filesystem::exists(provider_path)) {
+        logger.Log(LogLevel::Warning,
+                   fmt::format("WebGPU EP: {} set but file does not exist ({})",
+                               kWebGpuProviderOverrideEnv, provider_path.string()));
+        return false;
+      }
+
+      if (progress_cb) {
+        progress_cb(name_, 90.0f);
+      }
+
+      if (!register_ep_(kRegistrationName, provider_path)) {
+        logger.Log(LogLevel::Warning,
+                   fmt::format("WebGPU EP: ORT registration failed for override {}={}",
+                               kWebGpuProviderOverrideEnv, provider_path.string()));
+        return false;
+      }
+
+      registered_ = true;
+
+      if (progress_cb) {
+        progress_cb(name_, 100.0f);
+      }
+
+      logger.Log(LogLevel::Information,
+                 fmt::format("WebGPU EP: ready (override_env={} install_path={})",
+                             kWebGpuProviderOverrideEnv, provider_path.string()));
+      return true;
+    }
+
     // Fetch manifest before acquiring lock (avoid holding lock during network I/O)
     auto manifest = FetchManifest(logger);
 

--- a/sdk_v2/cpp/src/manager.cc
+++ b/sdk_v2/cpp/src/manager.cc
@@ -41,6 +41,7 @@ namespace fl {
 
 namespace {
 
+std::atomic<ILogger*> s_ort_logger{nullptr};
 std::atomic<ILogger*> s_oga_logger{nullptr};
 
 bool IsTruthyConfigValue(const std::string& value) {
@@ -85,13 +86,13 @@ LogLevel MapOrtLogLevel(OrtLoggingLevel severity) {
   }
 }
 
-void ORT_API_CALL OrtLogCallback(void* logger_param,
+void ORT_API_CALL OrtLogCallback(void* /*logger_param*/,
                                  OrtLoggingLevel severity,
                                  const char* category,
                                  const char* logid,
                                  const char* code_location,
                                  const char* message) {
-  auto* logger = static_cast<ILogger*>(logger_param);
+  auto* logger = s_ort_logger.load(std::memory_order_acquire);
   if (logger == nullptr) {
     return;
   }
@@ -203,7 +204,7 @@ Manager::Manager(const Configuration& config)
 
   {
     OrtStatus* status = ort_api_->CreateEnvWithCustomLogger(
-        OrtLogCallback, logger_.get(), GetDefaultOrtLoggingLevel(genai_verbose_logging), "foundry_local", &ort_env_);
+        OrtLogCallback, nullptr, GetDefaultOrtLoggingLevel(genai_verbose_logging), "foundry_local", &ort_env_);
     if (status != nullptr) {
       const char* msg = ort_api_->GetErrorMessage(status);
       std::string err = std::string("Failed to create OrtEnv: ") + (msg ? msg : "unknown");
@@ -304,9 +305,15 @@ Manager::Manager(const Configuration& config)
       config_.external_service_url.has_value(),
       config_.catalog_region.value_or("auto"),
       disable_region_fallback);
+
+  s_ort_logger.store(logger_.get(), std::memory_order_release);
 }
 
 Manager::~Manager() {
+  // ORT may still emit late teardown logs from internal static cleanup after Manager destruction.
+  // Route those callbacks to a null logger to avoid dereferencing a dangling pointer.
+  s_ort_logger.store(nullptr, std::memory_order_release);
+
   // Signal subsystems to drain before tearing down infrastructure
   try {
     Shutdown();

--- a/sdk_v2/cpp/src/manager.cc
+++ b/sdk_v2/cpp/src/manager.cc
@@ -182,6 +182,7 @@ Manager::Manager(const Configuration& config)
   const auto logger_level = genai_verbose_logging ? LogLevel::Verbose : config_.log_level;
 
   logger_ = std::make_unique<SpdlogLogger>(logger_level, config_.logs_dir.value_or(""));
+  s_ort_logger.store(logger_.get(), std::memory_order_release);
 
   if (genai_verbose_logging) {
     SetOgaLogCallback(logger_.get());
@@ -305,15 +306,9 @@ Manager::Manager(const Configuration& config)
       config_.external_service_url.has_value(),
       config_.catalog_region.value_or("auto"),
       disable_region_fallback);
-
-  s_ort_logger.store(logger_.get(), std::memory_order_release);
 }
 
 Manager::~Manager() {
-  // ORT may still emit late teardown logs from internal static cleanup after Manager destruction.
-  // Route those callbacks to a null logger to avoid dereferencing a dangling pointer.
-  s_ort_logger.store(nullptr, std::memory_order_release);
-
   // Signal subsystems to drain before tearing down infrastructure
   try {
     Shutdown();
@@ -362,6 +357,11 @@ Manager::~Manager() {
   }
 
   logger_->Log(LogLevel::Information, "Manager is being disposed.");
+
+  // ORT may still emit late teardown logs from internal static cleanup after Manager destruction
+  // due to GenAI keeping the OrtEnv alive until the process exits.
+  // Clear s_ort_logger so OrtLogCallback does not dereference a dangling pointer and ignores late logs.
+  s_ort_logger.store(nullptr, std::memory_order_release);
 }
 
 Manager& Manager::Create(const Configuration& config) {


### PR DESCRIPTION
* Handle late logging statements from static cleanup more gracefully. 
  * e.g. webgpu has a callback that is triggered on wgpu instance destruction which happens during static destruction due to globals in genai 
    * the globals in genai aren't required for plugin EPs but that's a separate issue/cleanup
* Make it possible to drop in a custom webgpu or cuda EP for debugging.
  * add env var for specifying path to load library from