### PR TITLE
Fix website accessibility (MAS/WCAG) issues from Accessibility Insights FastPass

### DIFF
--- a/www/src/lib/components/home/nav.svelte
+++ b/www/src/lib/components/home/nav.svelte
@@ -59,7 +59,7 @@
 						darkSrc={siteConfig.logoDark ?? siteConfig.logo}
 						strokeSrc={siteConfig.logoMark}
 						height={28}
-						alt="Foundry Local"
+						alt=""
 					/>
 				</span>
 				<span class="ml-1 whitespace-nowrap text-lg font-semibold">Foundry Local</span>

--- a/www/src/lib/components/install-command.svelte
+++ b/www/src/lib/components/install-command.svelte
@@ -208,7 +208,7 @@ let response = client.complete_chat(&messages, None).await?;`,
 	class="border-primary/20 bg-primary/5 hover:border-primary/40 relative w-full rounded-xl border p-4 transition-all duration-300 hover:shadow-lg sm:p-5"
 >
 	<div class="mb-4 text-center">
-		<h3 class="text-foreground text-sm font-semibold sm:text-base">Start with the SDK</h3>
+		<h2 class="text-foreground text-sm font-semibold sm:text-base">Start with the SDK</h2>
 		<p class="text-muted-foreground mx-auto mt-1 max-w-xl text-xs">
 			Install one package, load a model, then run inference in-process.
 		</p>

--- a/www/src/routes/models/+page.svelte
+++ b/www/src/routes/models/+page.svelte
@@ -509,6 +509,7 @@
 
 	<div class="bg-white dark:bg-neutral-950">
 		<main id="main-content" class="mx-auto w-full max-w-6xl px-6 py-8 sm:px-8 lg:px-12">
+			<h1 class="sr-only">Foundry Local model catalog</h1>
 			<section
 				class="border-border/50 bg-muted/30 mb-4 rounded-lg border px-3 py-2.5 sm:px-4"
 				aria-label="CLI quick test"

--- a/www/src/routes/models/components/ModelFilters.svelte
+++ b/www/src/routes/models/components/ModelFilters.svelte
@@ -43,7 +43,7 @@
 <Card.Root class="border-border/40 bg-background shadow-sm">
 	<Card.Header class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
 		<div>
-			<Card.Title class="text-2xl font-semibold">Browse Foundry Models</Card.Title>
+			<Card.Title level={2} class="text-2xl font-semibold">Browse Foundry Models</Card.Title>
 			<Card.Description>Results update automatically as you type or change filters</Card.Description
 			>
 		</div>


### PR DESCRIPTION
Replaces #840 to move this PR off the fork branch and avoid the Vercel fork authorization gate.

Original fork PR: https://github.com/microsoft/Foundry-Local/pull/840

---

## What

Fixes the accessibility (Microsoft Accessibility Standards / WCAG) issues on the Foundry Local marketing website surfaced by **Accessibility Insights FastPass** (axe-core automated checks). This is the code-actionable portion of the June 2026 SDL Accessibility attestation (ADO User Story 97169 ΓåÆ Task 97172 "Run Accessibility Insights & Fix Bugs").

## Findings & fixes

| Rule (axe-core) | WCAG | Page | Fix |
|---|---|---|---|
| `heading-order` | 1.3.1 (A) | Home | The "Start with the SDK" card used `<h3>` directly under the hero `<h1>`, skipping `<h2>`. Promoted to `<h2>`. |
| `image-redundant-alt` | best-practice | Home + Models | The nav logo `<img>` had `alt="Foundry Local"` immediately next to a visible "Foundry Local" text label, so screen readers announced it twice. Marked the image decorative (`alt=""`); the adjacent text already provides the accessible name. |
| `page-has-heading-one` | best-practice | Models | The `/models` page had no `<h1>`. Added an `sr-only` `<h1>` and set the "Browse Foundry Models" filter card title to `aria-level={2}`, producing a valid `h1 ΓåÆ h2 ΓåÆ h3` outline. |

## Verification

Ran axe-core (tags: `wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`, `best-practice`) against the running dev site:

- **Home (light & dark):** 0 violations (was `heading-order` + `image-redundant-alt`)
- **/models:** 0 violations (was `image-redundant-alt` + `page-has-heading-one`); heading outline now `L1 ΓåÆ L2 ΓåÆ L3`

`npm run check` (svelte-check) holds at the pre-existing 17-error baseline ΓÇö these changes introduce **no new type errors**. (The repo is not currently Prettier-formatted; untouched files report the same Prettier warnings, so that's a pre-existing condition and out of scope here.)

## Notes for the broader attestation

This PR closes the automated-scan ("Accessibility 2") portion. The remaining ADO tasks are process steps that require a human: requesting the Trusted Tester test pass (Accessibility 3), fixing any A11yMAS bugs they file (Accessibility 4), and publishing conformance documentation (Accessibility 5).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
