### PR TITLE
Use WinHTTP transport with Azure Core on Windows

### DIFF
--- a/sdk_v2/cpp/CMakeLists.txt
+++ b/sdk_v2/cpp/CMakeLists.txt
@@ -247,6 +247,11 @@ function(foundry_local_configure_target TARGET LINK_SCOPE)
 
     if(WIN32)
         target_link_libraries(${TARGET} ${LINK_SCOPE} dbghelp bcrypt)
+        # UWP builds have CMAKE_SYSTEM_NAME = "WindowsStore"; desktop = "Windows".
+        # WinHTTP is not available in UWP, so only define this on desktop Windows.
+        if(NOT CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+            target_compile_definitions(${TARGET} PRIVATE FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT=1)
+        endif()
     endif()
 
     if(ANDROID)

--- a/sdk_v2/cpp/src/http/http_client.cc
+++ b/sdk_v2/cpp/src/http/http_client.cc
@@ -10,18 +10,11 @@
 #include <azure/core/http/raw_response.hpp>
 #include <azure/core/io/body_stream.hpp>
 
-#if defined(_WIN32)
-#include <winapifamily.h>
-
-#if !defined(WINAPI_FAMILY) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-#define FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT 1
-#endif
-#endif
-
 // Desktop Windows uses the WinHTTP transport (OS SChannel TLS, no background threads)
 // and drops libcurl entirely to shrink the binary and avoid curl's process-lifetime
 // connection-pool cleanup thread, which races with host-runtime teardown (Node/V8).
 // UWP and non-Windows builds keep the libcurl transport to match the vcpkg feature selection.
+// FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT is set by CMake for non-UWP Windows builds.
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
 #include <azure/core/http/win_http_transport.hpp>
 #else

--- a/sdk_v2/cpp/src/http/http_client.cc
+++ b/sdk_v2/cpp/src/http/http_client.cc
@@ -6,10 +6,19 @@
 
 #include <azure/core/context.hpp>
 #include <azure/core/datetime.hpp>
-#include <azure/core/http/curl_transport.hpp>
 #include <azure/core/http/http.hpp>
 #include <azure/core/http/raw_response.hpp>
 #include <azure/core/io/body_stream.hpp>
+
+// On Windows we use the WinHTTP transport (OS SChannel TLS, no background threads)
+// and drop libcurl entirely to shrink the binary and avoid curl's process-lifetime
+// connection-pool cleanup thread, which races with host-runtime teardown (Node/V8).
+// Other platforms keep the libcurl transport.
+#if defined(_WIN32)
+#include <azure/core/http/win_http_transport.hpp>
+#else
+#include <azure/core/http/curl_transport.hpp>
+#endif
 
 #include <chrono>
 #include <random>
@@ -35,7 +44,11 @@ HttpRawResult HttpRequestRaw(const Azure::Core::Http::HttpMethod& method,
   using namespace Azure::Core;
   using namespace Azure::Core::Http;
 
+#if defined(_WIN32)
+  WinHttpTransport transport;
+#else
   CurlTransport transport;
+#endif
 
   // Build the request. For methods with a body (POST), attach a MemoryBodyStream.
   std::vector<uint8_t> body_bytes(body.begin(), body.end());

--- a/sdk_v2/cpp/src/http/http_client.cc
+++ b/sdk_v2/cpp/src/http/http_client.cc
@@ -10,11 +10,19 @@
 #include <azure/core/http/raw_response.hpp>
 #include <azure/core/io/body_stream.hpp>
 
-// On Windows we use the WinHTTP transport (OS SChannel TLS, no background threads)
-// and drop libcurl entirely to shrink the binary and avoid curl's process-lifetime
-// connection-pool cleanup thread, which races with host-runtime teardown (Node/V8).
-// Other platforms keep the libcurl transport.
 #if defined(_WIN32)
+#include <winapifamily.h>
+
+#if !defined(WINAPI_FAMILY) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#define FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT 1
+#endif
+#endif
+
+// Desktop Windows uses the WinHTTP transport (OS SChannel TLS, no background threads)
+// and drops libcurl entirely to shrink the binary and avoid curl's process-lifetime
+// connection-pool cleanup thread, which races with host-runtime teardown (Node/V8).
+// UWP and non-Windows builds keep the libcurl transport to match the vcpkg feature selection.
+#if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
 #include <azure/core/http/win_http_transport.hpp>
 #else
 #include <azure/core/http/curl_transport.hpp>
@@ -44,7 +52,7 @@ HttpRawResult HttpRequestRaw(const Azure::Core::Http::HttpMethod& method,
   using namespace Azure::Core;
   using namespace Azure::Core::Http;
 
-#if defined(_WIN32)
+#if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
   WinHttpTransport transport;
 #else
   CurlTransport transport;

--- a/sdk_v2/cpp/src/http/http_download.cc
+++ b/sdk_v2/cpp/src/http/http_download.cc
@@ -9,15 +9,8 @@
 #include <azure/core/http/http.hpp>
 #include <azure/core/io/body_stream.hpp>
 
-#if defined(_WIN32)
-#include <winapifamily.h>
-
-#if !defined(WINAPI_FAMILY) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-#define FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT 1
-#endif
-#endif
-
 // See http_client.cc: desktop Windows uses WinHTTP; UWP and non-Windows builds use libcurl.
+// FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT is set by CMake for non-UWP Windows builds.
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
 #include <azure/core/http/win_http_transport.hpp>
 #else

--- a/sdk_v2/cpp/src/http/http_download.cc
+++ b/sdk_v2/cpp/src/http/http_download.cc
@@ -9,8 +9,16 @@
 #include <azure/core/http/http.hpp>
 #include <azure/core/io/body_stream.hpp>
 
-// See http_client.cc: WinHTTP on Windows (no libcurl), libcurl elsewhere.
 #if defined(_WIN32)
+#include <winapifamily.h>
+
+#if !defined(WINAPI_FAMILY) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#define FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT 1
+#endif
+#endif
+
+// See http_client.cc: desktop Windows uses WinHTTP; UWP and non-Windows builds use libcurl.
+#if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
 #include <azure/core/http/win_http_transport.hpp>
 #else
 #include <azure/core/http/curl_transport.hpp>
@@ -36,7 +44,7 @@ bool HttpDownloadFile(const std::string& url,
     std::filesystem::create_directories(parent);
   }
 
-#if defined(_WIN32)
+#if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
   WinHttpTransport transport;
 #else
   CurlTransport transport;

--- a/sdk_v2/cpp/src/http/http_download.cc
+++ b/sdk_v2/cpp/src/http/http_download.cc
@@ -6,9 +6,15 @@
 #include "util/string_utils.h"
 
 #include <azure/core/context.hpp>
-#include <azure/core/http/curl_transport.hpp>
 #include <azure/core/http/http.hpp>
 #include <azure/core/io/body_stream.hpp>
+
+// See http_client.cc: WinHTTP on Windows (no libcurl), libcurl elsewhere.
+#if defined(_WIN32)
+#include <azure/core/http/win_http_transport.hpp>
+#else
+#include <azure/core/http/curl_transport.hpp>
+#endif
 
 #include <filesystem>
 #include <fstream>
@@ -30,7 +36,11 @@ bool HttpDownloadFile(const std::string& url,
     std::filesystem::create_directories(parent);
   }
 
+#if defined(_WIN32)
+  WinHttpTransport transport;
+#else
   CurlTransport transport;
+#endif
   Request request(HttpMethod::Get, Url(url));
   request.SetHeader("User-Agent", user_agent);
 

--- a/sdk_v2/cpp/src/service/web_service.cc
+++ b/sdk_v2/cpp/src/service/web_service.cc
@@ -188,6 +188,23 @@ struct WebService::Impl {
   std::unique_ptr<ServiceContext> context;
   std::atomic<bool> running{false};
 
+#ifdef FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT
+  // oatpp does not call WSAStartup() itself; it relies on the application to have done so.
+  // On desktop Windows (FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT), libcurl is absent, so its DllMain no longer
+  // initialises Winsock as a side effect. We must do it explicitly so that oatpp's getaddrinfo() call in
+  // ConnectionProvider::instantiateServer() succeeds. UWP Windows still uses libcurl and is unaffected.
+  struct WsaGuard {
+    bool ok;
+    WSADATA data{};
+    WsaGuard() : ok(WSAStartup(MAKEWORD(2, 2), &data) == 0) {}
+    ~WsaGuard() {
+      if (ok) {
+        WSACleanup();
+      }
+    }
+  } wsa_guard_;
+#endif
+
   Impl(ICatalog& catalog, ILogger& logger, std::string model_cache_dir,
        ModelLoadManager& model_load_manager, SessionManager& session_manager,
        ITelemetry& telemetry, std::function<void()> shutdown_callback)

--- a/sdk_v2/cpp/vcpkg.json
+++ b/sdk_v2/cpp/vcpkg.json
@@ -5,6 +5,18 @@
   "builtin-baseline": "256acc64012b23a13041d8705805e1f23b43a024",
   "dependencies": [
     "azure-storage-blobs-cpp",
+    {
+      "name": "azure-core-cpp",
+      "default-features": false,
+      "features": ["winhttp"],
+      "platform": "windows & !uwp"
+    },
+    {
+      "name": "azure-core-cpp",
+      "default-features": false,
+      "features": ["curl"],
+      "platform": "!windows | uwp"
+    },
     "ms-gsl",
     "nlohmann-json",
     "spdlog"


### PR DESCRIPTION
Both `http_client.cc` and `http_download.cc` duplicated the same 7-line preprocessor block to detect desktop-vs-UWP Windows and define `FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT`. This moves that logic to a single CMake definition.

## Changes

- **`CMakeLists.txt`** — in `foundry_local_configure_target`, define `FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT=1` for non-UWP Windows builds. UWP is identified via `CMAKE_SYSTEM_NAME STREQUAL "WindowsStore"` (desktop = `"Windows"`):
  ```cmake
  if(WIN32)
      target_link_libraries(${TARGET} ${LINK_SCOPE} dbghelp bcrypt)
      # UWP builds have CMAKE_SYSTEM_NAME = "WindowsStore"; desktop = "Windows".
      # WinHTTP is not available in UWP, so only define this on desktop Windows.
      if(NOT CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
          target_compile_definitions(${TARGET} PRIVATE FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT=1)
      endif()
  endif()
  ```

- **`http_client.cc` / `http_download.cc`** — remove the duplicated detection block (`#include <winapifamily.h>` + `WINAPI_FAMILY_PARTITION` guard + local `#define`); both files now consume `FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT` directly as a CMake-supplied definition.