### PR TITLE
Fix Node shutdown crash

### DIFF
--- a/memories/repo/js-tsfn-env-cleanup-hook.md
+++ b/memories/repo/js-tsfn-env-cleanup-hook.md
@@ -1,0 +1,47 @@
+# JS addon: release ThreadSafeFunction from an env cleanup hook, never a finalizer
+
+A `Napi::ThreadSafeFunction` (TSFN) held for the life of the addon — e.g. stored
+in `SetInstanceData` addon data — must be released via
+`napi_add_env_cleanup_hook` (node-addon-api: `env.AddCleanupHook(...)`), **not**
+from the instance-data destructor (`~AddonData`) or an `ObjectWrap` finalizer.
+
+Per Node's N-API docs, *"Finalization on the exit of the Node.js environment"*:
+the `napi_finalize` callbacks of JS objects, thread-safe functions, and
+environment instance data are *"invoked immediately and independently"* at env
+teardown, and *"scheduled after the manually registered cleanup hooks."*
+Releasing a TSFN from a finalizer therefore races the TSFN's own `uv_async`
+handle close against libuv/V8 graceful teardown, and Node dereferences freed
+state while draining the loop.
+
+**Symptom:** intermittent process-exit crash after all app work completes —
+`0xC0000005` (access violation) faulting in `node.exe` inside
+`node::FreeEnvironment` → `uv_run` (reading a freed object, e.g. `read of 0xc`),
+occasionally `0xC0000374` (heap corruption). Variable hit-rate, worse on
+Node 24+. WER (AeDebug JIT and LocalDumps) cannot capture it because the fault
+is consumed first-chance during teardown; a live debugger hides it (Heisenbug).
+A first-chance vectored exception handler (`AddVectoredExceptionHandler`) is the
+tool that names the faulting frame.
+
+**Rule:** for a process-lifetime TSFN, register a cleanup hook at `Init` that
+does the `Release()`, and null the handle so the destructor does not
+double-release. Example (`sdk_v2/js/native/src/addon.cc`,
+`AddonData::buffer_release_tsfn`):
+
+```cpp
+data->buffer_release_tsfn = Napi::ThreadSafeFunction::New(env, noop, name, 0, 1);
+data->buffer_release_tsfn.Unref(env);  // don't pin the loop
+env.AddCleanupHook(
+    [](AddonData* d) {
+      if (d->buffer_release_tsfn) {
+        d->buffer_release_tsfn.Release();
+        d->buffer_release_tsfn = Napi::ThreadSafeFunction();  // null so ~AddonData won't re-release
+      }
+    },
+    data);
+```
+
+This was the true root cause of the JS SDK's Node-exit crash. Earlier
+attributions (a libcurl connection-pool cleanup thread; ORT/GenAI `OgaShutdown`
+static teardown) were misdiagnoses driven by the variable hit-rate — neither was
+the cause, and `process.exit()` only masked it. The proper fix needs no
+`process.exit()` and no native shutdown hook.

--- a/sdk_v2/js/native/src/addon.cc
+++ b/sdk_v2/js/native/src/addon.cc
@@ -63,12 +63,16 @@ static void PreloadIsolatedOpenSsl() {
 namespace foundry_local_node {
 
 AddonData::~AddonData() {
-  // Release the addon's own reference acquired at Init. Per-item Acquires
-  // are released by their deleters; once both sides drain, the TSFN
-  // finalizes. By the time ~AddonData runs at env teardown, ObjectWrap
-  // finalizers have already destroyed Requests (and therefore their Items),
-  // so any pending Releases from item deleters have been queued on the JS
-  // thread before we get here.
+  // buffer_release_tsfn is released by the env cleanup hook registered in
+  // Init(), not by this destructor. Releasing a ThreadSafeFunction from the
+  // instance-data destructor is unsafe: it runs late in node::FreeEnvironment,
+  // after the point where the TSFN's uv_async handle can be finalized cleanly,
+  // so the async close races the loop teardown and Node dereferences freed
+  // state during uv_run (a process-exit access violation). N-API's
+  // "Finalization on the exit of the environment" guidance prescribes
+  // napi_add_env_cleanup_hook for exactly this. The cleanup hook nulls the
+  // handle, so this guard is normally false; the Release() below is a
+  // defensive fallback that only runs if the cleanup hook never fired.
   if (buffer_release_tsfn) {
     buffer_release_tsfn.Release();
   }
@@ -100,6 +104,23 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   // queued from background threads still execute on the JS thread; we just
   // stop using this TSFN to artificially keep the process alive.
   data->buffer_release_tsfn.Unref(env);
+
+  // Release the TSFN from an env cleanup hook rather than from ~AddonData.
+  // Cleanup hooks run early in node::FreeEnvironment, while the event loop
+  // can still finalize the TSFN's uv_async handle safely; the instance-data
+  // destructor runs too late and its async close races loop teardown,
+  // producing a process-exit access violation (a use-after-free that Node
+  // hits while draining the loop in uv_run). Null the handle so ~AddonData
+  // does not double-release. Per N-API "Finalization on the exit of the
+  // Node.js environment".
+  env.AddCleanupHook(
+      [](foundry_local_node::AddonData* d) {
+        if (d->buffer_release_tsfn) {
+          d->buffer_release_tsfn.Release();
+          d->buffer_release_tsfn = Napi::ThreadSafeFunction();
+        }
+      },
+      data);
 
   Napi::Function manager_ctor = foundry_local_node::Manager::Init(env);
   Napi::Function catalog_ctor = foundry_local_node::Catalog::Init(env);

--- a/sdk_v2/js/native/src/addon_data.h
+++ b/sdk_v2/js/native/src/addon_data.h
@@ -30,9 +30,12 @@ struct AddonData {
   //
   // Created once at addon Init with an initial thread count of 1 (the
   // addon's own reference). Each MakePinnedDeleter call Acquires; each
-  // deleter invocation Releases. The addon's reference is released by
-  // ~AddonData at env teardown so the TSFN finalizes after all pending
-  // pinned-buffer deleters have drained.
+  // deleter invocation Releases. The addon's own reference is released by an
+  // env cleanup hook registered in Init (napi_add_env_cleanup_hook) — NOT by
+  // ~AddonData — so the TSFN's uv_async handle is finalized while the event
+  // loop is still alive. Releasing it from the instance-data destructor runs
+  // too late in node::FreeEnvironment and races the loop teardown, causing a
+  // process-exit access violation. See the Init comment in addon.cc.
   Napi::ThreadSafeFunction buffer_release_tsfn;
 
   ~AddonData();

--- a/sdk_v2/js/src/foundryLocalManager.ts
+++ b/sdk_v2/js/src/foundryLocalManager.ts
@@ -13,16 +13,12 @@ import {
 } from "./detail/native.js";
 import type { EpDownloadResult, EpInfo } from "./types.js";
 
-// Once a native Manager exists, ONNX Runtime's process-wide teardown races with
-// Node's environment teardown on a natural exit and crashes — a long-standing
-// ORT-on-exit issue, independent of this SDK. It is avoided only by releasing
-// the Manager and then leaving via `process.exit()`, which skips that graceful
-// teardown. So track the live manager and do exactly that on the way out: dispose
-// on `beforeExit` then exit explicitly; an `exit` handler covers callers who
-// invoke `process.exit()` themselves (releasing the env before the C runtime
-// tears the ORT libraries down keeps their static destructors benign).
-// The native layer permits only one live Manager at a time, so a single
-// reference is enough.
+// A native Manager holds process-global native resources. Dispose the live
+// Manager on process exit so native teardown happens at a deterministic point
+// rather than being left entirely to environment finalizers. `beforeExit`
+// covers a natural event-loop drain; `exit` covers callers who invoke
+// `process.exit()` themselves. Both are idempotent. The native layer permits
+// only one live Manager at a time, so a single reference is enough.
 let liveManager: FoundryLocalManager | undefined;
 let exitHandlersInstalled = false;
 
@@ -45,7 +41,6 @@ function installExitHandlersOnce(): void {
   exitHandlersInstalled = true;
   process.on("beforeExit", () => {
     disposeLiveManager();
-    process.exit(process.exitCode ?? 0);
   });
   process.on("exit", () => {
     disposeLiveManager();


### PR DESCRIPTION
Fix the cleanup point for the AddonData::buffer_release_tsfn Napi::ThreadSafeFunction so we don't crash during shutdown.

Remove the `process.exit()` in the `beforeExit` handler which was working around the issue but not allowing graceful exit. 
