### PR TITLE
fix(cpp): honor SSL_CERT_FILE via CURLOPT_CAINFO for TLS on Android

### DIFF
--- a/sdk_v2/cpp/CMakeLists.txt
+++ b/sdk_v2/cpp/CMakeLists.txt
@@ -230,6 +230,7 @@ set(FOUNDRY_LOCAL_SOURCES
     src/exception.cc
     src/inferencing/generative/genai_config.cc
     src/http/http_client.cc
+    src/http/curl_transport.cc
     src/inferencing/generative/genai_model_instance.cc
     src/inferencing/generative/tokenizer.cc
     src/logger.cc

--- a/sdk_v2/cpp/build.py
+++ b/sdk_v2/cpp/build.py
@@ -568,17 +568,14 @@ def android_test(args: argparse.Namespace) -> None:
 
         # Collect shared libraries that need to be pushed alongside the test binary
         build_dir = args.build_dir
-        shared_libs = list(build_dir.glob("*.so"))
+        bin_dir = build_dir / "bin"
+        shared_libs = list(bin_dir.glob("*.so"))
 
-        # Also include ORT/GenAI .so files that were copied to the build dir
-        for pattern in ["libonnxruntime.so", "libonnxruntime-genai.so"]:
-            shared_libs.extend(build_dir.glob(pattern))
-
-        # Deduplicate
-        shared_libs = list({lib.resolve(): lib for lib in shared_libs}.values())
-
-        test_binary = build_dir / "bin" / "foundry_local_tests"
-        test_data = build_dir / "bin" / "testdata"
+        # foundry_local_tests links the SDK statically (unit tests); sdk_integration_tests links the
+        # shared lib and drives the SDK end to end
+        test_binaries = [bin_dir / name for name in ("foundry_local_tests", "sdk_integration_tests")]
+        test_binaries = [b for b in test_binaries if b.exists()]
+        test_data = bin_dir / "testdata"
 
         # Resolve test model cache the same way the C++ tests do (FOUNDRY_TEST_DATA_DIR env var)
         model_cache_env = os.environ.get("FOUNDRY_TEST_DATA_DIR")
@@ -586,7 +583,7 @@ def android_test(args: argparse.Namespace) -> None:
 
         exit_code = android_tools.run_tests_on_device(
             sdk_tool_paths,
-            test_binary,
+            test_binaries,
             shared_libs,
             test_data_dir=test_data if test_data.exists() else None,
             model_cache_dir=model_cache if model_cache and model_cache.is_dir() else None,

--- a/sdk_v2/cpp/docs/AndroidBuildPlan.md
+++ b/sdk_v2/cpp/docs/AndroidBuildPlan.md
@@ -192,11 +192,27 @@ When `--android_run_emulator --test` is specified, `build.py`:
 
 ### Problem
 
-Statically-linked OpenSSL (built by vcpkg) **ignores the `SSL_CERT_DIR` environment variable** at
-runtime. The `--openssldir` path is baked at build time to a non-existent location on Android.
-`SSL_CERT_FILE` with a single concatenated PEM bundle *is* honored.
+Statically-linked OpenSSL/libcurl (built by vcpkg) **ignores both the `SSL_CERT_DIR` and the
+`SSL_CERT_FILE` environment variables** at request time. The default CA location (`--openssldir`) is
+baked at build time to a path that does not exist on Android, and this libcurl build was not
+compiled with the fallback that would otherwise consult `SSL_CERT_FILE`. As a result, setting either
+environment variable alone has **no effect** — curl uses its (non-existent) compiled-in default and
+verification fails with a misleading "self-signed certificate in certificate chain".
 
-### Solution for Testing
+> This was confirmed on-device: passing the device's own trust store via `SSL_CERT_FILE` still
+> failed, while the *exact same* bundle passed explicitly as a CA file (`openssl s_client -CAfile`,
+> equivalent to `CURLOPT_CAINFO`) verified `ai.azure.com` with `Verify return code: 0 (ok)`. Only the
+> delivery mechanism differed.
+
+### Solution
+
+The Core reads the `SSL_CERT_FILE` environment variable and forwards it explicitly to libcurl via
+`CurlTransportOptions.CAInfo` (`CURLOPT_CAINFO`), which libcurl **always** honors. See
+`src/http/http_client.cc` and `src/http/http_download.cc`. Callers therefore still set
+`SSL_CERT_FILE`, but its effect now comes from the Core forwarding it to `CAInfo` — not from OpenSSL
+auto-reading the environment.
+
+### Building the bundle for testing
 
 `tools/android.py` builds a CA bundle at test time from the device's system certificates:
 
@@ -207,7 +223,7 @@ runtime. The `--openssldir` path is baked at build time to a non-existent locati
    ```
    cat /system/etc/security/cacerts/*.0 > /data/local/tmp/foundry_tests/cacert.pem
    ```
-3. Sets `SSL_CERT_FILE` pointing to the bundle
+3. Sets `SSL_CERT_FILE` pointing to the bundle (the Core forwards it to `CAInfo`)
 
 This approach uses the device's actual trust store, so it works with any API level and includes
 all root CAs that the device trusts (including DigiCert Global Root G2 needed for Azure endpoints).
@@ -220,9 +236,11 @@ the same pattern FL Core used.
 
 ### Key Insight
 
-`SSL_CERT_DIR` does **not** work with statically-linked OpenSSL on Android. Always use `SSL_CERT_FILE`
-with a concatenated PEM bundle. The error message when this fails is misleading: "self-signed
-certificate in certificate chain" — it actually means OpenSSL cannot find **any** CA store.
+Neither `SSL_CERT_DIR` nor `SSL_CERT_FILE` is auto-consulted by this statically-linked
+OpenSSL/libcurl on Android. The CA bundle **must** be passed explicitly via `CURLOPT_CAINFO`; the
+Core does this by forwarding `SSL_CERT_FILE`. The error message when the store is missing is
+misleading: "self-signed certificate in certificate chain" — it actually means OpenSSL cannot find
+**any** CA store.
 
 ---
 

--- a/sdk_v2/cpp/src/download/blob_downloader.cc
+++ b/sdk_v2/cpp/src/download/blob_downloader.cc
@@ -29,6 +29,8 @@
 // does not honor SSL_CERT_FILE. On non-Windows builds we install a CurlTransport preconfigured with
 // CAInfo (see MakeBlobClientOptions below). Desktop Windows uses the default WinHTTP transport.
 #if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
+#include "http/curl_transport.h"
+
 #include <azure/core/http/curl_transport.hpp>
 #endif
 
@@ -50,10 +52,11 @@ constexpr size_t kStreamingBufferBytes = 64 * 1024;
 Azure::Storage::Blobs::BlobClientOptions MakeBlobClientOptions() {
   Azure::Storage::Blobs::BlobClientOptions options;
 #if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
-  if (std::string ca_bundle = fl::http::CaBundleFile(); !ca_bundle.empty()) {
-    Azure::Core::Http::CurlTransportOptions curl_opts;
-    curl_opts.CAInfo = std::move(ca_bundle);
-    options.Transport.Transport = std::make_shared<Azure::Core::Http::CurlTransport>(curl_opts);
+  // Only override the Storage SDK's default transport when a CA bundle is configured; the options are
+  // cached and shared with our other curl transports (see http/curl_transport.h).
+  if (!fl::http::CaBundleFile().empty()) {
+    options.Transport.Transport =
+        std::make_shared<Azure::Core::Http::CurlTransport>(fl::http::CachedCurlTransportOptions());
   }
 #endif
   return options;

--- a/sdk_v2/cpp/src/download/blob_downloader.cc
+++ b/sdk_v2/cpp/src/download/blob_downloader.cc
@@ -52,11 +52,11 @@ constexpr size_t kStreamingBufferBytes = 64 * 1024;
 Azure::Storage::Blobs::BlobClientOptions MakeBlobClientOptions() {
   Azure::Storage::Blobs::BlobClientOptions options;
 #if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
-  // Only override the Storage SDK's default transport when a CA bundle is configured; the options are
-  // cached and shared with our other curl transports (see http/curl_transport.h).
-  if (!fl::http::CaBundleFile().empty()) {
+  // Only override the Storage SDK's default transport when a CA bundle is configured.
+  auto curl_options = fl::http::MakeCurlTransportOptions();
+  if (!curl_options.CAInfo.empty()) {
     options.Transport.Transport =
-        std::make_shared<Azure::Core::Http::CurlTransport>(fl::http::CachedCurlTransportOptions());
+        std::make_shared<Azure::Core::Http::CurlTransport>(curl_options);
   }
 #endif
   return options;

--- a/sdk_v2/cpp/src/download/blob_downloader.cc
+++ b/sdk_v2/cpp/src/download/blob_downloader.cc
@@ -4,6 +4,7 @@
 #include "download/blob_download_state.h"
 #include "download/file_writer.h"
 #include "exception.h"
+#include "http/http_client.h"
 #include "logger.h"
 #include "util/path_safety.h"
 #include "util/string_utils.h"
@@ -18,10 +19,18 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <azure/core/context.hpp>
 #include <azure/storage/blobs.hpp>
+
+// The Azure Storage SDK builds its own libcurl transport, which — like our other curl transports —
+// does not honor SSL_CERT_FILE. On non-Windows builds we install a CurlTransport preconfigured with
+// CAInfo (see MakeBlobClientOptions below). Desktop Windows uses the default WinHTTP transport.
+#if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
+#include <azure/core/http/curl_transport.hpp>
+#endif
 
 namespace fl {
 
@@ -31,6 +40,24 @@ namespace {
 /// 64 KB-ish granularity Stream.CopyTo uses in .NET, capping per-worker peak
 /// memory at this many bytes regardless of chunk size.
 constexpr size_t kStreamingBufferBytes = 64 * 1024;
+
+/// Builds BlobClientOptions with the CA bundle wired into the transport. The Azure Storage SDK
+/// constructs its own libcurl transport internally, which does not consult SSL_CERT_FILE, so blob
+/// downloads would otherwise fail TLS verification on Android with "unable to get local issuer
+/// certificate". On non-Windows builds we install a CurlTransport preconfigured with CAInfo so
+/// verification uses the caller-provided trust store; on desktop Windows the default WinHTTP
+/// transport uses the OS store and is left untouched.
+Azure::Storage::Blobs::BlobClientOptions MakeBlobClientOptions() {
+  Azure::Storage::Blobs::BlobClientOptions options;
+#if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
+  if (std::string ca_bundle = fl::http::CaBundleFile(); !ca_bundle.empty()) {
+    Azure::Core::Http::CurlTransportOptions curl_opts;
+    curl_opts.CAInfo = std::move(ca_bundle);
+    options.Transport.Transport = std::make_shared<Azure::Core::Http::CurlTransport>(curl_opts);
+  }
+#endif
+  return options;
+}
 
 }  // namespace
 
@@ -55,7 +82,7 @@ AzureBlobDownloader::AzureBlobDownloader(ILogger& logger) : logger_(logger) {}
 
 std::vector<BlobItemInfo> AzureBlobDownloader::ListBlobs(const std::string& sas_uri) {
   try {
-    auto container_client = Azure::Storage::Blobs::BlobContainerClient(sas_uri);
+    auto container_client = Azure::Storage::Blobs::BlobContainerClient(sas_uri, MakeBlobClientOptions());
     std::vector<BlobItemInfo> items;
 
     for (auto page = container_client.ListBlobs(); page.HasPage(); page.MoveToNextPage()) {
@@ -137,7 +164,8 @@ void AzureBlobDownloader::DownloadBlob(const std::string& sas_uri,
   try {
     // Configure retry at the SDK level instead of a manual retry loop.
     // Exponential backoff: 2s initial delay, 30s cap, generous retry count.
-    Azure::Storage::Blobs::BlobClientOptions client_options;
+    // MakeBlobClientOptions wires the CA bundle into the transport (see its comment).
+    auto client_options = MakeBlobClientOptions();
     client_options.Retry.MaxRetries = 10;
     client_options.Retry.RetryDelay = std::chrono::milliseconds{2000};
     client_options.Retry.MaxRetryDelay = std::chrono::milliseconds{30000};

--- a/sdk_v2/cpp/src/download/blob_downloader.cc
+++ b/sdk_v2/cpp/src/download/blob_downloader.cc
@@ -26,9 +26,9 @@
 #include <azure/storage/blobs.hpp>
 
 // The Azure Storage SDK builds its own libcurl transport, which — like our other curl transports —
-// does not honor SSL_CERT_FILE. On non-Windows builds we install a CurlTransport preconfigured with
-// CAInfo (see MakeBlobClientOptions below). Desktop Windows uses the default WinHTTP transport.
-#if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
+// does not honor SSL_CERT_FILE. On Android we install a CurlTransport preconfigured with CAInfo
+// (see MakeBlobClientOptions below); every other platform uses the SDK's default transport.
+#if defined(ANDROID)
 #include "http/curl_transport.h"
 
 #include <azure/core/http/curl_transport.hpp>
@@ -46,12 +46,12 @@ constexpr size_t kStreamingBufferBytes = 64 * 1024;
 /// Builds BlobClientOptions with the CA bundle wired into the transport. The Azure Storage SDK
 /// constructs its own libcurl transport internally, which does not consult SSL_CERT_FILE, so blob
 /// downloads would otherwise fail TLS verification on Android with "unable to get local issuer
-/// certificate". On non-Windows builds we install a CurlTransport preconfigured with CAInfo so
-/// verification uses the caller-provided trust store; on desktop Windows the default WinHTTP
-/// transport uses the OS store and is left untouched.
+/// certificate". On Android we install a CurlTransport preconfigured with CAInfo so verification
+/// uses the caller-provided trust store; every other platform resolves trust through its default
+/// transport (system CA store on Linux/macOS, WinHTTP OS store on Windows) and is left untouched.
 Azure::Storage::Blobs::BlobClientOptions MakeBlobClientOptions() {
   Azure::Storage::Blobs::BlobClientOptions options;
-#if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
+#if defined(ANDROID)
   // Only override the Storage SDK's default transport when a CA bundle is configured.
   auto curl_options = fl::http::MakeCurlTransportOptions();
   if (!curl_options.CAInfo.empty()) {

--- a/sdk_v2/cpp/src/http/curl_transport.cc
+++ b/sdk_v2/cpp/src/http/curl_transport.cc
@@ -15,8 +15,8 @@ namespace http {
 const Azure::Core::Http::CurlTransportOptions& CachedCurlTransportOptions() {
   static const Azure::Core::Http::CurlTransportOptions options = [] {
     Azure::Core::Http::CurlTransportOptions opts;
-    if (std::string ca_bundle = CaBundleFile(); !ca_bundle.empty()) {
-      opts.CAInfo = std::move(ca_bundle);
+    if (const std::string& ca_bundle = CaBundleFile(); !ca_bundle.empty()) {
+      opts.CAInfo = ca_bundle;
     }
     return opts;
   }();

--- a/sdk_v2/cpp/src/http/curl_transport.cc
+++ b/sdk_v2/cpp/src/http/curl_transport.cc
@@ -7,19 +7,16 @@
 #include "http/http_client.h"
 
 #include <string>
-#include <utility>
 
 namespace fl {
 namespace http {
 
-const Azure::Core::Http::CurlTransportOptions& CachedCurlTransportOptions() {
-  static const Azure::Core::Http::CurlTransportOptions options = [] {
-    Azure::Core::Http::CurlTransportOptions opts;
-    if (const std::string& ca_bundle = CaBundleFile(); !ca_bundle.empty()) {
-      opts.CAInfo = ca_bundle;
-    }
-    return opts;
-  }();
+Azure::Core::Http::CurlTransportOptions MakeCurlTransportOptions() {
+  Azure::Core::Http::CurlTransportOptions options;
+  if (const std::string& ca_bundle = CABundleFilePath(); !ca_bundle.empty()) {
+    options.CAInfo = ca_bundle;
+  }
+
   return options;
 }
 

--- a/sdk_v2/cpp/src/http/curl_transport.cc
+++ b/sdk_v2/cpp/src/http/curl_transport.cc
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "http/curl_transport.h"
+
+#if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
+
+#include "http/http_client.h"
+
+#include <string>
+#include <utility>
+
+namespace fl {
+namespace http {
+
+const Azure::Core::Http::CurlTransportOptions& CachedCurlTransportOptions() {
+  static const Azure::Core::Http::CurlTransportOptions options = [] {
+    Azure::Core::Http::CurlTransportOptions opts;
+    if (std::string ca_bundle = CaBundleFile(); !ca_bundle.empty()) {
+      opts.CAInfo = std::move(ca_bundle);
+    }
+    return opts;
+  }();
+  return options;
+}
+
+}  // namespace http
+}  // namespace fl
+
+#endif  // !FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT

--- a/sdk_v2/cpp/src/http/curl_transport.cc
+++ b/sdk_v2/cpp/src/http/curl_transport.cc
@@ -13,9 +13,11 @@ namespace http {
 
 Azure::Core::Http::CurlTransportOptions MakeCurlTransportOptions() {
   Azure::Core::Http::CurlTransportOptions options;
+#if defined(ANDROID)
   if (const std::string& ca_bundle = CABundleFilePath(); !ca_bundle.empty()) {
     options.CAInfo = ca_bundle;
   }
+#endif
 
   return options;
 }

--- a/sdk_v2/cpp/src/http/curl_transport.h
+++ b/sdk_v2/cpp/src/http/curl_transport.h
@@ -12,8 +12,8 @@
 namespace fl {
 namespace http {
 
-/// Creates libcurl transport options with `CAInfo` populated from `SSL_CERT_FILE` via `CABundleFilePath`.
-/// When `SSL_CERT_FILE` is unset, `CAInfo` is empty and libcurl falls back to its compiled-in default.
+/// Creates libcurl transport options with `CAInfo` set from `CABundleFilePath` (Android only; empty
+/// elsewhere, so libcurl falls back to the system default CA store).
 Azure::Core::Http::CurlTransportOptions MakeCurlTransportOptions();
 
 }  // namespace http

--- a/sdk_v2/cpp/src/http/curl_transport.h
+++ b/sdk_v2/cpp/src/http/curl_transport.h
@@ -12,12 +12,9 @@
 namespace fl {
 namespace http {
 
-/// Returns the process-wide libcurl transport options, with `CAInfo` populated from `SSL_CERT_FILE`
-/// (via `CaBundleFile`). Built once and shared by every libcurl transport we construct — direct
-/// requests, file downloads, and the Azure Storage blob client — because the CA bundle path is fixed
-/// for the process lifetime. When `SSL_CERT_FILE` is unset, `CAInfo` is empty and libcurl falls back
-/// to its compiled-in default. The returned reference is valid for the lifetime of the process.
-const Azure::Core::Http::CurlTransportOptions& CachedCurlTransportOptions();
+/// Creates libcurl transport options with `CAInfo` populated from `SSL_CERT_FILE` via `CABundleFilePath`.
+/// When `SSL_CERT_FILE` is unset, `CAInfo` is empty and libcurl falls back to its compiled-in default.
+Azure::Core::Http::CurlTransportOptions MakeCurlTransportOptions();
 
 }  // namespace http
 }  // namespace fl

--- a/sdk_v2/cpp/src/http/curl_transport.h
+++ b/sdk_v2/cpp/src/http/curl_transport.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+// Desktop Windows uses the WinHTTP transport and never links libcurl, so the curl transport options
+// are only meaningful for the non-WinHTTP (libcurl) builds. Guard the whole header accordingly so
+// includers on Windows do not pull in the Azure curl transport dependency.
+#if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
+
+#include <azure/core/http/curl_transport.hpp>
+
+namespace fl {
+namespace http {
+
+/// Returns the process-wide libcurl transport options, with `CAInfo` populated from `SSL_CERT_FILE`
+/// (via `CaBundleFile`). Built once and shared by every libcurl transport we construct — direct
+/// requests, file downloads, and the Azure Storage blob client — because the CA bundle path is fixed
+/// for the process lifetime. When `SSL_CERT_FILE` is unset, `CAInfo` is empty and libcurl falls back
+/// to its compiled-in default. The returned reference is valid for the lifetime of the process.
+const Azure::Core::Http::CurlTransportOptions& CachedCurlTransportOptions();
+
+}  // namespace http
+}  // namespace fl
+
+#endif  // !FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT

--- a/sdk_v2/cpp/src/http/http_client.cc
+++ b/sdk_v2/cpp/src/http/http_client.cc
@@ -18,11 +18,12 @@
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
 #include <azure/core/http/win_http_transport.hpp>
 #else
+#include "http/curl_transport.h"
+
 #include <azure/core/http/curl_transport.hpp>
 #endif
 
 #include <chrono>
-#include <cstdlib>
 #include <random>
 #include <string>
 #include <thread>
@@ -33,11 +34,13 @@ namespace fl {
 namespace http {
 
 std::string CaBundleFile() {
-  const char* cert_file = std::getenv("SSL_CERT_FILE");
-  if (cert_file != nullptr && cert_file[0] != '\0') {
-    return cert_file;
-  }
-  return {};
+  // SSL_CERT_FILE is fixed for the process lifetime (callers set it before loading the library), so
+  // read it once and reuse the cached path for every request.
+  static const std::string ca_bundle = [] {
+    auto cert_file = Utils::GetEnv("SSL_CERT_FILE");
+    return (cert_file && !cert_file->empty()) ? std::move(*cert_file) : std::string();
+  }();
+  return ca_bundle;
 }
 
 namespace {
@@ -58,14 +61,10 @@ HttpRawResult HttpRequestRaw(const Azure::Core::Http::HttpMethod& method,
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
   WinHttpTransport transport;
 #else
-  // The bundled libcurl does not honor the SSL_CERT_FILE environment variable (it was built with a
-  // compiled-in default CA path that does not exist on platforms like Android). Explicitly pass the
-  // CA bundle via CAInfo so the caller-provided trust store is actually used for TLS verification.
-  CurlTransportOptions curl_opts;
-  if (std::string ca_bundle = CaBundleFile(); !ca_bundle.empty()) {
-    curl_opts.CAInfo = std::move(ca_bundle);
-  }
-  CurlTransport transport(curl_opts);
+  // libcurl does not honor SSL_CERT_FILE (its compiled-in default CA path is absent on Android), so
+  // we pass the CA bundle explicitly via CAInfo. The options are cached and shared (see
+  // http/curl_transport.h) and copied into the per-request transport.
+  CurlTransport transport(CachedCurlTransportOptions());
 #endif
 
   // Build the request. For methods with a body (POST), attach a MemoryBodyStream.

--- a/sdk_v2/cpp/src/http/http_client.cc
+++ b/sdk_v2/cpp/src/http/http_client.cc
@@ -22,13 +22,23 @@
 #endif
 
 #include <chrono>
+#include <cstdlib>
 #include <random>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace fl {
 namespace http {
+
+std::string CaBundleFile() {
+  const char* cert_file = std::getenv("SSL_CERT_FILE");
+  if (cert_file != nullptr && cert_file[0] != '\0') {
+    return cert_file;
+  }
+  return {};
+}
 
 namespace {
 
@@ -48,7 +58,14 @@ HttpRawResult HttpRequestRaw(const Azure::Core::Http::HttpMethod& method,
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
   WinHttpTransport transport;
 #else
-  CurlTransport transport;
+  // The bundled libcurl does not honor the SSL_CERT_FILE environment variable (it was built with a
+  // compiled-in default CA path that does not exist on platforms like Android). Explicitly pass the
+  // CA bundle via CAInfo so the caller-provided trust store is actually used for TLS verification.
+  CurlTransportOptions curl_opts;
+  if (std::string ca_bundle = CaBundleFile(); !ca_bundle.empty()) {
+    curl_opts.CAInfo = std::move(ca_bundle);
+  }
+  CurlTransport transport(curl_opts);
 #endif
 
   // Build the request. For methods with a body (POST), attach a MemoryBodyStream.

--- a/sdk_v2/cpp/src/http/http_client.cc
+++ b/sdk_v2/cpp/src/http/http_client.cc
@@ -33,9 +33,9 @@
 namespace fl {
 namespace http {
 
-std::string CaBundleFile() {
+const std::string& CaBundleFile() {
   // SSL_CERT_FILE is fixed for the process lifetime (callers set it before loading the library), so
-  // read it once and reuse the cached path for every request.
+  // read it once and return a reference to the cached path for every request.
   static const std::string ca_bundle = [] {
     auto cert_file = Utils::GetEnv("SSL_CERT_FILE");
     return (cert_file && !cert_file->empty()) ? std::move(*cert_file) : std::string();

--- a/sdk_v2/cpp/src/http/http_client.cc
+++ b/sdk_v2/cpp/src/http/http_client.cc
@@ -65,8 +65,9 @@ HttpRawResult HttpRequestRaw(const Azure::Core::Http::HttpMethod& method,
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
   WinHttpTransport transport;
 #else
-  // libcurl does not honor SSL_CERT_FILE (its compiled-in default CA path is absent on Android), so
-  // pass the CA bundle explicitly via CAInfo (see http/curl_transport.h).
+  // On Android, libcurl has no valid default CA path, so MakeCurlTransportOptions() supplies the CA
+  // bundle via CAInfo; on other curl platforms it returns empty options and libcurl uses the system
+  // default trust store (see http/curl_transport.h).
   CurlTransport transport(MakeCurlTransportOptions());
 #endif
 

--- a/sdk_v2/cpp/src/http/http_client.cc
+++ b/sdk_v2/cpp/src/http/http_client.cc
@@ -34,11 +34,15 @@ namespace fl {
 namespace http {
 
 const std::string& CABundleFilePath() {
-  // SSL_CERT_FILE is fixed for the process lifetime (callers set it before loading the library), so
-  // read it once and return a reference to the cached path for every request.
   static const std::string ca_bundle = [] {
+#if defined(ANDROID)
+    // Gated to Android: it is the only platform where the bundled libcurl has no default CA store
+    // and where we own the process environment (the Android host sets SSL_CERT_FILE itself).
     auto cert_file = Utils::GetEnv("SSL_CERT_FILE");
     return (cert_file && !cert_file->empty()) ? std::move(*cert_file) : std::string();
+#else
+    return std::string();
+#endif
   }();
   return ca_bundle;
 }

--- a/sdk_v2/cpp/src/http/http_client.cc
+++ b/sdk_v2/cpp/src/http/http_client.cc
@@ -33,7 +33,7 @@
 namespace fl {
 namespace http {
 
-const std::string& CaBundleFile() {
+const std::string& CABundleFilePath() {
   // SSL_CERT_FILE is fixed for the process lifetime (callers set it before loading the library), so
   // read it once and return a reference to the cached path for every request.
   static const std::string ca_bundle = [] {
@@ -62,9 +62,8 @@ HttpRawResult HttpRequestRaw(const Azure::Core::Http::HttpMethod& method,
   WinHttpTransport transport;
 #else
   // libcurl does not honor SSL_CERT_FILE (its compiled-in default CA path is absent on Android), so
-  // we pass the CA bundle explicitly via CAInfo. The options are cached and shared (see
-  // http/curl_transport.h) and copied into the per-request transport.
-  CurlTransport transport(CachedCurlTransportOptions());
+  // pass the CA bundle explicitly via CAInfo (see http/curl_transport.h).
+  CurlTransport transport(MakeCurlTransportOptions());
 #endif
 
   // Build the request. For methods with a body (POST), attach a MemoryBodyStream.

--- a/sdk_v2/cpp/src/http/http_client.h
+++ b/sdk_v2/cpp/src/http/http_client.h
@@ -34,7 +34,7 @@ struct HttpRequestOptions {
 /// does not exist on platforms like Android), so every libcurl-based transport we construct — direct
 /// requests, file downloads, and the Azure Storage blob client — must pass this explicitly as
 /// `CAInfo`. On desktop Windows the WinHTTP transport uses the OS trust store and ignores this.
-const std::string& CaBundleFile();
+const std::string& CABundleFilePath();
 
 /// Perform an HTTP POST and return status, headers, and body without throwing on non-2xx responses.
 /// Transport failures are returned as `status == 0` with the error message in `body`.

--- a/sdk_v2/cpp/src/http/http_client.h
+++ b/sdk_v2/cpp/src/http/http_client.h
@@ -27,13 +27,10 @@ struct HttpRequestOptions {
   bool close_connection = false;
 };
 
-/// Returns the CA bundle file path from the `SSL_CERT_FILE` environment variable, or an empty
-/// string when it is unset/empty. The value is read once and cached for the process lifetime, so a
-/// reference to the cached string is returned (valid until process exit). The bundled libcurl does
-/// not consult `SSL_CERT_FILE` automatically (it was built with a compiled-in default CA path that
-/// does not exist on platforms like Android), so every libcurl-based transport we construct — direct
-/// requests, file downloads, and the Azure Storage blob client — must pass this explicitly as
-/// `CAInfo`. On desktop Windows the WinHTTP transport uses the OS trust store and ignores this.
+/// Returns the CA bundle path from `SSL_CERT_FILE` (read once, cached for the process lifetime), or
+/// empty when unset. The bundled libcurl does not consult `SSL_CERT_FILE` itself, so libcurl-based
+/// transports must pass this explicitly as `CAInfo`. Gated to Android; empty everywhere else, where
+/// the system default CA store (or WinHTTP on Windows) is used instead.
 const std::string& CABundleFilePath();
 
 /// Perform an HTTP POST and return status, headers, and body without throwing on non-2xx responses.

--- a/sdk_v2/cpp/src/http/http_client.h
+++ b/sdk_v2/cpp/src/http/http_client.h
@@ -27,6 +27,14 @@ struct HttpRequestOptions {
   bool close_connection = false;
 };
 
+/// Returns the CA bundle file path from the `SSL_CERT_FILE` environment variable, or an empty
+/// string when it is unset/empty. The bundled libcurl does not consult `SSL_CERT_FILE`
+/// automatically (it was built with a compiled-in default CA path that does not exist on platforms
+/// like Android), so every libcurl-based transport we construct — direct requests, file downloads,
+/// and the Azure Storage blob client — must pass this explicitly as `CAInfo`. On desktop Windows the
+/// WinHTTP transport uses the OS trust store and ignores this.
+std::string CaBundleFile();
+
 /// Perform an HTTP POST and return status, headers, and body without throwing on non-2xx responses.
 /// Transport failures are returned as `status == 0` with the error message in `body`.
 HttpResponse HttpPostWithResponse(const std::string& url,

--- a/sdk_v2/cpp/src/http/http_client.h
+++ b/sdk_v2/cpp/src/http/http_client.h
@@ -28,12 +28,13 @@ struct HttpRequestOptions {
 };
 
 /// Returns the CA bundle file path from the `SSL_CERT_FILE` environment variable, or an empty
-/// string when it is unset/empty. The bundled libcurl does not consult `SSL_CERT_FILE`
-/// automatically (it was built with a compiled-in default CA path that does not exist on platforms
-/// like Android), so every libcurl-based transport we construct — direct requests, file downloads,
-/// and the Azure Storage blob client — must pass this explicitly as `CAInfo`. On desktop Windows the
-/// WinHTTP transport uses the OS trust store and ignores this.
-std::string CaBundleFile();
+/// string when it is unset/empty. The value is read once and cached for the process lifetime, so a
+/// reference to the cached string is returned (valid until process exit). The bundled libcurl does
+/// not consult `SSL_CERT_FILE` automatically (it was built with a compiled-in default CA path that
+/// does not exist on platforms like Android), so every libcurl-based transport we construct — direct
+/// requests, file downloads, and the Azure Storage blob client — must pass this explicitly as
+/// `CAInfo`. On desktop Windows the WinHTTP transport uses the OS trust store and ignores this.
+const std::string& CaBundleFile();
 
 /// Perform an HTTP POST and return status, headers, and body without throwing on non-2xx responses.
 /// Transport failures are returned as `status == 0` with the error message in `body`.

--- a/sdk_v2/cpp/src/http/http_download.cc
+++ b/sdk_v2/cpp/src/http/http_download.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #include "http/http_download.h"
 
+#include "http/http_client.h"
 #include "logger.h"
 #include "util/string_utils.h"
 
@@ -18,9 +19,11 @@
 #endif
 
 #include <charconv>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <system_error>
+#include <utility>
 
 namespace fl {
 
@@ -74,7 +77,14 @@ bool HttpDownloadFile(const std::string& url, const std::filesystem::path& desti
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
   WinHttpTransport transport;
 #else
-  CurlTransport transport;
+  // The bundled libcurl does not honor the SSL_CERT_FILE environment variable (it was built with a
+  // compiled-in default CA path that does not exist on platforms like Android). Explicitly pass the
+  // CA bundle via CAInfo so the caller-provided trust store is actually used for TLS verification.
+  CurlTransportOptions curl_opts;
+  if (std::string ca_bundle = http::CaBundleFile(); !ca_bundle.empty()) {
+    curl_opts.CAInfo = std::move(ca_bundle);
+  }
+  CurlTransport transport(curl_opts);
 #endif
   Request request(HttpMethod::Get, Url(url));
   request.SetHeader("User-Agent", user_agent);

--- a/sdk_v2/cpp/src/http/http_download.cc
+++ b/sdk_v2/cpp/src/http/http_download.cc
@@ -21,11 +21,9 @@
 #endif
 
 #include <charconv>
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <system_error>
-#include <utility>
 
 namespace fl {
 

--- a/sdk_v2/cpp/src/http/http_download.cc
+++ b/sdk_v2/cpp/src/http/http_download.cc
@@ -15,6 +15,8 @@
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
 #include <azure/core/http/win_http_transport.hpp>
 #else
+#include "http/curl_transport.h"
+
 #include <azure/core/http/curl_transport.hpp>
 #endif
 
@@ -77,14 +79,9 @@ bool HttpDownloadFile(const std::string& url, const std::filesystem::path& desti
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
   WinHttpTransport transport;
 #else
-  // The bundled libcurl does not honor the SSL_CERT_FILE environment variable (it was built with a
-  // compiled-in default CA path that does not exist on platforms like Android). Explicitly pass the
-  // CA bundle via CAInfo so the caller-provided trust store is actually used for TLS verification.
-  CurlTransportOptions curl_opts;
-  if (std::string ca_bundle = http::CaBundleFile(); !ca_bundle.empty()) {
-    curl_opts.CAInfo = std::move(ca_bundle);
-  }
-  CurlTransport transport(curl_opts);
+  // libcurl does not honor SSL_CERT_FILE (its compiled-in default CA path is absent on Android), so
+  // pass the shared CA bundle explicitly via CAInfo (see http/curl_transport.h).
+  CurlTransport transport(http::CachedCurlTransportOptions());
 #endif
   Request request(HttpMethod::Get, Url(url));
   request.SetHeader("User-Agent", user_agent);

--- a/sdk_v2/cpp/src/http/http_download.cc
+++ b/sdk_v2/cpp/src/http/http_download.cc
@@ -80,8 +80,8 @@ bool HttpDownloadFile(const std::string& url, const std::filesystem::path& desti
   WinHttpTransport transport;
 #else
   // libcurl does not honor SSL_CERT_FILE (its compiled-in default CA path is absent on Android), so
-  // pass the shared CA bundle explicitly via CAInfo (see http/curl_transport.h).
-  CurlTransport transport(http::CachedCurlTransportOptions());
+  // pass the CA bundle explicitly via CAInfo (see http/curl_transport.h).
+  CurlTransport transport(http::MakeCurlTransportOptions());
 #endif
   Request request(HttpMethod::Get, Url(url));
   request.SetHeader("User-Agent", user_agent);

--- a/sdk_v2/cpp/src/http/http_download.cc
+++ b/sdk_v2/cpp/src/http/http_download.cc
@@ -77,8 +77,9 @@ bool HttpDownloadFile(const std::string& url, const std::filesystem::path& desti
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
   WinHttpTransport transport;
 #else
-  // libcurl does not honor SSL_CERT_FILE (its compiled-in default CA path is absent on Android), so
-  // pass the CA bundle explicitly via CAInfo (see http/curl_transport.h).
+  // On Android, libcurl has no valid default CA path, so MakeCurlTransportOptions() supplies the CA
+  // bundle via CAInfo; on other curl platforms it returns empty options and libcurl uses the system
+  // default trust store (see http/curl_transport.h).
   CurlTransport transport(http::MakeCurlTransportOptions());
 #endif
   Request request(HttpMethod::Get, Url(url));

--- a/sdk_v2/cpp/test/CMakeLists.txt
+++ b/sdk_v2/cpp/test/CMakeLists.txt
@@ -185,6 +185,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_link_options(sdk_integration_tests PRIVATE -Wl,--disable-new-dtags)
 endif()
 
+# On Android the ORT/GenAI prebuilts statically link libc++ but export its symbols WEAK.
+# Without this, the executable's own static libc++ symbols (e.g. std::locale::use_facet) are
+# exported GLOBAL and interpose the prebuilts' weak copies.
+if(ANDROID)
+    target_link_options(sdk_integration_tests PRIVATE -Wl,--exclude-libs,ALL)
+endif()
+
 add_custom_command(TARGET sdk_integration_tests POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
             ${CMAKE_CURRENT_SOURCE_DIR}/testdata

--- a/sdk_v2/cpp/tools/android.py
+++ b/sdk_v2/cpp/tools/android.py
@@ -346,38 +346,40 @@ def stop_emulator(emulator_proc: subprocess.Popen) -> None:
 
 def run_tests_on_device(
     sdk_tool_paths: SdkToolPaths,
-    test_binary: Path,
+    test_binaries: list[Path],
     shared_libs: list[Path],
     device_dir: str = "/data/local/tmp/foundry_tests",
     test_data_dir: Path | None = None,
     model_cache_dir: Path | None = None,
 ) -> int:
-    """Push a native test binary and its shared library dependencies to the device and run it.
+    """Push native test binaries and their shared library dependencies to the device and run them.
 
     Args:
         sdk_tool_paths: Resolved SDK tool paths.
-        test_binary: Path to the host test executable (e.g. foundry_local_tests).
-        shared_libs: Shared libraries (.so) to push alongside the binary.
+        test_binaries: Host test executables to push and run (e.g. foundry_local_tests,
+            sdk_integration_tests).
+        shared_libs: Shared libraries (.so) to push alongside the binaries.
         device_dir: Target directory on the device.
         test_data_dir: Optional host directory with test data to push.
         model_cache_dir: Optional host directory with test models (e.g. test-data-shared).
             Only subdirectories with "cpu" in their name are pushed (the emulator has no GPU).
 
     Returns:
-        The test process exit code.
+        The first non-zero test exit code, or 0 if every binary passed.
     """
     adb = sdk_tool_paths.adb
 
     # Create target directory on device
     subprocess.run([adb, "shell", "mkdir", "-p", device_dir], check=True)
 
-    # Push the test binary
-    log.info("Pushing test binary: %s", test_binary.name)
-    subprocess.run([adb, "push", str(test_binary), f"{device_dir}/"], check=True)
-    subprocess.run(
-        [adb, "shell", "chmod", "755", f"{device_dir}/{test_binary.name}"],
-        check=True,
-    )
+    # Push the test binaries
+    for test_binary in test_binaries:
+        log.info("Pushing test binary: %s", test_binary.name)
+        subprocess.run([adb, "push", str(test_binary), f"{device_dir}/"], check=True)
+        subprocess.run(
+            [adb, "shell", "chmod", "755", f"{device_dir}/{test_binary.name}"],
+            check=True,
+        )
 
     # Push shared libraries
     for lib in shared_libs:
@@ -411,8 +413,8 @@ def run_tests_on_device(
                 check=True,
             )
 
-    # Build environment variables for the test process.
-    env_vars = f"LD_LIBRARY_PATH={device_dir}"
+    # Build environment variables for the test process. HOME must point at a writable location
+    env_vars = f"HOME={device_dir} LD_LIBRARY_PATH={device_dir}"
     if pushed_models:
         env_vars += f" FOUNDRY_TEST_DATA_DIR={device_model_cache}"
 
@@ -444,17 +446,13 @@ def run_tests_on_device(
     # Clear logcat before running tests so we only capture relevant output.
     subprocess.run([adb, "logcat", "-c"], check=False)
 
-    # Run the test binary
-    cmd = (
-        f"cd {device_dir} && "
-        f"{env_vars} "
-        f"./{test_binary.name} --gtest_color=yes"
-    )
-    log.info("Running tests on device: %s", cmd)
-    result = subprocess.run(
-        [adb, "shell", cmd],
-        # adb shell returns the exit code of the remote command
-    )
+    # Run each test binary in turn, run them all and fail the run if any binary fails.
+    returncode = 0
+    for test_binary in test_binaries:
+        cmd = f"cd {device_dir} && {env_vars} ./{test_binary.name} --gtest_color=yes"
+        log.info("Running tests on device: %s", cmd)
+        result = subprocess.run([adb, "shell", cmd])
+        returncode = returncode or result.returncode
 
     # Capture logcat output from the SDK (tag: foundry_local) and any crash/abort diagnostics.
     log.info("Capturing logcat output...")
@@ -468,4 +466,4 @@ def run_tests_on_device(
     else:
         log.info("No logcat output from foundry_local tag.")
 
-    return result.returncode
+    return returncode


### PR DESCRIPTION
## Problem

TLS verification on Android failed for every HTTPS request to Azure, with two different misleading errors:

- `self-signed certificate in certificate chain` — catalog requests
- `unable to get local issuer certificate` — blob downloads

Both have the same root cause: **the trust store was empty**, because neither of the two mechanisms that should have supplied it works in this build.

1. **The compiled-in default is wrong.** OpenSSL's `--openssldir` is baked in at build time as a string constant. vcpkg cross-compiles for Android on the host, so the baked path does not exist on a device (Android's store lives at `/system/etc/security/cacerts/` as hash-named `.0` files).

2. **`SSL_CERT_FILE` never gets read.** It is an OpenSSL-level fallback consulted only by `SSL_CTX_set_default_verify_paths()` — the "no explicit CA configured" path. libcurl *always* configures an explicit CA (its own build-time default, via `SSL_CTX_load_verify_locations()`), so that fallback never runs and the environment variable is silently ignored.

The `self-signed certificate in certificate chain` wording is a red herring: with an empty store the chain walks up to a root, and every root *is* self-signed — with nothing to validate it against, that is exactly what OpenSSL reports.

Isolated on-device: passing the device's own trust store via `SSL_CERT_FILE` failed, while the **same bundle** passed explicitly as a CA file (`openssl s_client -CAfile`, equivalent to `CURLOPT_CAINFO`) verified `ai.azure.com` with `Verify return code: 0 (ok)`. Same bytes, same device, same endpoint — only the delivery mechanism differed.

## Fix

Keep the familiar `SSL_CERT_FILE` interface, but stop relying on OpenSSL to read it. A shared `http::CaBundleFile()` helper reads the variable, and each libcurl transport receives it explicitly as `CurlTransportOptions.CAInfo` (`CURLOPT_CAINFO`), which libcurl always honors.


The third is the non-obvious one: **the Azure Storage SDK builds its own libcurl transport internally** rather than reusing ours, so fixing the first two left blob downloads still failing — with the different `unable to get local issuer certificate` message. `MakeBlobClientOptions()` injects a preconfigured `CurlTransport` into `options.Transport.Transport`.

Every site is guarded by `#if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)`, so **desktop Windows is unaffected** — it uses WinHTTP and the OS trust store.

Callers still set `SSL_CERT_FILE` exactly as before; its effect now comes from the Core forwarding it to `CAInfo`, not from OpenSSL auto-reading the environment.


## Validation

- Verified on-device: catalog browse + model download over HTTPS to Azure now succeed.