### PR TITLE
www: derive model family filter dynamically from catalog

### DIFF
--- a/www/src/lib/utils/model-helpers.ts
+++ b/www/src/lib/utils/model-helpers.ts
@@ -1,111 +1,170 @@
 // Device icon mapping
 const DEVICE_ICONS: Record<string, string> = {
-    npu: '🧠',
-    gpu: '🎮',
-    cpu: '💻'
+	npu: '🧠',
+	gpu: '🎮',
+	cpu: '💻'
 };
 
 export function getDeviceIcon(device: string): string {
-    return DEVICE_ICONS[device.toLowerCase()] || '🔧';
+	return DEVICE_ICONS[device.toLowerCase()] || '🔧';
 }
 
 // Accelerator logo patterns and paths
 const ACCELERATOR_LOGO_PATTERNS: Array<{ patterns: string[]; logo: string }> = [
-    { patterns: ['-cuda-', '-cuda', '-tensorrt-', '-tensorrt', '-trt-rtx-', '-trt-rtx', '-trtrtx'], logo: '/logos/nvidia-logo.svg' },
-    { patterns: ['-qnn-', '-qnn'], logo: '/logos/qualcomm-logo.svg' },
-    { patterns: ['-vitis-', '-vitis', '-vitisai'], logo: '/logos/amd-logo.svg' },
-    { patterns: ['-openvino-', '-openvino'], logo: '/logos/intel-logo.svg' },
-    { patterns: ['-webgpu-', '-webgpu', 'webgpu', '-generic-gpu'], logo: '/logos/webgpu-logo.svg' }
+	{
+		patterns: ['-cuda-', '-cuda', '-tensorrt-', '-tensorrt', '-trt-rtx-', '-trt-rtx', '-trtrtx'],
+		logo: '/logos/nvidia-logo.svg'
+	},
+	{ patterns: ['-qnn-', '-qnn'], logo: '/logos/qualcomm-logo.svg' },
+	{ patterns: ['-vitis-', '-vitis', '-vitisai'], logo: '/logos/amd-logo.svg' },
+	{ patterns: ['-openvino-', '-openvino'], logo: '/logos/intel-logo.svg' },
+	{ patterns: ['-webgpu-', '-webgpu', 'webgpu', '-generic-gpu'], logo: '/logos/webgpu-logo.svg' }
 ];
 
 export function getAcceleratorLogo(variantName: string): string | null {
-    const name = variantName.toLowerCase();
-    for (const { patterns, logo } of ACCELERATOR_LOGO_PATTERNS) {
-        if (patterns.some(pattern => name.includes(pattern))) {
-            return logo;
-        }
-    }
-    return null;
+	const name = variantName.toLowerCase();
+	for (const { patterns, logo } of ACCELERATOR_LOGO_PATTERNS) {
+		if (patterns.some((pattern) => name.includes(pattern))) {
+			return logo;
+		}
+	}
+	return null;
+}
+
+// Family detection.
+// Priority-ordered keyword list: brand/product families come before base
+// architectures so that derivative aliases (e.g. `llama-3.1-nemotron-*`) are
+// bucketed by brand rather than by base model. `ministral` must precede
+// `mistral` for the same reason.
+const FAMILY_KEYWORDS: string[] = [
+	// brand / product families first
+	'nemotron',
+	'gpt-oss',
+	'deepseek',
+	// base architectures / product families
+	'ministral',
+	'mistral',
+	'phi',
+	'qwen',
+	'llama',
+	'gemma',
+	// speech / audio
+	'whisper',
+	'parakeet',
+	// other open families
+	'smollm',
+	'olmo'
+];
+
+// Display-name overrides for families whose canonical casing isn't just
+// capitalize-the-first-letter (e.g. `gpt-oss` -> `GPT-OSS`).
+const FAMILY_DISPLAY_NAMES: Record<string, string> = {
+	'gpt-oss': 'GPT-OSS',
+	smollm: 'SmolLM',
+	olmo: 'OLMo'
+};
+
+// Detect the family for a model given its alias (or fall back to name).
+// Returns the matching keyword from FAMILY_KEYWORDS, or undefined if no
+// known family keyword appears as a token in the identifier.
+export function detectModelFamily(identifier: string | null | undefined): string | undefined {
+	if (!identifier) return undefined;
+	const s = identifier.toLowerCase();
+	for (const k of FAMILY_KEYWORDS) {
+		// Token-boundary match: keyword must start the string or follow a
+		// separator, and must be followed by a separator or end-of-string.
+		const re = new RegExp(`(^|[-_/])${k.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}([-_/.]|$)`);
+		if (re.test(s)) return k;
+	}
+	return undefined;
+}
+
+export function getFamilyDisplayName(family: string): string {
+	return FAMILY_DISPLAY_NAMES[family] ?? family.charAt(0).toUpperCase() + family.slice(1);
 }
 
 // Accelerator color patterns
 const ACCELERATOR_COLOR_PATTERNS: Array<{ patterns: string[]; color: string }> = [
-    { patterns: ['-cuda-', '-cuda', '-tensorrt-', '-tensorrt', '-trt-rtx-', '-trt-rtx', '-trtrtx'], color: '#76B900' },
-    { patterns: ['-qnn-', '-qnn'], color: '#3253DC' },
-    { patterns: ['-vitis-', '-vitis', '-vitisai'], color: 'var(--amd-color, #000000)' },
-    { patterns: ['-openvino-', '-openvino'], color: '#0071C5' },
-    { patterns: ['-webgpu-', '-webgpu', 'webgpu', '-generic-gpu'], color: '#005A9C' }
+	{
+		patterns: ['-cuda-', '-cuda', '-tensorrt-', '-tensorrt', '-trt-rtx-', '-trt-rtx', '-trtrtx'],
+		color: '#76B900'
+	},
+	{ patterns: ['-qnn-', '-qnn'], color: '#3253DC' },
+	{ patterns: ['-vitis-', '-vitis', '-vitisai'], color: 'var(--amd-color, #000000)' },
+	{ patterns: ['-openvino-', '-openvino'], color: '#0071C5' },
+	{ patterns: ['-webgpu-', '-webgpu', 'webgpu', '-generic-gpu'], color: '#005A9C' }
 ];
 
 export function getAcceleratorColor(variantName: string): string {
-    const name = variantName.toLowerCase();
-    for (const { patterns, color } of ACCELERATOR_COLOR_PATTERNS) {
-        if (patterns.some(pattern => name.includes(pattern))) {
-            return color;
-        }
-    }
-    return 'currentColor';
+	const name = variantName.toLowerCase();
+	for (const { patterns, color } of ACCELERATOR_COLOR_PATTERNS) {
+		if (patterns.some((pattern) => name.includes(pattern))) {
+			return color;
+		}
+	}
+	return 'currentColor';
 }
 
 // Variant label patterns - ordered by specificity (most specific first)
-const VARIANT_LABEL_PATTERNS: Array<{ patterns: string[]; label: string; requiresAll?: boolean }> = [
-    { patterns: ['-cuda-', '-trt-rtx-'], label: 'CUDA + TensorRT', requiresAll: true },
-    { patterns: ['-cuda-', '-tensorrt-'], label: 'CUDA + TensorRT', requiresAll: true },
-    { patterns: ['-cuda-', '-trtrtx'], label: 'CUDA + TensorRT', requiresAll: true },
-    { patterns: ['-cuda-gpu', '-cuda-'], label: 'CUDA' },
-    { patterns: ['-generic-gpu', 'webgpu'], label: 'WebGPU' },
-    { patterns: ['-qnn-'], label: 'QNN' },
-    { patterns: ['-vitis-'], label: 'Vitis' },
-    { patterns: ['-openvino-'], label: 'OpenVINO' },
-    { patterns: ['-trt-rtx-', '-tensorrt-', '-trtrtx-', '-trtrtx'], label: 'TensorRT' },
-    { patterns: ['-generic-cpu'], label: 'Generic' }
-];
+const VARIANT_LABEL_PATTERNS: Array<{ patterns: string[]; label: string; requiresAll?: boolean }> =
+	[
+		{ patterns: ['-cuda-', '-trt-rtx-'], label: 'CUDA + TensorRT', requiresAll: true },
+		{ patterns: ['-cuda-', '-tensorrt-'], label: 'CUDA + TensorRT', requiresAll: true },
+		{ patterns: ['-cuda-', '-trtrtx'], label: 'CUDA + TensorRT', requiresAll: true },
+		{ patterns: ['-cuda-gpu', '-cuda-'], label: 'CUDA' },
+		{ patterns: ['-generic-gpu', 'webgpu'], label: 'WebGPU' },
+		{ patterns: ['-qnn-'], label: 'QNN' },
+		{ patterns: ['-vitis-'], label: 'Vitis' },
+		{ patterns: ['-openvino-'], label: 'OpenVINO' },
+		{ patterns: ['-trt-rtx-', '-tensorrt-', '-trtrtx-', '-trtrtx'], label: 'TensorRT' },
+		{ patterns: ['-generic-cpu'], label: 'Generic' }
+	];
 
 export function getVariantLabel(variant: { name: string; deviceSupport: string[] }): string {
-    const modelName = variant.name.toLowerCase();
-    const device = variant.deviceSupport[0]?.toUpperCase() || '';
+	const modelName = variant.name.toLowerCase();
+	const device = variant.deviceSupport[0]?.toUpperCase() || '';
 
-    for (const { patterns, label, requiresAll } of VARIANT_LABEL_PATTERNS) {
-        if (requiresAll) {
-            if (patterns.every(pattern => modelName.includes(pattern))) {
-                return `${device} (${label})`;
-            }
-        } else {
-            if (patterns.some(pattern => modelName.includes(pattern))) {
-                return `${device} (${label})`;
-            }
-        }
-    }
+	for (const { patterns, label, requiresAll } of VARIANT_LABEL_PATTERNS) {
+		if (requiresAll) {
+			if (patterns.every((pattern) => modelName.includes(pattern))) {
+				return `${device} (${label})`;
+			}
+		} else {
+			if (patterns.some((pattern) => modelName.includes(pattern))) {
+				return `${device} (${label})`;
+			}
+		}
+	}
 
-    return device;
+	return device;
 }
 
 // Acceleration to logo mapping
 const ACCELERATION_LOGOS: Record<string, string> = {
-    cuda: '/logos/nvidia-logo.svg',
-    'trt-rtx': '/logos/nvidia-logo.svg',
-    trtrtx: '/logos/nvidia-logo.svg',
-    qnn: '/logos/qualcomm-logo.svg',
-    vitis: '/logos/amd-logo.svg',
-    openvino: '/logos/intel-logo.svg',
-    webgpu: '/logos/webgpu-logo.svg'
+	cuda: '/logos/nvidia-logo.svg',
+	'trt-rtx': '/logos/nvidia-logo.svg',
+	trtrtx: '/logos/nvidia-logo.svg',
+	qnn: '/logos/qualcomm-logo.svg',
+	vitis: '/logos/amd-logo.svg',
+	openvino: '/logos/intel-logo.svg',
+	webgpu: '/logos/webgpu-logo.svg'
 };
 
 export function getAcceleratorLogoFromAcceleration(acceleration: string): string | null {
-    return ACCELERATION_LOGOS[acceleration.toLowerCase()] || null;
+	return ACCELERATION_LOGOS[acceleration.toLowerCase()] || null;
 }
 
 // Acceleration to color mapping
 const ACCELERATION_COLORS: Record<string, string> = {
-    cuda: '#76B900',
-    'trt-rtx': '#76B900',
-    trtrtx: '#76B900',
-    qnn: '#3253DC',
-    vitis: 'var(--amd-color, #000000)',
-    openvino: '#0071C5',
-    webgpu: '#005A9C'
+	cuda: '#76B900',
+	'trt-rtx': '#76B900',
+	trtrtx: '#76B900',
+	qnn: '#3253DC',
+	vitis: 'var(--amd-color, #000000)',
+	openvino: '#0071C5',
+	webgpu: '#005A9C'
 };
 
 export function getAcceleratorColorFromAcceleration(acceleration: string): string {
-    return ACCELERATION_COLORS[acceleration.toLowerCase()] || 'currentColor';
+	return ACCELERATION_COLORS[acceleration.toLowerCase()] || 'currentColor';
 }

--- a/www/src/lib/utils/model-helpers.ts
+++ b/www/src/lib/utils/model-helpers.ts
@@ -71,9 +71,14 @@ export function detectModelFamily(identifier: string | null | undefined): string
 	if (!identifier) return undefined;
 	const s = identifier.toLowerCase();
 	for (const k of FAMILY_KEYWORDS) {
-		// Token-boundary match: keyword must start the string or follow a
-		// separator, and must be followed by a separator or end-of-string.
-		const re = new RegExp(`(^|[-_/])${k.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}([-_/.]|$)`);
+		// Token-boundary match: the keyword must start the string or follow a
+		// separator, and must NOT be followed by a letter. A trailing digit
+		// is treated as a version boundary so `qwen3`, `qwen2.5`, `smollm3`
+		// all match. Trailing `-`, `.`, `_`, `/`, or end-of-string also
+		// count as a boundary. This blocks false positives like `phillm`
+		// matching `phi`.
+		const escaped = k.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+		const re = new RegExp(`(^|[-_/])${escaped}(?![a-z])`);
 		if (re.test(s)) return k;
 	}
 	return undefined;

--- a/www/src/routes/models/+page.svelte
+++ b/www/src/routes/models/+page.svelte
@@ -13,6 +13,7 @@
 	import { toast } from 'svelte-sonner';
 	import { ModelFilters, ModelGrid, ModelDetailsModal } from './components';
 	import { Terminal, Copy, Check, ExternalLink } from 'lucide-svelte';
+	import { detectModelFamily } from '$lib/utils/model-helpers';
 
 	// Known device names used as shorthand URL params (e.g. /models?cpu)
 	const KNOWN_DEVICES = ['cpu', 'gpu', 'npu'];
@@ -72,7 +73,7 @@
 
 	// Available filter options
 	let availableDevices: string[] = [];
-	let availableFamilies: string[] = ['deepseek', 'mistral', 'qwen', 'phi', 'whisper'];
+	let availableFamilies: string[] = [];
 	let availableAccelerations: string[] = [];
 
 	// Read filter state from URL search params
@@ -259,6 +260,14 @@
 	function updateFilterOptions() {
 		availableDevices = [...new Set(allModels.flatMap((m) => m.deviceSupport))].sort();
 
+		availableFamilies = [
+			...new Set(
+				allModels
+					.map((m) => detectModelFamily(m.alias ?? m.displayName))
+					.filter((f): f is string => Boolean(f))
+			)
+		].sort();
+
 		const accelerations = new Set<string>();
 		allModels.forEach((model) => {
 			if (model.acceleration) {
@@ -325,9 +334,7 @@
 				selectedDevices.length === 0 ||
 				selectedDevices.some((device) => model.deviceSupport.includes(device));
 			const matchesFamily =
-				!selectedFamily ||
-				model.displayName.toLowerCase().includes(selectedFamily.toLowerCase()) ||
-				model.alias.toLowerCase().includes(selectedFamily.toLowerCase());
+				!selectedFamily || detectModelFamily(model.alias ?? model.displayName) === selectedFamily;
 			const matchesAcceleration =
 				!selectedAcceleration ||
 				model.acceleration === selectedAcceleration ||

--- a/www/src/routes/models/components/ModelFilters.svelte
+++ b/www/src/routes/models/components/ModelFilters.svelte
@@ -9,7 +9,8 @@
 	import {
 		getDeviceIcon,
 		getAcceleratorLogoFromAcceleration,
-		getAcceleratorColorFromAcceleration
+		getAcceleratorColorFromAcceleration,
+		getFamilyDisplayName
 	} from '$lib/utils/model-helpers';
 
 	export let searchTerm = '';
@@ -47,7 +48,13 @@
 			<Card.Description>Results update automatically as you type or change filters</Card.Description
 			>
 		</div>
-		<Button variant="ghost" size="sm" onclick={onRefresh} disabled={loading} aria-label="Refresh models">
+		<Button
+			variant="ghost"
+			size="sm"
+			onclick={onRefresh}
+			disabled={loading}
+			aria-label="Refresh models"
+		>
 			<RefreshCw class={`mr-1 size-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />
 			Refresh
 		</Button>
@@ -58,7 +65,10 @@
 			<div class="lg:col-span-2">
 				<Label for="search">Search Models</Label>
 				<div class="relative">
-					<Search class="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-gray-400" aria-hidden="true" />
+					<Search
+						class="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-gray-400"
+						aria-hidden="true"
+					/>
 					<Input
 						id="search"
 						type="text"
@@ -153,9 +163,7 @@
 						{#snippet child({ props })}
 							<Button {...props} variant="outline" class="h-10 w-full justify-between font-normal">
 								<span>
-									{selectedFamily
-										? selectedFamily.charAt(0).toUpperCase() + selectedFamily.slice(1)
-										: 'All Families'}
+									{selectedFamily ? getFamilyDisplayName(selectedFamily) : 'All Families'}
 								</span>
 								<ChevronDown class="ml-2 size-4 opacity-50" />
 							</Button>
@@ -175,7 +183,7 @@
 								<Check
 									class="mr-2 size-4 {selectedFamily === family ? 'opacity-100' : 'opacity-0'}"
 								/>
-								{family.charAt(0).toUpperCase() + family.slice(1)}
+								{getFamilyDisplayName(family)}
 							</DropdownMenu.Item>
 						{/each}
 					</DropdownMenu.Content>
@@ -234,7 +242,7 @@
 		</div>
 
 		<!-- Filter Summary -->
-		<div class="mt-4 flex items-center justify-between border-t border-border/40 pt-4">
+		<div class="border-border/40 mt-4 flex items-center justify-between border-t pt-4">
 			<div class="text-sm text-gray-600 dark:text-gray-400">
 				{#if isFiltering}
 					<span class="inline-flex items-center">


### PR DESCRIPTION
## Summary

Fixes the model-family filter on the `/models` page so it (a) surfaces every family present in the catalog rather than a hardcoded 5, and (b) matches exactly by family instead of substring-in-name.

## Problem

Today `+page.svelte` hardcodes:

```ts
let availableFamilies: string[] = ['deepseek', 'mistral', 'qwen', 'phi', 'whisper'];
```

and filters via `model.displayName.toLowerCase().includes(selectedFamily)`. Two issues:

1. **Coverage gap.** Running the current catalog through the proxy returns 48 unique aliases across 11 families. The 5-item list misses 8 aliases in 6 families: `gpt-oss`, `nemotron` (×3 ASR variants), `ministral`, `olmo`, `parakeet`, `smollm`.
2. **False positives.** Substring match means selecting **Qwen** also sweeps in `deepseek-r1-distill-qwen-*`; selecting **Mistral** would sweep in `ministral-*` (and any future `mistral-nemotron`).

## Fix

- `model-helpers.ts`: add `detectModelFamily()` and a priority-ordered `FAMILY_KEYWORDS` list. Brand/product families (`nemotron`, `gpt-oss`, `deepseek`) precede base architectures so derivative aliases bucket by brand rather than base model (e.g. a future `llama-3.1-nemotron-nano-8b` → `nemotron`, not `llama`). `ministral` precedes `mistral` for the same reason. Matching is a token-boundary regex, not a substring.
- `model-helpers.ts`: add `getFamilyDisplayName()` with casing overrides — `GPT-OSS`, `SmolLM`, `OLMo`.
- `+page.svelte`: compute `availableFamilies` dynamically from `allModels` in `updateFilterOptions()`.
- `+page.svelte`: replace the substring predicate with `detectModelFamily(...) === selectedFamily`.
- `ModelFilters.svelte`: render family labels via `getFamilyDisplayName`.

## Result vs current catalog

Before: 5 families, ~83% alias coverage, false positives on qwen.
After: **11 families, 100% alias coverage, exact match.**

| Family | Count | Aliases |
|---|---:|---|
| Qwen | 23 | qwen2.5-*, qwen2.5-coder-*, qwen3-*, qwen3-embedding-*, qwen3-vl-*, qwen3.5-* |
| Phi | 7 | phi-3-mini-{4k,128k}, phi-3.5-mini, phi-4{,-mini,-mini-reasoning,-reasoning} |
| Whisper | 5 | whisper-{tiny,base,small,medium,large-v3-turbo} |
| Deepseek | 3 | deepseek-r1-{1.5b,7b,14b} |
| Nemotron | 3 | nemotron-3.5-asr-*, nemotron-speech-streaming-{en,es}-* |
| Mistral | 2 | mistral-7b-v0.2, mistral-nemo-12b-instruct |
| GPT-OSS | 1 | gpt-oss-20b |
| Ministral | 1 | ministral-3-3b-instruct-2512 |
| OLMo | 1 | olmo-3-7b-instruct |
| Parakeet | 1 | parakeet-tdt-0.6b-v2 |
| SmolLM | 1 | smollm3-3b |

## Validation

- `prettier --check` on all touched files: clean.
- `svelte-check`: no new errors; the 17 pre-existing errors (all `asChild` / `ClassValue` / footer / ModelCard) are unchanged and unrelated to this change.
- Priority-list ordering verified against tricky aliases:
  - `mistral-nemo-12b-instruct` → `mistral` ✅ (Mistral AI's NeMo collab; brand is Mistral).
  - `ministral-3-3b-instruct-2512` → `ministral` ✅ (would incorrectly go to `mistral` if ordering were wrong).
  - `nemotron-speech-streaming-*` → `nemotron` ✅.
