### PR TITLE
support file-based ASR for nemotron streaming model

### DIFF
--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
@@ -579,7 +579,7 @@ void AudioSession::DecodeNemotronTokens(OgaGenerator& generator, OgaTokenizerStr
                                         int& completion_tokens) const {
   const bool is_streaming = (streaming_callback != nullptr);
 
-  while (!generator.IsDone() && !original_request.canceled) {
+  while (!generator.IsDone() && !generator.IsSessionTerminated() && !original_request.canceled) {
     generator.GenerateNextToken();
     auto next_tokens = generator.GetNextTokens();
     if (next_tokens.empty()) {
@@ -667,8 +667,10 @@ void AudioSession::ProcessNemotronFileTranscription(const AudioTranscriptionRequ
     RunNemotronDecodePass(processor->Process(samples.data() + offset, count), *generator, *tokenizer_stream, text,
                           streaming_callback, response_id, original_request, completion_tokens);
   }
-  RunNemotronDecodePass(processor->Flush(), *generator, *tokenizer_stream, text, streaming_callback, response_id,
-                        original_request, completion_tokens);
+  if (!original_request.canceled) {
+    RunNemotronDecodePass(processor->Flush(), *generator, *tokenizer_stream, text, streaming_callback, response_id,
+                          original_request, completion_tokens);
+  }
 
   response.finish_reason = original_request.canceled ? FOUNDRY_LOCAL_FINISH_NONE : FOUNDRY_LOCAL_FINISH_STOP;
   // Nemotron file-transcription path feeds audio tensors directly and does not expose prompt token accounting.

--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
@@ -19,9 +19,15 @@
 #include "utils.h"
 
 #include <filesystem>
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 #include <ort_genai.h>
+#include <unordered_map>
 
 namespace fl {
 
@@ -71,41 +77,45 @@ std::string JoinTokens(const std::vector<std::string>& token_texts) {
   return out;
 }
 
+const std::unordered_map<std::string, std::string>& NemotronLanguageIdMap() {
+  static const std::unordered_map<std::string, std::string> kMap = {
+      {"en", "0"},       {"en-us", "0"},    {"en-gb", "1"},    {"es-es", "2"},   {"es", "3"},
+      {"es-us", "3"},    {"zh-cn", "4"},    {"hi", "6"},       {"hi-in", "6"},   {"ar", "7"},
+      {"ar-ar", "7"},    {"fr", "8"},       {"fr-fr", "8"},    {"fr-ca", "100"}, {"de", "9"},
+      {"de-de", "9"},    {"ja", "10"},      {"ja-jp", "10"},   {"ru", "11"},     {"ru-ru", "11"},
+      {"pt-br", "12"},   {"pt", "13"},      {"pt-pt", "13"},   {"ko", "14"},     {"ko-kr", "14"},
+      {"it", "15"},      {"it-it", "15"},   {"nl", "16"},      {"nl-nl", "16"},  {"pl", "17"},
+      {"pl-pl", "17"},   {"tr", "18"},      {"tr-tr", "18"},   {"uk", "19"},     {"uk-ua", "19"},
+      {"ro", "20"},      {"ro-ro", "20"},   {"el", "21"},      {"el-gr", "21"},  {"cs", "22"},
+      {"cs-cz", "22"},   {"hu", "23"},      {"hu-hu", "23"},   {"sv", "24"},     {"sv-se", "24"},
+      {"da", "25"},      {"da-dk", "25"},   {"fi", "26"},      {"fi-fi", "26"},  {"sk", "28"},
+      {"sk-sk", "28"},   {"hr", "29"},      {"hr-hr", "29"},   {"bg", "30"},     {"bg-bg", "30"},
+      {"lt", "31"},      {"lt-lt", "31"},   {"th", "32"},      {"th-th", "32"},  {"vi", "33"},
+      {"vi-vn", "33"},   {"et", "60"},      {"et-ee", "60"},   {"lv", "61"},     {"lv-lv", "61"},
+      {"sl", "62"},      {"sl-si", "62"},   {"he", "64"},      {"he-il", "64"},  {"auto", "101"},
+      {"mt", "102"},     {"mt-mt", "102"},  {"nb", "103"},     {"nb-no", "103"}, {"nn", "104"},
+      {"nn-no", "104"},
+  };
+  return kMap;
+}
+
+std::string ToLowerAscii(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return s;
+}
+
+bool IsLanguageToken(const std::string& token) {
+  size_t start = token.find_first_not_of(" \t\r\n");
+  if (start == std::string::npos) {
+    return false;
+  }
+
+  size_t end = token.find_last_not_of(" \t\r\n");
+  return end >= start && token[start] == '<' && token[end] == '>';
+}
+
 }  // namespace
-
-namespace {
-  const std::unordered_map<std::string, std::string> NemotronLangIdMap = {
-      ["en"] = "0", ["en-US"] = "0", ["en-GB"] = "1",
-      ["es-ES"] = "2", ["es"] = "3", ["es-US"] = "3",
-      ["zh-CN"] = "4",
-      ["hi"] = "6", ["hi-IN"] = "6", ["ar"] = "7", ["ar-AR"] = "7",
-      ["fr"] = "8", ["fr-FR"] = "8", ["fr-CA"] = "100",
-      ["de"] = "9", ["de-DE"] = "9",
-      ["ja"] = "10", ["ja-JP"] = "10", ["ru"] = "11", ["ru-RU"] = "11",
-      ["pt-BR"] = "12", ["pt"] = "13", ["pt-PT"] = "13",
-      ["ko"] = "14", ["ko-KR"] = "14", ["it"] = "15", ["it-IT"] = "15",
-      ["nl"] = "16", ["nl-NL"] = "16", ["pl"] = "17", ["pl-PL"] = "17",
-      ["tr"] = "18", ["tr-TR"] = "18", ["uk"] = "19", ["uk-UA"] = "19",
-      ["ro"] = "20", ["ro-RO"] = "20",
-      ["el"] = "21", ["el-GR"] = "21", ["cs"] = "22", ["cs-CZ"] = "22",
-      ["hu"] = "23", ["hu-HU"] = "23", ["sv"] = "24", ["sv-SE"] = "24",
-      ["da"] = "25", ["da-DK"] = "25",
-      ["fi"] = "26", ["fi-FI"] = "26", ["sk"] = "28", ["sk-SK"] = "28",
-      ["hr"] = "29", ["hr-HR"] = "29", ["bg"] = "30", ["bg-BG"] = "30",
-      ["lt"] = "31", ["lt-LT"] = "31", ["th"] = "32", ["th-TH"] = "32",
-      ["vi"] = "33", ["vi-VN"] = "33",
-      ["et"] = "60", ["et-EE"] = "60", ["lv"] = "61", ["lv-LV"] = "61",
-      ["sl"] = "62", ["sl-SI"] = "62", ["he"] = "64", ["he-IL"] = "64",
-      ["auto"] = "101",
-      ["mt"] = "102", ["mt-MT"] = "102", ["nb"] = "103", ["nb-NO"] = "103",
-      ["nn"] = "104", ["nn-NO"] = "104",
-    };
-
-    std::string ToLowerAscii(std::string s) {
-      std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
-      return s;
-    }
-  }  // namespace fl
 
 
 AudioSession::AudioSession(const fl::Model& catalog_model, GenAIModelInstance& model,
@@ -546,153 +556,276 @@ void AudioSession::ProcessAudioTranscriptionJson(const std::string& request_json
 
 
 bool AudioSession::IsNemotronSpeechModel() const {
-  const auto& cfg = Model().GetConfig();
+  const auto& cfg = Model().GetGenAIConfig();
   return cfg.model.has_value() && cfg.model->type == "nemotron_speech";
 }
 
-
-void AudioSession::TryNemotronLanguageId(OgaGenerator& generator,
-                                         const std::string& language) const {
-    if (language.empty()) {
-      return;
-    }
-
-    const auto key = ToLowerAscii(language);
-    auto it = NemotronLanguageIdMap().find(key);
-    if (it == NemotronLanguageIdMap().end()) {
-      return;
-    }
-    
-    
-    try {
-      generator.SetRuntimeOption("lang_id", it->second.c_str());
-    } catch (const std::exception& e) {
-      logger_.Log(LogLevel::Error, fmt::format("Failed to set Nemotron language ID: {}", e.what()));
-    }
+void AudioSession::TrySetNemotronLanguageId(OgaGenerator& generator, const std::string& language) const {
+  if (language.empty()) {
+    return;
   }
 
-
-  void AudioSession::ProcessNemotronFileTranscription(const AudioTranscriptionRequest& req,
-                                                      const Requests& original_request,
-                                                      const Response& response) {
-    
-    constexpr size_t kInitialTokenCapacity = 256;
-
-    if (original_request.canceled) {
-      response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
-      return;
-    }
-
-    const float temperature = req.temperature.value_or(
-      session_options_.temperature.value_or(0.0f)
-    );
-
-    const std::string language = req.language.value_or("");
-
-    std::vector<float> samples = LoadPcmWavAsFloatSamples(req.audio_file_path);
-
-    auto& oga_model = Model().GetOgaModel();
-    
-    auto processor = OgaStreamingProcessor::Create(oga_model);
-
-    auto tokenizer_stream = OgaTokenizerStream::Create(Model().GetOgaModel());
-
-    std::vector<std::string> token_texts;
-
-    token_texts.reserve(kInitialTokenCapacity);
-
-    std::vector<std::unique_ptr<SpeechSegmentItem>> segments;
-
-    segments.reserve(kInitialSegmentCapacity);
-
-    int completion_tokens = 0;
-
-    auto callback = CreateCallbackHandler(original_request);
-
-    // Process initial tensors with fresh generator
-
-    if (!original_request.canceled) {
-      // Process initial tensors here
-
-      auto tensors = processor->Process(samples.data(), samples.size());
-
-      if (tensors) {
-        auto gen_params = OgaGeneratorParams::Create(oga_model);
-
-        gen_params->SetSearchOption("temperature", temperature);
-
-        auto generator = OgaGenerator::Create(oga_model, *gen_params);
-
-        TryNemotronLanguageId(*generator, language);
-
-        generator->SetInputs(*tensors);
-
-        DecodeTokens(*generator, *tokenizer_stream, token_texts, segments, 
-                     callback, original_request, completion_tokens);
-      }
-    }
-
-    // Flush tensors with fresh generator (Important: avoid done-state reuse bug)
-
-    if (!original_request.canceled) {
-      auto flush_tensors = processor->Flush();
-
-      if (flush_tensors) {
-
-        auto gen_params = OgaGeneratorParams::Create(oga_model);
-        
-        gen_params->SetSearchOption("temperature", temperature);
-
-        auto generator = OgaGenerator::Create(oga_model, *gen_params);
-
-        TryNemotronLanguageId(*generator, language);
-
-        generator->SetInputs(*flush_tensors);
-
-        DecodeTokens(*generator, *tokenizer_stream, token_texts, segments, 
-                     callback, original_request, completion_tokens);
-      }
-    }
-
-    std::string full_text = JoinTokens(token_texts);
-    response.items.push_back(BuildSpeechResult(std::move(full_text), std::move(segments)));
-
-    response.finish_reason = original_request.canceled ? FOUNDRY_FINISH_REASON_CANCELED : FOUNDRY_FINISH_REASON_COMPLETED;
-
-    response.usage.prompt_tokens = 0;
-
-    response.usage.completion_tokens = completion_tokens;
-
-    response.usage.total_tokens = response.usage.prompt_tokens + response.usage.completion_tokens;
+  const auto key = ToLowerAscii(language);
+  auto it = NemotronLanguageIdMap().find(key);
+  if (it == NemotronLanguageIdMap().end()) {
+    return;
   }
 
-  std::vector<float> AudioSession::LoadPcmWavAsFloatSamples(const std::string& audio_file_path) {
-
-    std::ifstream in(audio_file_path, std::ios::binary);
-
-    if (!in) {
-      FL_THROW("Failed to open audio file: " + audio_file_path);
-    }
-
-    // TODO:
-   // 1) Read RIFF/WAVE header, fail if invalid.
-   // 2) Iterate chunks safely:
-   //    - read chunk id + size
-   //    - bounds-check size
-  //    - if "fmt " and size < 16 => throw (GitOps feedback fix)
-  //    - parse format/channels/sampleRate/bitsPerSample
-  //    - capture "data" bytes
-  // 3) Enforce sampleRate == 16000
-  // 4) Convert:
-  //    - PCM16 -> float [-1,1], average channels to mono if needed
-  //    - (optional parity) float32 PCM -> mono float
-  // 5) return std::vector<float>
-
-  FL_THROW(FOUNDRY_LOCAL_ERROR_NOT_IMPLEMENTED,
-           "LoadPcmWavAsFloatSamples not implemented yet");
+  try {
+    generator.SetRuntimeOption("lang_id", it->second.c_str());
+  } catch (const std::exception& e) {
+    logger_.Log(LogLevel::Warning,
+                fmt::format("Failed to set Nemotron lang_id '{}' for '{}': {}",
+                            it->second, language, e.what()));
+  }
 }
 
+void AudioSession::ProcessNemotronFileTranscription(const AudioTranscriptionRequest& req,
+                                                    const Request& original_request,
+                                                    Response& response) {
+  if (original_request.canceled) {
+    response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
+    return;
   }
 
+  std::optional<float> temperature = req.temperature.has_value() ? req.temperature : session_options_.temperature;
+
+  std::string language;
+  if (req.language.has_value()) {
+    language = *req.language;
+  } else {
+    auto session_lang_it = SessionOptions().find("language");
+    if (session_lang_it != SessionOptions().end()) {
+      language = session_lang_it->second;
+    }
+  }
+
+  auto samples = LoadPcmWavAsFloatSamples(req.filename);
+  auto& oga_model = Model().GetOgaModel();
+  auto processor = OgaStreamingProcessor::Create(oga_model);
+  auto tokenizer = OgaTokenizer::Create(oga_model);
+  auto tokenizer_stream = OgaTokenizerStream::Create(*tokenizer);
+  auto generator_params = OgaGeneratorParams::Create(oga_model);
+  if (temperature.has_value()) {
+    generator_params->SetSearchOption("temperature", *temperature);
+  } else {
+    generator_params->SetSearchOption("temperature", 0.0f);
+  }
+  auto generator = OgaGenerator::Create(oga_model, *generator_params);
+  TrySetNemotronLanguageId(*generator, language);
+
+  auto streaming_callback = CreateCallbackHandler(original_request);
+  const bool is_streaming = (streaming_callback != nullptr);
+  std::string response_id = ResponseConverter::GenerateId("audio");
+
+  std::string text;
+  text.reserve(512);
+  int completion_tokens = 0;
+
+  auto decode_all_tokens = [&]() {
+    while (!generator->IsDone() && !original_request.canceled) {
+      generator->GenerateNextToken();
+      auto next_tokens = generator->GetNextTokens();
+      if (next_tokens.empty()) {
+        continue;
+      }
+
+      ++completion_tokens;
+      const char* decoded = tokenizer_stream->Decode(next_tokens[0]);
+      if (!decoded || decoded[0] == '\0') {
+        continue;
+      }
+
+      std::string token(decoded);
+      if (IsLanguageToken(token)) {
+        continue;
+      }
+
+      text += token;
+
+      if (is_streaming) {
+        AudioTranscriptionResponse chunk;
+        chunk.id = response_id;
+        chunk.text = token;
+        streaming_callback->PushItem(std::make_unique<TextItem>(nlohmann::json(chunk).dump(),
+                                                                FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+      }
+    }
+  };
+
+  auto run_one_pass = [&](std::unique_ptr<OgaNamedTensors> tensors) {
+    if (!tensors || original_request.canceled) {
+      return;
+    }
+    generator->SetInputs(*tensors);
+    decode_all_tokens();
+  };
+
+  constexpr size_t kNemotronSamplesPerChunk = 1600;  // 100ms at 16kHz
+  for (size_t offset = 0; offset < samples.size() && !original_request.canceled;
+       offset += kNemotronSamplesPerChunk) {
+    size_t count = std::min(kNemotronSamplesPerChunk, samples.size() - offset);
+    run_one_pass(processor->Process(samples.data() + offset, count));
+  }
+  run_one_pass(processor->Flush());
+
+  response.finish_reason = original_request.canceled ? FOUNDRY_LOCAL_FINISH_NONE : FOUNDRY_LOCAL_FINISH_STOP;
+  response.usage.prompt_tokens = 0;
+  response.usage.completion_tokens = completion_tokens;
+  response.usage.total_tokens = completion_tokens;
+
+  AudioTranscriptionResponse output;
+  output.id = response_id;
+  output.text = std::move(text);
+  response.items.push_back(std::make_unique<TextItem>(nlohmann::json(output).dump(),
+                                                      FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+}
+
+std::vector<float> AudioSession::LoadPcmWavAsFloatSamples(const std::string& audio_file_path) {
+  std::ifstream in(audio_file_path, std::ios::binary);
+  if (!in) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
+             fmt::format("Failed to open audio file: '{}'", audio_file_path));
+  }
+
+  in.seekg(0, std::ios::end);
+  std::streamoff file_size = in.tellg();
+  in.seekg(0, std::ios::beg);
+  if (file_size < 12) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Invalid WAV file: too small for RIFF/WAVE header.");
+  }
+
+  char riff[4];
+  uint32_t riff_size = 0;
+  char wave[4];
+  in.read(riff, sizeof(riff));
+  in.read(reinterpret_cast<char*>(&riff_size), sizeof(riff_size));
+  in.read(wave, sizeof(wave));
+
+  if (!in || std::strncmp(riff, "RIFF", 4) != 0 || std::strncmp(wave, "WAVE", 4) != 0) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Invalid WAV file: missing RIFF/WAVE header.");
+  }
+
+  int16_t audio_format = 0;
+  int16_t channels = 0;
+  int32_t sample_rate = 0;
+  int16_t bits_per_sample = 0;
+  std::vector<uint8_t> data;
+
+  while (in && in.tellg() < file_size) {
+    char chunk_id_chars[4];
+    uint32_t chunk_size = 0;
+    in.read(chunk_id_chars, sizeof(chunk_id_chars));
+    in.read(reinterpret_cast<char*>(&chunk_size), sizeof(chunk_size));
+    if (!in) {
+      break;
+    }
+
+    const std::string chunk_id(chunk_id_chars, sizeof(chunk_id_chars));
+    const std::streamoff chunk_start = in.tellg();
+    if (chunk_start < 0 ||
+        chunk_start + static_cast<std::streamoff>(chunk_size) >
+            file_size - (chunk_size % 2 == 1 ? 1 : 0)) {
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Corrupted WAV chunk.");
+    }
+
+    if (chunk_id == "fmt ") {
+      if (chunk_size < 16) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
+                 fmt::format("Invalid WAV fmt chunk size {}; expected at least 16.", chunk_size));
+      }
+
+      in.read(reinterpret_cast<char*>(&audio_format), sizeof(audio_format));
+      in.read(reinterpret_cast<char*>(&channels), sizeof(channels));
+      in.read(reinterpret_cast<char*>(&sample_rate), sizeof(sample_rate));
+
+      int32_t byte_rate = 0;
+      int16_t block_align = 0;
+      in.read(reinterpret_cast<char*>(&byte_rate), sizeof(byte_rate));
+      in.read(reinterpret_cast<char*>(&block_align), sizeof(block_align));
+      in.read(reinterpret_cast<char*>(&bits_per_sample), sizeof(bits_per_sample));
+
+      int32_t remaining = static_cast<int32_t>(chunk_size) - 16;
+      if (remaining > 0) {
+        in.seekg(remaining, std::ios::cur);
+      }
+      if (!in) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Corrupted WAV fmt chunk.");
+      }
+    } else if (chunk_id == "data") {
+      data.resize(chunk_size);
+      if (chunk_size > 0) {
+        in.read(reinterpret_cast<char*>(data.data()), chunk_size);
+      }
+      if (!in) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Corrupted WAV data chunk.");
+      }
+    } else {
+      in.seekg(chunk_size, std::ios::cur);
+      if (!in) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Corrupted WAV chunk.");
+      }
+    }
+
+    if (chunk_size % 2 == 1) {
+      in.seekg(1, std::ios::cur);
+      if (!in) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Corrupted WAV padding byte.");
+      }
+    }
+  }
+
+  if (channels <= 0 || sample_rate <= 0 || bits_per_sample <= 0) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Missing or invalid WAV fmt chunk.");
+  }
+  if (sample_rate != 16000) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
+             fmt::format("Expected 16kHz WAV input, got {}Hz.", sample_rate));
+  }
+  if (data.empty()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "WAV data chunk is missing or empty.");
+  }
+
+  const size_t bytes_per_sample = static_cast<size_t>(bits_per_sample / 8);
+  if ((audio_format != 1 || bits_per_sample != 16) && (audio_format != 3 || bits_per_sample != 32)) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
+             fmt::format("Unsupported WAV format: audioFormat={}, bitsPerSample={}.", audio_format, bits_per_sample));
+  }
+  if (bytes_per_sample == 0 || data.size() % (bytes_per_sample * static_cast<size_t>(channels)) != 0) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Corrupted WAV data size.");
+  }
+
+  const size_t frame_count = data.size() / (bytes_per_sample * static_cast<size_t>(channels));
+  std::vector<float> samples;
+  samples.reserve(frame_count);
+
+  if (audio_format == 1 && bits_per_sample == 16) {
+    for (size_t frame = 0; frame < frame_count; ++frame) {
+      float mixed = 0.0f;
+      for (int16_t ch = 0; ch < channels; ++ch) {
+        size_t idx = frame * static_cast<size_t>(channels) + static_cast<size_t>(ch);
+        size_t byte_offset = idx * bytes_per_sample;
+        int16_t sample = 0;
+        std::memcpy(&sample, data.data() + byte_offset, sizeof(sample));
+        mixed += static_cast<float>(sample) / 32768.0f;
+      }
+      samples.push_back(mixed / static_cast<float>(channels));
+    }
+    return samples;
+  }
+
+  for (size_t frame = 0; frame < frame_count; ++frame) {
+    float mixed = 0.0f;
+    for (int16_t ch = 0; ch < channels; ++ch) {
+      size_t idx = frame * static_cast<size_t>(channels) + static_cast<size_t>(ch);
+      float value = 0.0f;
+      std::memcpy(&value, data.data() + (idx * bytes_per_sample), sizeof(float));
+      mixed += value;
+    }
+    samples.push_back(mixed / static_cast<float>(channels));
+  }
+
+  return samples;
+}
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
@@ -73,6 +73,41 @@ std::string JoinTokens(const std::vector<std::string>& token_texts) {
 
 }  // namespace
 
+namespace {
+  const std::unordered_map<std::string, std::string> NemotronLangIdMap = {
+      ["en"] = "0", ["en-US"] = "0", ["en-GB"] = "1",
+      ["es-ES"] = "2", ["es"] = "3", ["es-US"] = "3",
+      ["zh-CN"] = "4",
+      ["hi"] = "6", ["hi-IN"] = "6", ["ar"] = "7", ["ar-AR"] = "7",
+      ["fr"] = "8", ["fr-FR"] = "8", ["fr-CA"] = "100",
+      ["de"] = "9", ["de-DE"] = "9",
+      ["ja"] = "10", ["ja-JP"] = "10", ["ru"] = "11", ["ru-RU"] = "11",
+      ["pt-BR"] = "12", ["pt"] = "13", ["pt-PT"] = "13",
+      ["ko"] = "14", ["ko-KR"] = "14", ["it"] = "15", ["it-IT"] = "15",
+      ["nl"] = "16", ["nl-NL"] = "16", ["pl"] = "17", ["pl-PL"] = "17",
+      ["tr"] = "18", ["tr-TR"] = "18", ["uk"] = "19", ["uk-UA"] = "19",
+      ["ro"] = "20", ["ro-RO"] = "20",
+      ["el"] = "21", ["el-GR"] = "21", ["cs"] = "22", ["cs-CZ"] = "22",
+      ["hu"] = "23", ["hu-HU"] = "23", ["sv"] = "24", ["sv-SE"] = "24",
+      ["da"] = "25", ["da-DK"] = "25",
+      ["fi"] = "26", ["fi-FI"] = "26", ["sk"] = "28", ["sk-SK"] = "28",
+      ["hr"] = "29", ["hr-HR"] = "29", ["bg"] = "30", ["bg-BG"] = "30",
+      ["lt"] = "31", ["lt-LT"] = "31", ["th"] = "32", ["th-TH"] = "32",
+      ["vi"] = "33", ["vi-VN"] = "33",
+      ["et"] = "60", ["et-EE"] = "60", ["lv"] = "61", ["lv-LV"] = "61",
+      ["sl"] = "62", ["sl-SI"] = "62", ["he"] = "64", ["he-IL"] = "64",
+      ["auto"] = "101",
+      ["mt"] = "102", ["mt-MT"] = "102", ["nb"] = "103", ["nb-NO"] = "103",
+      ["nn"] = "104", ["nn-NO"] = "104",
+    };
+
+    std::string ToLowerAscii(std::string s) {
+      std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
+      return s;
+    }
+  }  // namespace fl
+
+
 AudioSession::AudioSession(const fl::Model& catalog_model, GenAIModelInstance& model,
                            ILogger& logger, ITelemetry& telemetry)
     : Session(catalog_model, logger, telemetry), logger_(logger), model_(model) {
@@ -422,6 +457,13 @@ void AudioSession::ProcessAudioTranscriptionJson(const std::string& request_json
     FL_LOG_AND_THROW(logger_, FOUNDRY_LOCAL_ERROR_INVALID_USAGE, fmt::format("Audio file not found: '{}'", req.filename));
   }
 
+  // If the model is a Nemotron speech model, process the transcription using the Nemotron-specific method.
+  // e.g. RNNT models require Nemotron-specific transcription handling.
+  if (IsNemotronSpeechModel()) {
+    ProcessNemotronFileTranscription(req, original_request, response);
+    return;
+  }
+
   // Build generation options from session defaults
   SearchOptions options = session_options_;
 
@@ -501,5 +543,156 @@ void AudioSession::ProcessAudioTranscriptionJson(const std::string& request_json
               fmt::format("Audio transcription stats: Total Tokens: {}, Prompt Tokens: {}, Completion Tokens: {}",
                           total_tokens, prompt_tokens, completion_tokens));
 }
+
+
+bool AudioSession::IsNemotronSpeechModel() const {
+  const auto& cfg = Model().GetConfig();
+  return cfg.model.has_value() && cfg.model->type == "nemotron_speech";
+}
+
+
+void AudioSession::TryNemotronLanguageId(OgaGenerator& generator,
+                                         const std::string& language) const {
+    if (language.empty()) {
+      return;
+    }
+
+    const auto key = ToLowerAscii(language);
+    auto it = NemotronLanguageIdMap().find(key);
+    if (it == NemotronLanguageIdMap().end()) {
+      return;
+    }
+    
+    
+    try {
+      generator.SetRuntimeOption("lang_id", it->second.c_str());
+    } catch (const std::exception& e) {
+      logger_.Log(LogLevel::Error, fmt::format("Failed to set Nemotron language ID: {}", e.what()));
+    }
+  }
+
+
+  void AudioSession::ProcessNemotronFileTranscription(const AudioTranscriptionRequest& req,
+                                                      const Requests& original_request,
+                                                      const Response& response) {
+    
+    constexpr size_t kInitialTokenCapacity = 256;
+
+    if (original_request.canceled) {
+      response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
+      return;
+    }
+
+    const float temperature = req.temperature.value_or(
+      session_options_.temperature.value_or(0.0f)
+    );
+
+    const std::string language = req.language.value_or("");
+
+    std::vector<float> samples = LoadPcmWavAsFloatSamples(req.audio_file_path);
+
+    auto& oga_model = Model().GetOgaModel();
+    
+    auto processor = OgaStreamingProcessor::Create(oga_model);
+
+    auto tokenizer_stream = OgaTokenizerStream::Create(Model().GetOgaModel());
+
+    std::vector<std::string> token_texts;
+
+    token_texts.reserve(kInitialTokenCapacity);
+
+    std::vector<std::unique_ptr<SpeechSegmentItem>> segments;
+
+    segments.reserve(kInitialSegmentCapacity);
+
+    int completion_tokens = 0;
+
+    auto callback = CreateCallbackHandler(original_request);
+
+    // Process initial tensors with fresh generator
+
+    if (!original_request.canceled) {
+      // Process initial tensors here
+
+      auto tensors = processor->Process(samples.data(), samples.size());
+
+      if (tensors) {
+        auto gen_params = OgaGeneratorParams::Create(oga_model);
+
+        gen_params->SetSearchOption("temperature", temperature);
+
+        auto generator = OgaGenerator::Create(oga_model, *gen_params);
+
+        TryNemotronLanguageId(*generator, language);
+
+        generator->SetInputs(*tensors);
+
+        DecodeTokens(*generator, *tokenizer_stream, token_texts, segments, 
+                     callback, original_request, completion_tokens);
+      }
+    }
+
+    // Flush tensors with fresh generator (Important: avoid done-state reuse bug)
+
+    if (!original_request.canceled) {
+      auto flush_tensors = processor->Flush();
+
+      if (flush_tensors) {
+
+        auto gen_params = OgaGeneratorParams::Create(oga_model);
+        
+        gen_params->SetSearchOption("temperature", temperature);
+
+        auto generator = OgaGenerator::Create(oga_model, *gen_params);
+
+        TryNemotronLanguageId(*generator, language);
+
+        generator->SetInputs(*flush_tensors);
+
+        DecodeTokens(*generator, *tokenizer_stream, token_texts, segments, 
+                     callback, original_request, completion_tokens);
+      }
+    }
+
+    std::string full_text = JoinTokens(token_texts);
+    response.items.push_back(BuildSpeechResult(std::move(full_text), std::move(segments)));
+
+    response.finish_reason = original_request.canceled ? FOUNDRY_FINISH_REASON_CANCELED : FOUNDRY_FINISH_REASON_COMPLETED;
+
+    response.usage.prompt_tokens = 0;
+
+    response.usage.completion_tokens = completion_tokens;
+
+    response.usage.total_tokens = response.usage.prompt_tokens + response.usage.completion_tokens;
+  }
+
+  std::vector<float> AudioSession::LoadPcmWavAsFloatSamples(const std::string& audio_file_path) {
+
+    std::ifstream in(audio_file_path, std::ios::binary);
+
+    if (!in) {
+      FL_THROW("Failed to open audio file: " + audio_file_path);
+    }
+
+    // TODO:
+   // 1) Read RIFF/WAVE header, fail if invalid.
+   // 2) Iterate chunks safely:
+   //    - read chunk id + size
+   //    - bounds-check size
+  //    - if "fmt " and size < 16 => throw (GitOps feedback fix)
+  //    - parse format/channels/sampleRate/bitsPerSample
+  //    - capture "data" bytes
+  // 3) Enforce sampleRate == 16000
+  // 4) Convert:
+  //    - PCM16 -> float [-1,1], average channels to mono if needed
+  //    - (optional parity) float32 PCM -> mono float
+  // 5) return std::vector<float>
+
+  FL_THROW(FOUNDRY_LOCAL_ERROR_NOT_IMPLEMENTED,
+           "LoadPcmWavAsFloatSamples not implemented yet");
+}
+
+  }
+
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
@@ -325,7 +325,9 @@ void AudioSession::ProcessStreamingAudio(const AudioItem& format_item, ItemQueue
   auto effective_kvp = MergedOptions(request.options);
   SearchOptions options = SearchOptions::FromParameters(effective_kvp);
 
-  gen_params->SetSearchOption("temperature", options.temperature.value_or(0.0f));
+  if (options.temperature.has_value()) {
+    gen_params->SetSearchOption("temperature", *options.temperature);
+  }
 
   auto generator = OgaGenerator::Create(oga_model, *gen_params);
   auto tokenizer_stream = OgaTokenizerStream::Create(Model().GetOgaTokenizer());
@@ -649,7 +651,9 @@ void AudioSession::ProcessNemotronFileTranscription(const AudioTranscriptionRequ
   auto tokenizer = OgaTokenizer::Create(oga_model);
   auto tokenizer_stream = OgaTokenizerStream::Create(*tokenizer);
   auto generator_params = OgaGeneratorParams::Create(oga_model);
-  generator_params->SetSearchOption("temperature", temperature.value_or(0.0f));
+  if (temperature.has_value()) {
+    generator_params->SetSearchOption("temperature", *temperature);
+  }
   auto generator = OgaGenerator::Create(oga_model, *generator_params);
   TryNemotronLanguageId(*generator, language);
 

--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
@@ -62,6 +62,8 @@ std::unique_ptr<SpeechResultItem> BuildSpeechResult(
 // (~10s on Whisper, ~5s on Nemotron streaming) produces under 256 tokens, so most short-form
 // transcriptions avoid any reallocation. Longer transcriptions still grow geometrically.
 constexpr size_t kInitialTokenCapacity = 256;
+constexpr size_t kMaxWavDataBytes = 64ull * 1024ull * 1024ull;
+constexpr size_t kMaxWavSamples = kMaxWavDataBytes / sizeof(float);
 
 // Concatenate the per-token strings into a single buffer with one allocation.
 std::string JoinTokens(const std::vector<std::string>& token_texts) {
@@ -775,6 +777,11 @@ std::vector<float> AudioSession::LoadPcmWavAsFloatSamples(const std::string& aud
       if (channels <= 0 || sample_rate <= 0 || bits_per_sample <= 0) {
         FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Missing WAV fmt chunk before data.");
       }
+      if (chunk_size > kMaxWavDataBytes) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
+                 fmt::format("WAV data chunk exceeds the maximum supported size ({} bytes).",
+                             kMaxWavDataBytes));
+      }
 
       data.resize(chunk_size);
       if (chunk_size > 0) {
@@ -820,6 +827,11 @@ std::vector<float> AudioSession::LoadPcmWavAsFloatSamples(const std::string& aud
   }
 
   const size_t frame_count = data.size() / (bytes_per_sample * static_cast<size_t>(channels));
+  if (frame_count > kMaxWavSamples) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
+             fmt::format("WAV sample count exceeds the maximum supported size ({} samples).", kMaxWavSamples));
+  }
+
   std::vector<float> samples;
   samples.reserve(frame_count);
 

--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
@@ -78,6 +78,7 @@ std::string JoinTokens(const std::vector<std::string>& token_texts) {
 }
 
 const std::unordered_map<std::string, std::string>& NemotronLanguageIdMap() {
+  // Language id 5 is intentionally missing because upstream Nemotron lang_id assignments skip it.
   static const std::unordered_map<std::string, std::string> kMap = {
       {"en", "0"},       {"en-us", "0"},    {"en-gb", "1"},    {"es-es", "2"},   {"es", "3"},
       {"es-us", "3"},    {"zh-cn", "4"},    {"hi", "6"},       {"hi-in", "6"},   {"ar", "7"},
@@ -324,9 +325,7 @@ void AudioSession::ProcessStreamingAudio(const AudioItem& format_item, ItemQueue
   auto effective_kvp = MergedOptions(request.options);
   SearchOptions options = SearchOptions::FromParameters(effective_kvp);
 
-  if (options.temperature.has_value()) {
-    gen_params->SetSearchOption("temperature", *options.temperature);
-  }
+  gen_params->SetSearchOption("temperature", options.temperature.value_or(0.0f));
 
   auto generator = OgaGenerator::Create(oga_model, *gen_params);
   auto tokenizer_stream = OgaTokenizerStream::Create(Model().GetOgaTokenizer());
@@ -467,8 +466,8 @@ void AudioSession::ProcessAudioTranscriptionJson(const std::string& request_json
     FL_LOG_AND_THROW(logger_, FOUNDRY_LOCAL_ERROR_INVALID_USAGE, fmt::format("Audio file not found: '{}'", req.filename));
   }
 
-  // If the model is a Nemotron speech model, process the transcription using the Nemotron-specific method.
-  // e.g. RNNT models require Nemotron-specific transcription handling.
+  // Nemotron speech models are RNNT-based and do not use the Whisper-oriented OnnxAudioGenerator path below.
+  // Route file transcription through StreamingProcessor so nemotron_speech models can decode correctly.
   if (IsNemotronSpeechModel()) {
     ProcessNemotronFileTranscription(req, original_request, response);
     return;
@@ -476,13 +475,7 @@ void AudioSession::ProcessAudioTranscriptionJson(const std::string& request_json
 
   // Build generation options from session defaults
   SearchOptions options = session_options_;
-
-  std::optional<float> temperature;
-  if (req.temperature.has_value()) {
-    temperature = *req.temperature;
-  } else {
-    temperature = options.temperature;
-  }
+  std::optional<float> temperature = req.temperature.has_value() ? req.temperature : options.temperature;
 
   // Language from request, falling back to session-level option
   std::string language;
@@ -560,7 +553,7 @@ bool AudioSession::IsNemotronSpeechModel() const {
   return cfg.model.has_value() && cfg.model->type == "nemotron_speech";
 }
 
-void AudioSession::TrySetNemotronLanguageId(OgaGenerator& generator, const std::string& language) const {
+void AudioSession::TryNemotronLanguageId(OgaGenerator& generator, const std::string& language) const {
   if (language.empty()) {
     return;
   }
@@ -578,6 +571,56 @@ void AudioSession::TrySetNemotronLanguageId(OgaGenerator& generator, const std::
                 fmt::format("Failed to set Nemotron lang_id '{}' for '{}': {}",
                             it->second, language, e.what()));
   }
+}
+
+void AudioSession::DecodeNemotronTokens(OgaGenerator& generator, OgaTokenizerStream& tokenizer_stream, std::string& text,
+                                        const std::unique_ptr<CallbackHandler>& streaming_callback,
+                                        const std::string& response_id, const Request& original_request,
+                                        int& completion_tokens) const {
+  const bool is_streaming = (streaming_callback != nullptr);
+
+  while (!generator.IsDone() && !original_request.canceled) {
+    generator.GenerateNextToken();
+    auto next_tokens = generator.GetNextTokens();
+    if (next_tokens.empty()) {
+      continue;
+    }
+
+    ++completion_tokens;
+    const char* decoded = tokenizer_stream.Decode(next_tokens[0]);
+    if (!decoded || decoded[0] == '\0') {
+      continue;
+    }
+
+    std::string token(decoded);
+    if (IsLanguageToken(token)) {
+      continue;
+    }
+
+    text += token;
+
+    if (is_streaming) {
+      AudioTranscriptionResponse chunk;
+      chunk.id = response_id;
+      chunk.text = token;
+      streaming_callback->PushItem(std::make_unique<TextItem>(nlohmann::json(chunk).dump(),
+                                                              FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+    }
+  }
+}
+
+void AudioSession::RunNemotronDecodePass(std::unique_ptr<OgaNamedTensors> tensors, OgaGenerator& generator,
+                                         OgaTokenizerStream& tokenizer_stream, std::string& text,
+                                         const std::unique_ptr<CallbackHandler>& streaming_callback,
+                                         const std::string& response_id, const Request& original_request,
+                                         int& completion_tokens) const {
+  if (!tensors || original_request.canceled) {
+    return;
+  }
+
+  generator.SetInputs(*tensors);
+  DecodeNemotronTokens(generator, tokenizer_stream, text, streaming_callback, response_id, original_request,
+                       completion_tokens);
 }
 
 void AudioSession::ProcessNemotronFileTranscription(const AudioTranscriptionRequest& req,
@@ -606,70 +649,29 @@ void AudioSession::ProcessNemotronFileTranscription(const AudioTranscriptionRequ
   auto tokenizer = OgaTokenizer::Create(oga_model);
   auto tokenizer_stream = OgaTokenizerStream::Create(*tokenizer);
   auto generator_params = OgaGeneratorParams::Create(oga_model);
-  if (temperature.has_value()) {
-    generator_params->SetSearchOption("temperature", *temperature);
-  } else {
-    generator_params->SetSearchOption("temperature", 0.0f);
-  }
+  generator_params->SetSearchOption("temperature", temperature.value_or(0.0f));
   auto generator = OgaGenerator::Create(oga_model, *generator_params);
-  TrySetNemotronLanguageId(*generator, language);
+  TryNemotronLanguageId(*generator, language);
 
   auto streaming_callback = CreateCallbackHandler(original_request);
-  const bool is_streaming = (streaming_callback != nullptr);
   std::string response_id = ResponseConverter::GenerateId("audio");
 
   std::string text;
   text.reserve(512);
   int completion_tokens = 0;
 
-  auto decode_all_tokens = [&]() {
-    while (!generator->IsDone() && !original_request.canceled) {
-      generator->GenerateNextToken();
-      auto next_tokens = generator->GetNextTokens();
-      if (next_tokens.empty()) {
-        continue;
-      }
-
-      ++completion_tokens;
-      const char* decoded = tokenizer_stream->Decode(next_tokens[0]);
-      if (!decoded || decoded[0] == '\0') {
-        continue;
-      }
-
-      std::string token(decoded);
-      if (IsLanguageToken(token)) {
-        continue;
-      }
-
-      text += token;
-
-      if (is_streaming) {
-        AudioTranscriptionResponse chunk;
-        chunk.id = response_id;
-        chunk.text = token;
-        streaming_callback->PushItem(std::make_unique<TextItem>(nlohmann::json(chunk).dump(),
-                                                                FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
-      }
-    }
-  };
-
-  auto run_one_pass = [&](std::unique_ptr<OgaNamedTensors> tensors) {
-    if (!tensors || original_request.canceled) {
-      return;
-    }
-    generator->SetInputs(*tensors);
-    decode_all_tokens();
-  };
-
   constexpr size_t kNemotronSamplesPerChunk = 1600;  // 100ms at 16kHz
   for (size_t offset = 0; offset < samples.size() && !original_request.canceled;
        offset += kNemotronSamplesPerChunk) {
     size_t count = std::min(kNemotronSamplesPerChunk, samples.size() - offset);
-    run_one_pass(processor->Process(samples.data() + offset, count));
+    RunNemotronDecodePass(processor->Process(samples.data() + offset, count), *generator, *tokenizer_stream, text,
+                          streaming_callback, response_id, original_request, completion_tokens);
   }
-  run_one_pass(processor->Flush());
+  RunNemotronDecodePass(processor->Flush(), *generator, *tokenizer_stream, text, streaming_callback, response_id,
+                        original_request, completion_tokens);
 
   response.finish_reason = original_request.canceled ? FOUNDRY_LOCAL_FINISH_NONE : FOUNDRY_LOCAL_FINISH_STOP;
+  // Nemotron file-transcription path feeds audio tensors directly and does not expose prompt token accounting.
   response.usage.prompt_tokens = 0;
   response.usage.completion_tokens = completion_tokens;
   response.usage.total_tokens = completion_tokens;
@@ -723,9 +725,7 @@ std::vector<float> AudioSession::LoadPcmWavAsFloatSamples(const std::string& aud
 
     const std::string chunk_id(chunk_id_chars, sizeof(chunk_id_chars));
     const std::streamoff chunk_start = in.tellg();
-    if (chunk_start < 0 ||
-        chunk_start + static_cast<std::streamoff>(chunk_size) >
-            file_size - (chunk_size % 2 == 1 ? 1 : 0)) {
+    if (chunk_start < 0 || chunk_start + static_cast<std::streamoff>(chunk_size) > file_size) {
       FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Corrupted WAV chunk.");
     }
 
@@ -752,7 +752,24 @@ std::vector<float> AudioSession::LoadPcmWavAsFloatSamples(const std::string& aud
       if (!in) {
         FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Corrupted WAV fmt chunk.");
       }
+
+      if (channels <= 0 || sample_rate <= 0 || bits_per_sample <= 0) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Missing or invalid WAV fmt fields.");
+      }
+      if (sample_rate != 16000) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
+                 fmt::format("Expected 16kHz WAV input, got {}Hz.", sample_rate));
+      }
+      if ((audio_format != 1 || bits_per_sample != 16) && (audio_format != 3 || bits_per_sample != 32)) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
+                 fmt::format("Unsupported WAV format: audioFormat={}, bitsPerSample={}.", audio_format,
+                             bits_per_sample));
+      }
     } else if (chunk_id == "data") {
+      if (channels <= 0 || sample_rate <= 0 || bits_per_sample <= 0) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Missing WAV fmt chunk before data.");
+      }
+
       data.resize(chunk_size);
       if (chunk_size > 0) {
         in.read(reinterpret_cast<char*>(data.data()), chunk_size);
@@ -760,6 +777,7 @@ std::vector<float> AudioSession::LoadPcmWavAsFloatSamples(const std::string& aud
       if (!in) {
         FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "Corrupted WAV data chunk.");
       }
+      break;
     } else {
       in.seekg(chunk_size, std::ios::cur);
       if (!in) {

--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.h
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.h
@@ -19,6 +19,7 @@ struct OgaTokenizerStream;
 namespace fl {
 
 class GenAIModelInstance;
+struct AudioTranscriptionRequest;
 struct AudioItem;
 struct ItemQueue;
 struct SpeechSegmentItem;
@@ -61,7 +62,7 @@ class AudioSession : public Session {
 
   void TrySetNemotronLanguageId(OgaGenerator& generator, const std::string& language) const;
 
-  static std::vector<float> LoadPcmWavAsFloatSample(const std::string&& audio_file_path);
+  static std::vector<float> LoadPcmWavAsFloatSamples(const std::string& audio_file_path);
 
   /// Process a streaming audio request: an AudioItem (format descriptor) + an ItemQueue (PCM chunks).
   void ProcessStreamingAudio(const AudioItem& format_item, ItemQueue& queue,

--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.h
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.h
@@ -60,7 +60,18 @@ class AudioSession : public Session {
                                         const Request& original_request,
                                         Response& response);
 
-  void TrySetNemotronLanguageId(OgaGenerator& generator, const std::string& language) const;
+  void RunNemotronDecodePass(std::unique_ptr<OgaNamedTensors> tensors, OgaGenerator& generator,
+                             OgaTokenizerStream& tokenizer_stream, std::string& text,
+                             const std::unique_ptr<CallbackHandler>& streaming_callback,
+                             const std::string& response_id, const Request& original_request,
+                             int& completion_tokens) const;
+
+  void DecodeNemotronTokens(OgaGenerator& generator, OgaTokenizerStream& tokenizer_stream, std::string& text,
+                            const std::unique_ptr<CallbackHandler>& streaming_callback,
+                            const std::string& response_id, const Request& original_request,
+                            int& completion_tokens) const;
+
+  void TryNemotronLanguageId(OgaGenerator& generator, const std::string& language) const;
 
   static std::vector<float> LoadPcmWavAsFloatSamples(const std::string& audio_file_path);
 

--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.h
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.h
@@ -53,6 +53,16 @@ class AudioSession : public Session {
   void ProcessAudioTranscriptionJson(const std::string& request_json, const Request& original_request,
                                      Response& response);
 
+  bool IsNemotronSpeechModel() const;
+
+  void ProcessNemotronFileTranscription(const AudioTranscriptionRequest& req, 
+                                        const Request& original_request,
+                                        Response& response);
+
+  void TrySetNemotronLanguageId(OgaGenerator& generator, const std::string& language) const;
+
+  static std::vector<float> LoadPcmWavAsFloatSample(const std::string&& audio_file_path);
+
   /// Process a streaming audio request: an AudioItem (format descriptor) + an ItemQueue (PCM chunks).
   void ProcessStreamingAudio(const AudioItem& format_item, ItemQueue& queue,
                              const Request& request, Response& response);

--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.h
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.h
@@ -18,6 +18,7 @@ struct OgaTokenizerStream;
 
 namespace fl {
 
+class AudioSessionTestAccessor;
 class GenAIModelInstance;
 struct AudioTranscriptionRequest;
 struct AudioItem;
@@ -46,7 +47,9 @@ class AudioSession : public Session {
   SessionType Type() const override;
 
  private:
-  void SetSessionOptionsImpl(const KeyValuePairs& options) override;
+   friend class AudioSessionTestAccessor;
+
+   void SetSessionOptionsImpl(const KeyValuePairs& options) override;
   void ProcessRequestImpl(const Request& request, Response& response) override;
 
   /// Process a request whose first item is a TEXT item tagged OPENAI_JSON containing an

--- a/sdk_v2/cpp/test/internal_api/audio/audio_session_test.cc
+++ b/sdk_v2/cpp/test/internal_api/audio/audio_session_test.cc
@@ -4,7 +4,9 @@
 // Validation tests exercise input checking without needing an audio model —
 // they throw before the generator is created, so any GenAIModelInstance works.
 
+#define private public
 #include "inferencing/generative/audio/audio_session.h"
+#undef private
 
 #include "ep_detection/ep_detector.h"
 #include "exception.h"
@@ -25,10 +27,12 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstring>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -102,6 +106,39 @@ void WriteWavPcm16(const std::filesystem::path& path, int sample_rate_hz, int ch
   if (!samples.empty()) {
     out.write(reinterpret_cast<const char*>(samples.data()),
               static_cast<std::streamsize>(samples.size() * sizeof(int16_t)));
+  }
+}
+
+void WriteWavFloat32(const std::filesystem::path& path, int sample_rate_hz, int channels,
+                     const std::vector<float>& samples) {
+  const uint16_t audio_format = 3;  // IEEE float
+  const uint16_t bits_per_sample = 32;
+  const uint16_t block_align = static_cast<uint16_t>((channels * bits_per_sample) / 8);
+  const uint32_t byte_rate = static_cast<uint32_t>(sample_rate_hz * block_align);
+  const uint32_t data_size = static_cast<uint32_t>(samples.size() * sizeof(float));
+  const uint32_t riff_size = 4 + (8 + 16) + (8 + data_size);
+
+  std::ofstream out(path, std::ios::binary);
+  ASSERT_TRUE(out.is_open()) << "Failed to create temp WAV: " << path.string();
+
+  WriteBytes(out, "RIFF", 4);
+  WriteLe<uint32_t>(out, riff_size);
+  WriteBytes(out, "WAVE", 4);
+
+  WriteBytes(out, "fmt ", 4);
+  WriteLe<uint32_t>(out, 16);
+  WriteLe<uint16_t>(out, audio_format);
+  WriteLe<uint16_t>(out, static_cast<uint16_t>(channels));
+  WriteLe<uint32_t>(out, static_cast<uint32_t>(sample_rate_hz));
+  WriteLe<uint32_t>(out, byte_rate);
+  WriteLe<uint16_t>(out, block_align);
+  WriteLe<uint16_t>(out, bits_per_sample);
+
+  WriteBytes(out, "data", 4);
+  WriteLe<uint32_t>(out, data_size);
+  if (!samples.empty()) {
+    out.write(reinterpret_cast<const char*>(samples.data()),
+              static_cast<std::streamsize>(samples.size() * sizeof(float)));
   }
 }
 
@@ -240,6 +277,74 @@ class AudioSessionInferenceTest : public ::testing::Test {
   static inline std::unique_ptr<test::CpuOnlyEpDetector> ep_detector_;
   static inline std::unique_ptr<ModelLoadManager> load_manager_;
   static inline GenAIModelInstance* model_ = nullptr;
+  static inline fl::test::FakeServiceBindings svc_;
+  static inline Model catalog_model_ = Model::FromModelInfo(
+      ModelInfo{}, "", svc_.download_manager, svc_.model_load_manager);
+  fl::test::NullTelemetry null_telemetry_;
+  fl::test::NullSessionManager null_session_manager_;
+};
+
+class AudioSessionNemotronInferenceTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    logger_ = std::make_unique<StderrLogger>();
+    ep_detector_ = std::make_unique<test::CpuOnlyEpDetector>();
+    load_manager_ = std::make_unique<ModelLoadManager>(*ep_detector_, *logger_);
+
+    fs::path cache_dir;
+    try {
+      cache_dir = fl::test::GetTestModelCacheDir();
+    } catch (const std::exception&) {
+      GTEST_SKIP() << "Model cache unavailable — skipping Nemotron inference test";
+      return;
+    }
+
+    std::optional<std::string> nemotron_alias;
+    for (const auto& entry : fs::directory_iterator(cache_dir)) {
+      if (!entry.is_directory()) {
+        continue;
+      }
+      const auto alias = entry.path().filename().string();
+      std::string lower = alias;
+      std::transform(lower.begin(), lower.end(), lower.begin(),
+                     [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+      if (lower.find("nemotron") != std::string::npos) {
+        nemotron_alias = alias;
+        break;
+      }
+    }
+
+    if (!nemotron_alias.has_value()) {
+      GTEST_SKIP() << "No nemotron model found in test cache";
+      return;
+    }
+
+    nemotron_alias_ = *nemotron_alias;
+    fs::path model_path = fl::test::GetTestModelPath(nemotron_alias_);
+    auto result = load_manager_->LoadModel(model_path.string(), nemotron_alias_);
+    ASSERT_EQ(result.status, ModelLoadManager::LoadStatus::kSuccess)
+        << "Failed to load Nemotron model from: " << model_path;
+    model_ = result.model;
+  }
+
+  static void TearDownTestSuite() {
+    if (load_manager_ && !nemotron_alias_.empty()) {
+      load_manager_->UnloadModel(nemotron_alias_);
+    }
+    load_manager_.reset();
+    ep_detector_.reset();
+    model_ = nullptr;
+    nemotron_alias_.clear();
+  }
+
+  GenAIModelInstance& GetModel() { return *model_; }
+  const Model& GetCatalogModel() { return catalog_model_; }
+
+  static inline std::unique_ptr<StderrLogger> logger_;
+  static inline std::unique_ptr<test::CpuOnlyEpDetector> ep_detector_;
+  static inline std::unique_ptr<ModelLoadManager> load_manager_;
+  static inline GenAIModelInstance* model_ = nullptr;
+  static inline std::string nemotron_alias_;
   static inline fl::test::FakeServiceBindings svc_;
   static inline Model catalog_model_ = Model::FromModelInfo(
       ModelInfo{}, "", svc_.download_manager, svc_.model_load_manager);
@@ -654,6 +759,18 @@ TEST_F(AudioSessionTest, NemotronOpenAIJsonRejectsUnsupportedWavFormatInFmtChunk
       fl::Exception);
 }
 
+TEST_F(AudioSessionTest, LoadPcmWavAsFloatSamples_DecodesFloat32Path) {
+  auto temp = fl::test::TempPath::CreateTempFile("audio_float32_");
+  const std::vector<float> input = {-0.75f, -0.25f, 0.0f, 0.25f, 0.75f};
+  WriteWavFloat32(temp.path(), /*sample_rate_hz=*/16000, /*channels=*/1, input);
+
+  auto samples = AudioSession::LoadPcmWavAsFloatSamples(temp.path().string());
+  ASSERT_EQ(samples.size(), input.size());
+  for (size_t i = 0; i < input.size(); ++i) {
+    EXPECT_NEAR(samples[i], input[i], 1e-6f);
+  }
+}
+
 // ===========================================================================
 // Real inference tests — require the whisper model in the test cache.
 // These run AudioSession::ProcessRequest directly (no web service).
@@ -737,4 +854,45 @@ TEST_F(AudioSessionInferenceTest, TranscribeViaOpenAIJson) {
 
   EXPECT_EQ(response.finish_reason, FOUNDRY_LOCAL_FINISH_STOP);
   EXPECT_GT(response.usage.total_tokens, 0) << "Expected non-zero total_tokens";
+}
+
+TEST_F(AudioSessionNemotronInferenceTest, OpenAIJsonNemotronFileTranscriptionMultiChunkNotTruncated) {
+  if (!model_) {
+    GTEST_SKIP() << "Nemotron model not loaded";
+  }
+
+  auto pcm_path = fl::test::GetTestDataPath("Recording.pcm");
+  ASSERT_TRUE(fs::exists(pcm_path)) << "Recording.pcm not found: " << pcm_path;
+
+  std::ifstream pcm_in(pcm_path, std::ios::binary);
+  ASSERT_TRUE(pcm_in.is_open()) << "Failed to open Recording.pcm";
+  std::vector<char> pcm_bytes((std::istreambuf_iterator<char>(pcm_in)),
+                              std::istreambuf_iterator<char>());
+  ASSERT_GT(pcm_bytes.size(), 3200u) << "Need multi-chunk PCM input";
+  ASSERT_EQ(pcm_bytes.size() % sizeof(int16_t), 0u) << "PCM file byte count must align to int16";
+
+  std::vector<int16_t> pcm_samples(pcm_bytes.size() / sizeof(int16_t));
+  std::memcpy(pcm_samples.data(), pcm_bytes.data(), pcm_bytes.size());
+
+  auto wav_temp = fl::test::TempPath::CreateTempFile("nemotron_multichunk_");
+  WriteWavPcm16(wav_temp.path(), /*sample_rate_hz=*/16000, /*channels=*/1, pcm_samples);
+
+  AudioSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  auto request = BuildOpenAiJsonAudioRequest(wav_temp.path());
+  request.options["language"] = "en";
+
+  Response response;
+  ASSERT_NO_THROW(session.ProcessRequest(request, response));
+  ASSERT_FALSE(response.items.empty()) << "No response items from Nemotron transcription";
+
+  const Item* first_item = response.items.front().get();
+  ASSERT_EQ(first_item->type, FOUNDRY_LOCAL_ITEM_TEXT);
+  const auto& text_item = static_cast<const TextItem&>(*first_item);
+  ASSERT_EQ(text_item.text_type, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON);
+
+  auto resp_json = nlohmann::json::parse(text_item.text);
+  ASSERT_TRUE(resp_json.contains("text"));
+  std::string text = resp_json["text"].get<std::string>();
+  EXPECT_FALSE(text.empty()) << "Nemotron transcript should not be empty";
+  ExpectTranscriptionContent(text);
 }

--- a/sdk_v2/cpp/test/internal_api/audio/audio_session_test.cc
+++ b/sdk_v2/cpp/test/internal_api/audio/audio_session_test.cc
@@ -25,8 +25,12 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -57,6 +61,86 @@ static void ExpectTranscriptionContent(const std::string& text) {
     EXPECT_NE(lower.find(phrase), std::string::npos)
         << "Expected transcription to contain '" << phrase << "'.\nGot: " << text;
   }
+}
+
+template <typename T>
+void WriteLe(std::ofstream& out, T value) {
+  out.write(reinterpret_cast<const char*>(&value), sizeof(T));
+}
+
+void WriteBytes(std::ofstream& out, const char* data, size_t size) {
+  out.write(data, static_cast<std::streamsize>(size));
+}
+
+void WriteWavPcm16(const std::filesystem::path& path, int sample_rate_hz, int channels,
+                   const std::vector<int16_t>& samples) {
+  const uint16_t audio_format = 1;  // PCM
+  const uint16_t bits_per_sample = 16;
+  const uint16_t block_align = static_cast<uint16_t>((channels * bits_per_sample) / 8);
+  const uint32_t byte_rate = static_cast<uint32_t>(sample_rate_hz * block_align);
+  const uint32_t data_size = static_cast<uint32_t>(samples.size() * sizeof(int16_t));
+  const uint32_t riff_size = 4 + (8 + 16) + (8 + data_size);
+
+  std::ofstream out(path, std::ios::binary);
+  ASSERT_TRUE(out.is_open()) << "Failed to create temp WAV: " << path.string();
+
+  WriteBytes(out, "RIFF", 4);
+  WriteLe<uint32_t>(out, riff_size);
+  WriteBytes(out, "WAVE", 4);
+
+  WriteBytes(out, "fmt ", 4);
+  WriteLe<uint32_t>(out, 16);
+  WriteLe<uint16_t>(out, audio_format);
+  WriteLe<uint16_t>(out, static_cast<uint16_t>(channels));
+  WriteLe<uint32_t>(out, static_cast<uint32_t>(sample_rate_hz));
+  WriteLe<uint32_t>(out, byte_rate);
+  WriteLe<uint16_t>(out, block_align);
+  WriteLe<uint16_t>(out, bits_per_sample);
+
+  WriteBytes(out, "data", 4);
+  WriteLe<uint32_t>(out, data_size);
+  if (!samples.empty()) {
+    out.write(reinterpret_cast<const char*>(samples.data()),
+              static_cast<std::streamsize>(samples.size() * sizeof(int16_t)));
+  }
+}
+
+void WriteRawFile(const std::filesystem::path& path, const std::vector<uint8_t>& bytes) {
+  std::ofstream out(path, std::ios::binary);
+  ASSERT_TRUE(out.is_open()) << "Failed to create temp file: " << path.string();
+  if (!bytes.empty()) {
+    out.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+  }
+}
+
+class ScopedModelTypeOverride {
+ public:
+  ScopedModelTypeOverride(GenAIModelInstance& model, std::string model_type)
+      : cfg_(const_cast<GenAIConfig&>(model.GetGenAIConfig())), old_model_(cfg_.model) {
+    if (!cfg_.model.has_value()) {
+      cfg_.model = GenAIConfig::OnnxModel{};
+    }
+    cfg_.model->type = std::move(model_type);
+  }
+
+  ~ScopedModelTypeOverride() {
+    cfg_.model = old_model_;
+  }
+
+ private:
+  GenAIConfig& cfg_;
+  std::optional<GenAIConfig::OnnxModel> old_model_;
+};
+
+Request BuildOpenAiJsonAudioRequest(const std::filesystem::path& file_path) {
+  nlohmann::json req_json = {
+      {"model", "nemotron-speech-streaming-en-0.6b-generic-cpu"},
+      {"filename", file_path.string()},
+      {"language", "en"}};
+
+  Request request;
+  request.AddOwnedItem(std::make_unique<TextItem>(req_json.dump(), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+  return request;
 }
 
 }  // namespace
@@ -429,6 +513,145 @@ TEST_F(AudioSessionTest, OpenAIJsonWithInvalidJsonThrows) {
 
   Response response;
   EXPECT_THROW(session.ProcessRequest(request, response), nlohmann::json::parse_error);
+}
+
+TEST_F(AudioSessionTest, NemotronOpenAIJsonWithInvalidRiffThrows) {
+  AudioSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  ScopedModelTypeOverride force_nemotron(GetModel(), "nemotron_speech");
+  auto temp = fl::test::TempPath::CreateTempFile("audio_bad_riff_");
+  WriteRawFile(temp.path(), {0x4E, 0x4F, 0x54, 0x57});  // "NOTW"
+
+  auto request = BuildOpenAiJsonAudioRequest(temp.path());
+  Response response;
+
+  EXPECT_THROW(
+      {
+        try {
+          session.ProcessRequest(request, response);
+        } catch (const fl::Exception& e) {
+          EXPECT_EQ(e.code(), FOUNDRY_LOCAL_ERROR_INVALID_USAGE);
+          EXPECT_NE(std::string(e.what()).find("RIFF/WAVE"), std::string::npos);
+          throw;
+        }
+      },
+      fl::Exception);
+}
+
+TEST_F(AudioSessionTest, NemotronOpenAIJsonWithCorruptedChunkBoundsThrows) {
+  AudioSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  ScopedModelTypeOverride force_nemotron(GetModel(), "nemotron_speech");
+  auto temp = fl::test::TempPath::CreateTempFile("audio_bad_chunk_");
+
+  // RIFF/WAVE + a "data" chunk that claims size far larger than file content.
+  std::vector<uint8_t> bytes = {
+      'R', 'I', 'F', 'F', 0x24, 0x00, 0x00, 0x00, 'W', 'A', 'V', 'E',
+      'd', 'a', 't', 'a', 0xFF, 0xFF, 0x00, 0x00};
+  WriteRawFile(temp.path(), bytes);
+
+  auto request = BuildOpenAiJsonAudioRequest(temp.path());
+  Response response;
+
+  EXPECT_THROW(
+      {
+        try {
+          session.ProcessRequest(request, response);
+        } catch (const fl::Exception& e) {
+          EXPECT_EQ(e.code(), FOUNDRY_LOCAL_ERROR_INVALID_USAGE);
+          EXPECT_NE(std::string(e.what()).find("Corrupted WAV chunk"), std::string::npos);
+          throw;
+        }
+      },
+      fl::Exception);
+}
+
+TEST_F(AudioSessionTest, NemotronOpenAIJsonMissingFmtBeforeDataThrows) {
+  AudioSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  ScopedModelTypeOverride force_nemotron(GetModel(), "nemotron_speech");
+  auto temp = fl::test::TempPath::CreateTempFile("audio_missing_fmt_");
+
+  // Valid RIFF/WAVE header, but "data" appears before any "fmt " chunk.
+  std::vector<uint8_t> bytes = {
+      'R', 'I', 'F', 'F', 0x14, 0x00, 0x00, 0x00, 'W', 'A', 'V', 'E',
+      'd', 'a', 't', 'a', 0x00, 0x00, 0x00, 0x00};
+  WriteRawFile(temp.path(), bytes);
+
+  auto request = BuildOpenAiJsonAudioRequest(temp.path());
+  Response response;
+
+  EXPECT_THROW(
+      {
+        try {
+          session.ProcessRequest(request, response);
+        } catch (const fl::Exception& e) {
+          EXPECT_EQ(e.code(), FOUNDRY_LOCAL_ERROR_INVALID_USAGE);
+          EXPECT_NE(std::string(e.what()).find("Missing WAV fmt chunk before data"), std::string::npos);
+          throw;
+        }
+      },
+      fl::Exception);
+}
+
+TEST_F(AudioSessionTest, NemotronOpenAIJsonRejectsUnsupportedSampleRateBeforeDataRead) {
+  AudioSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  ScopedModelTypeOverride force_nemotron(GetModel(), "nemotron_speech");
+  auto temp = fl::test::TempPath::CreateTempFile("audio_bad_sr_");
+  // 8 kHz PCM WAV should fail fast in fmt parsing path.
+  WriteWavPcm16(temp.path(), /*sample_rate_hz=*/8000, /*channels=*/1, {0, 1, 2, 3});
+
+  auto request = BuildOpenAiJsonAudioRequest(temp.path());
+  Response response;
+
+  EXPECT_THROW(
+      {
+        try {
+          session.ProcessRequest(request, response);
+        } catch (const fl::Exception& e) {
+          EXPECT_EQ(e.code(), FOUNDRY_LOCAL_ERROR_INVALID_USAGE);
+          EXPECT_NE(std::string(e.what()).find("16kHz"), std::string::npos);
+          throw;
+        }
+      },
+      fl::Exception);
+}
+
+TEST_F(AudioSessionTest, NemotronOpenAIJsonRejectsUnsupportedWavFormatInFmtChunk) {
+  AudioSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  ScopedModelTypeOverride force_nemotron(GetModel(), "nemotron_speech");
+  auto temp = fl::test::TempPath::CreateTempFile("audio_bad_fmt_");
+
+  // RIFF/WAVE with fmt chunk that advertises PCM 24-bit (unsupported by this path).
+  std::ofstream out(temp.path(), std::ios::binary);
+  ASSERT_TRUE(out.is_open()) << "Failed to create temp WAV: " << temp.path().string();
+  WriteBytes(out, "RIFF", 4);
+  WriteLe<uint32_t>(out, 36);
+  WriteBytes(out, "WAVE", 4);
+  WriteBytes(out, "fmt ", 4);
+  WriteLe<uint32_t>(out, 16);
+  WriteLe<uint16_t>(out, 1);      // PCM
+  WriteLe<uint16_t>(out, 1);      // mono
+  WriteLe<uint32_t>(out, 16000);  // sample rate
+  WriteLe<uint32_t>(out, 48000);  // byte rate for 24-bit mono
+  WriteLe<uint16_t>(out, 3);      // block align
+  WriteLe<uint16_t>(out, 24);     // unsupported bits-per-sample
+  WriteBytes(out, "data", 4);
+  WriteLe<uint32_t>(out, 0);
+  out.flush();
+  out.close();
+
+  auto request = BuildOpenAiJsonAudioRequest(temp.path());
+  Response response;
+
+  EXPECT_THROW(
+      {
+        try {
+          session.ProcessRequest(request, response);
+        } catch (const fl::Exception& e) {
+          EXPECT_EQ(e.code(), FOUNDRY_LOCAL_ERROR_INVALID_USAGE);
+          EXPECT_NE(std::string(e.what()).find("Unsupported WAV format"), std::string::npos);
+          throw;
+        }
+      },
+      fl::Exception);
 }
 
 // ===========================================================================

--- a/sdk_v2/cpp/test/internal_api/audio/audio_session_test.cc
+++ b/sdk_v2/cpp/test/internal_api/audio/audio_session_test.cc
@@ -4,9 +4,7 @@
 // Validation tests exercise input checking without needing an audio model —
 // they throw before the generator is created, so any GenAIModelInstance works.
 
-#define private public
 #include "inferencing/generative/audio/audio_session.h"
-#undef private
 
 #include "ep_detection/ep_detector.h"
 #include "exception.h"
@@ -15,7 +13,6 @@
 #include "items/bytes_item.h"
 #include "items/item_queue.h"
 #include "items/speech_result_item.h"
-#include "items/text_item.h"
 #include "items/text_item.h"
 #include "logger.h"
 #include "model.h"
@@ -39,6 +36,15 @@
 #include <nlohmann/json.hpp>
 
 using namespace fl;
+
+namespace fl {
+class AudioSessionTestAccessor {
+ public:
+  static std::vector<float> LoadPcmWavAsFloatSamples(const std::string& audio_file_path) {
+    return AudioSession::LoadPcmWavAsFloatSamples(audio_file_path);
+  }
+};
+}  // namespace fl
 
 namespace {
 
@@ -139,6 +145,31 @@ void WriteWavFloat32(const std::filesystem::path& path, int sample_rate_hz, int 
   if (!samples.empty()) {
     out.write(reinterpret_cast<const char*>(samples.data()),
               static_cast<std::streamsize>(samples.size() * sizeof(float)));
+  }
+}
+
+void WriteWavWithDataChunkSize(const std::filesystem::path& path, uint32_t data_size) {
+  const uint32_t riff_size = 4 + (8 + 16) + (8 + data_size);
+  std::ofstream out(path, std::ios::binary);
+  ASSERT_TRUE(out.is_open()) << "Failed to create temp WAV: " << path.string();
+
+  WriteBytes(out, "RIFF", 4);
+  WriteLe<uint32_t>(out, riff_size);
+  WriteBytes(out, "WAVE", 4);
+  WriteBytes(out, "fmt ", 4);
+  WriteLe<uint32_t>(out, 16);
+  WriteLe<uint16_t>(out, 1);      // PCM
+  WriteLe<uint16_t>(out, 1);      // mono
+  WriteLe<uint32_t>(out, 16000);  // sample rate
+  WriteLe<uint32_t>(out, 32000);  // byte rate (16-bit mono at 16kHz)
+  WriteLe<uint16_t>(out, 2);      // block align
+  WriteLe<uint16_t>(out, 16);     // bits per sample
+  WriteBytes(out, "data", 4);
+  WriteLe<uint32_t>(out, data_size);
+
+  if (data_size > 0) {
+    out.seekp(static_cast<std::streamoff>(data_size) - 1, std::ios::cur);
+    out.put('\0');
   }
 }
 
@@ -764,11 +795,35 @@ TEST_F(AudioSessionTest, LoadPcmWavAsFloatSamples_DecodesFloat32Path) {
   const std::vector<float> input = {-0.75f, -0.25f, 0.0f, 0.25f, 0.75f};
   WriteWavFloat32(temp.path(), /*sample_rate_hz=*/16000, /*channels=*/1, input);
 
-  auto samples = AudioSession::LoadPcmWavAsFloatSamples(temp.path().string());
+  auto samples = fl::AudioSessionTestAccessor::LoadPcmWavAsFloatSamples(temp.path().string());
   ASSERT_EQ(samples.size(), input.size());
   for (size_t i = 0; i < input.size(); ++i) {
     EXPECT_NEAR(samples[i], input[i], 1e-6f);
   }
+}
+
+TEST_F(AudioSessionTest, NemotronOpenAIJsonRejectsOversizedWavDataChunkBeforeAllocation) {
+  AudioSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  ScopedModelTypeOverride force_nemotron(GetModel(), "nemotron_speech");
+
+  auto temp = fl::test::TempPath::CreateTempFile("audio_oversized_data_");
+  constexpr uint32_t kOversizedDataBytes = (64u * 1024u * 1024u) + 1u;
+  WriteWavWithDataChunkSize(temp.path(), kOversizedDataBytes);
+
+  auto request = BuildOpenAiJsonAudioRequest(temp.path());
+  Response response;
+
+  EXPECT_THROW(
+      {
+        try {
+          session.ProcessRequest(request, response);
+        } catch (const fl::Exception& e) {
+          EXPECT_EQ(e.code(), FOUNDRY_LOCAL_ERROR_INVALID_USAGE);
+          EXPECT_NE(std::string(e.what()).find("maximum supported size"), std::string::npos);
+          throw;
+        }
+      },
+      fl::Exception);
 }
 
 // ===========================================================================
@@ -894,5 +949,49 @@ TEST_F(AudioSessionNemotronInferenceTest, OpenAIJsonNemotronFileTranscriptionMul
   ASSERT_TRUE(resp_json.contains("text"));
   std::string text = resp_json["text"].get<std::string>();
   EXPECT_FALSE(text.empty()) << "Nemotron transcript should not be empty";
+  ExpectTranscriptionContent(text);
+}
+
+TEST_F(AudioSessionNemotronInferenceTest, OpenAIJsonNemotronFileTranscriptionAcceptsFloat32Wav) {
+  if (!model_) {
+    GTEST_SKIP() << "Nemotron model not loaded";
+  }
+
+  auto pcm_path = fl::test::GetTestDataPath("Recording.pcm");
+  ASSERT_TRUE(fs::exists(pcm_path)) << "Recording.pcm not found: " << pcm_path;
+
+  std::ifstream pcm_in(pcm_path, std::ios::binary);
+  ASSERT_TRUE(pcm_in.is_open()) << "Failed to open Recording.pcm";
+  std::vector<char> pcm_bytes((std::istreambuf_iterator<char>(pcm_in)), std::istreambuf_iterator<char>());
+  ASSERT_GT(pcm_bytes.size(), 0u);
+  ASSERT_EQ(pcm_bytes.size() % sizeof(int16_t), 0u) << "PCM file byte count must align to int16";
+
+  std::vector<float> float_samples(pcm_bytes.size() / sizeof(int16_t));
+  for (size_t i = 0; i < float_samples.size(); ++i) {
+    int16_t sample = 0;
+    std::memcpy(&sample, pcm_bytes.data() + (i * sizeof(int16_t)), sizeof(sample));
+    float_samples[i] = static_cast<float>(sample) / 32768.0f;
+  }
+
+  auto wav_temp = fl::test::TempPath::CreateTempFile("nemotron_float32_");
+  WriteWavFloat32(wav_temp.path(), /*sample_rate_hz=*/16000, /*channels=*/1, float_samples);
+
+  AudioSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  auto request = BuildOpenAiJsonAudioRequest(wav_temp.path());
+  request.options["language"] = "en";
+
+  Response response;
+  ASSERT_NO_THROW(session.ProcessRequest(request, response));
+  ASSERT_FALSE(response.items.empty()) << "No response items from Nemotron transcription";
+
+  const Item* first_item = response.items.front().get();
+  ASSERT_EQ(first_item->type, FOUNDRY_LOCAL_ITEM_TEXT);
+  const auto& text_item = static_cast<const TextItem&>(*first_item);
+  ASSERT_EQ(text_item.text_type, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON);
+
+  auto resp_json = nlohmann::json::parse(text_item.text);
+  ASSERT_TRUE(resp_json.contains("text"));
+  std::string text = resp_json["text"].get<std::string>();
+  EXPECT_FALSE(text.empty()) << "Nemotron float32 WAV transcript should not be empty";
   ExpectTranscriptionContent(text);
 }


### PR DESCRIPTION
## Add file-based Nemotron ASR transcription support in C++ SDK v2

## Summary

This PR completes file-based audio transcription support for Nemotron streaming ASR models in  sdk_v2/cpp  by finishing the C++  AudioSession  implementation and aligning behavior with the existing OpenAI-JSON transcription flow.

For more details, please refer to https://github.com/github/copilot-cli/issues/4024#issuecomment-4951658941

## What changed

• Implemented/finished Nemotron file transcription path in:
```
 sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc 
 sdk_v2/cpp/src/inferencing/generative/audio/audio_session.h 
```
• Added WAV file parsing for file-based transcription input:
• RIFF/WAVE validation
•  fmt / data  chunk handling with bounds checks
• 16kHz enforcement
• PCM16 and float32 decoding
• Added Nemotron-specific language runtime option mapping ( lang_id ) and temperature handling.
• Fixed decode flow to keep a single generator across incremental audio processing (100ms chunks + flush), which resolves truncated transcription output for file-based runs.

## Behavior

• OpenAI-JSON file transcription for Nemotron models now returns full transcript text from WAV input in SDK v2.
• Existing streaming and non-Nemotron paths remain unchanged.

## End-to-end scenario covered

• Model alias:  nemotron-3.5-asr-streaming-0.6b 
• Input:  sample-speech-1m-16k.wav 
• Path exercised: JS SDK v2  AudioClient.transcribe(...)  → C++ SDK v2 audio transcription pipeline