### PR TITLE
Fix broken links in C# documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,4 +26,4 @@ Foundry Local is a unified local AI runtime that supports both **text generation
 - [JavaScript: Chat + Audio](../samples/js/chat-and-audio-foundry-local/) — Unified chat and audio in one app
 - [JavaScript: Tool Calling](../samples/js/tool-calling-foundry-local/) — Function calling with local models
 - [JavaScript: Electron Chat App](../samples/js/electron-chat-application/) — Desktop chat application
-- [C#: Getting Started](../samples/cs/GettingStarted/) — C# SDK examples including audio transcription
+- [C#: Samples](../samples/cs/) — C# SDK examples including audio transcription

--- a/sdk/cs/test/FoundryLocal.Tests/LOCAL_MODEL_TESTING.md
+++ b/sdk/cs/test/FoundryLocal.Tests/LOCAL_MODEL_TESTING.md
@@ -20,5 +20,5 @@ The tests will automatically find the models in the configured test model cache 
 
 ```bash
 cd /path/to/parent-dir/foundry-local-sdk/sdk/cs/test/FoundryLocal.Tests
-dotnet test Microsoft.AI.Foundry.Local.Tests.csproj --configuration Release# Running Local Model Tests
+dotnet test Microsoft.AI.Foundry.Local.Tests.csproj --configuration Release
 ```


### PR DESCRIPTION
## Summary

- fix the malformed `dotnet test` command in the local model testing guide
- point the C# documentation entry to the existing samples index

## Validation

- verified both referenced paths exist
- ran `git diff --check`