### PR TITLE
Preserve HTTP errors when loading JS models

### DIFF
--- a/sdk/js/src/detail/modelLoadManager.ts
+++ b/sdk/js/src/detail/modelLoadManager.ts
@@ -27,13 +27,15 @@ export class ModelLoadManager {
     public async load(modelId: string): Promise<void> {
         if (this.externalServiceUrl) {
             const url = new URL(`models/load/${encodeURIComponent(modelId)}`, this.externalServiceUrl);
+            let response: Response;
             try {
-                const response = await fetch(url.toString(), { headers: this.headers });
-                if (!response.ok) {
-                    throw new Error(`Error loading model ${modelId} from ${this.externalServiceUrl}: ${response.statusText}`);
-                }
-            } catch (error: any) {
-                throw new Error(`Network error occurred while loading model ${modelId} from ${this.externalServiceUrl}: ${error.message}`);
+                response = await fetch(url.toString(), { headers: this.headers });
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                throw new Error(`Network error occurred while loading model ${modelId} from ${this.externalServiceUrl}: ${message}`);
+            }
+            if (!response.ok) {
+                throw new Error(`Error loading model ${modelId} from ${this.externalServiceUrl}: ${response.status} ${response.statusText}`);
             }
             return;
         }

--- a/sdk/js/test/detail/modelLoadManager.externalService.test.ts
+++ b/sdk/js/test/detail/modelLoadManager.externalService.test.ts
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import { ModelLoadManager } from '../../src/detail/modelLoadManager.js';
+
+describe('ModelLoadManager external service errors', function() {
+    let originalFetch: typeof globalThis.fetch;
+
+    beforeEach(function() {
+        originalFetch = globalThis.fetch;
+    });
+
+    afterEach(function() {
+        globalThis.fetch = originalFetch;
+    });
+
+    it('should report an HTTP error if the external service rejects the load request', async function() {
+        globalThis.fetch = async () => new Response(null, {
+            status: 404,
+            statusText: 'Not Found'
+        });
+        const manager = new ModelLoadManager({} as any, 'http://localhost:5273/');
+
+        try {
+            await manager.load('missing-model');
+            expect.fail('Should have thrown an HTTP error');
+        } catch (error) {
+            expect(error).to.be.instanceOf(Error);
+            expect((error as Error).message).to.equal(
+                'Error loading model missing-model from http://localhost:5273/: 404 Not Found'
+            );
+        }
+    });
+
+    it('should report a network error if the external service cannot be reached', async function() {
+        globalThis.fetch = async () => {
+            throw new Error('connection refused');
+        };
+        const manager = new ModelLoadManager({} as any, 'http://localhost:5273/');
+
+        try {
+            await manager.load('test-model');
+            expect.fail('Should have thrown a network error');
+        } catch (error) {
+            expect(error).to.be.instanceOf(Error);
+            expect((error as Error).message).to.equal(
+                'Network error occurred while loading model test-model from http://localhost:5273/: connection refused'
+            );
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- limit network error wrapping to failures thrown by `fetch`
- preserve unsuccessful HTTP responses as server errors with the status code
- add focused coverage for HTTP and transport failures

## Validation

- `npm test -- --grep "ModelLoadManager external service errors"`
- `npm run build`
- isolated TypeScript check for the changed source and test