### PR TITLE
Introduce winml trusted execution providers

### DIFF
--- a/sdk_v2/cpp/src/ep_detection/winml_ep_bootstrapper.cc
+++ b/sdk_v2/cpp/src/ep_detection/winml_ep_bootstrapper.cc
@@ -11,8 +11,11 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <string>
+#include <string_view>
 #include <vector>
 
 // WinML EP Catalog C API — delay-loaded via Microsoft.Windows.AI.MachineLearning.dll
@@ -25,6 +28,20 @@
 namespace fl {
 
 namespace {
+
+constexpr std::array<std::string_view, 6> kTrustedProviderNames = {
+    "MIGraphXExecutionProvider",
+    "NvTensorRtRtxExecutionProvider",
+    "OpenVINOExecutionProvider",
+    "QNNExecutionProvider",
+    "RyzenAILightExecutionProvider",
+    "VitisAIExecutionProvider",
+};
+
+bool IsTrustedProvider(std::string_view provider_name) {
+  return std::find(kTrustedProviderNames.begin(), kTrustedProviderNames.end(),
+                   provider_name) != kTrustedProviderNames.end();
+}
 
 /// Look up the running Windows build number via ``ntdll!RtlGetVersion``,
 /// resolved through ``GetProcAddress`` to avoid pulling ``<winternl.h>`` and
@@ -287,6 +304,9 @@ std::vector<std::unique_ptr<WinMLEpBootstrapper>> WinMLEpBootstrapper::DiscoverP
         auto* ctx = static_cast<EnumContext*>(context);
 
         std::string provider_name = info->name ? info->name : "";
+        if (!IsTrustedProvider(provider_name)) {
+          return TRUE;  // continue enumeration
+        }
 
         ctx->logger->Log(
             LogLevel::Information,

--- a/sdk_v2/cpp/src/ep_detection/winml_ep_bootstrapper.h
+++ b/sdk_v2/cpp/src/ep_detection/winml_ep_bootstrapper.h
@@ -46,7 +46,7 @@ class WinMLEpBootstrapper : public IEpBootstrapper {
                            const ProgressCallback& progress_cb,
                            ILogger& logger) override;
 
-  /// Discovers all WinML EPs available on this system.
+  /// Discovers trusted WinML EPs available on this system.
   /// Returns empty on unsupported OS version or missing WinML DLL.
   /// @param register_ep  Callback called after EnsureReady to register the EP with ORT.
   /// @param logger  Logger for diagnostic output.


### PR DESCRIPTION
webgpu execution provider should only be downloaded through the webgpuepbootstrapper. The duplicate webgpu ep available through winml eps breaks ep registration causing only cpu models to be visible.

This PR introduces trustedproviders for winml (that exclude webgpuep)