### PR TITLE
fix(python): guard empty choices on final streaming chunk

### DIFF
--- a/samples/python/native-chat-completions/src/app.py
+++ b/samples/python/native-chat-completions/src/app.py
@@ -51,6 +51,8 @@ def main():
     # Stream the response token by token
     print("Assistant: ", end="", flush=True)
     for chunk in client.complete_streaming_chat(messages):
+        if not chunk.choices:  # the final chunk can carry no choices
+            continue
         content = chunk.choices[0].delta.content
         if content:
             print(content, end="", flush=True)

--- a/samples/python/tutorial-chat-assistant/src/app.py
+++ b/samples/python/tutorial-chat-assistant/src/app.py
@@ -63,6 +63,8 @@ def main():
         print("Assistant: ", end="", flush=True)
         full_response = ""
         for chunk in client.complete_streaming_chat(messages):
+            if not chunk.choices:  # the final chunk can carry no choices
+                continue
             content = chunk.choices[0].delta.content
             if content:
                 print(content, end="", flush=True)

--- a/sdk/python/src/openai/chat_client.py
+++ b/sdk/python/src/openai/chat_client.py
@@ -270,6 +270,8 @@ class ChatClient:
         Consume with a standard ``for`` loop::
 
             for chunk in client.complete_streaming_chat(messages):
+                if not chunk.choices:  # the final chunk can carry no choices
+                    continue
                 if chunk.choices[0].delta.content:
                     print(chunk.choices[0].delta.content, end="", flush=True)
 


### PR DESCRIPTION
Related issue: #905
Supersedes #919 (closed after renaming the branch to remove the `/` so Azure Pipelines can resolve it).

## Problem
The final chunk yielded by `complete_streaming_chat` can carry an empty `choices` list. The documented example in `chat_client.py` and the streaming samples indexed `chunk.choices[0]` unconditionally, raising `IndexError` after the full response had already been produced.

## Fix
Guard with `if not chunk.choices: continue` in:
- `sdk/python/src/openai/chat_client.py` (documented example in the docstring)
- `samples/python/native-chat-completions/src/app.py`
- `samples/python/tutorial-chat-assistant/src/app.py`

## Testing
Reproduced on macOS (arm64), Python 3.13, foundry-local-sdk 1.2.3, model qwen2.5-0.5b via the WebGPU EP. After the fix, streaming completes cleanly with no exception — verified with the interactive `app.py` over a 3-turn conversation and a single-prompt run.
