### PR TITLE
Update website CLI release links

### DIFF
--- a/www/src/lib/cli-downloads.ts
+++ b/www/src/lib/cli-downloads.ts
@@ -1,0 +1,29 @@
+export const FOUNDRY_LOCAL_RELEASES_URL = 'https://github.com/microsoft/Foundry-Local/releases';
+
+export type CliDownloadLink = {
+	id: 'windows-cli' | 'macos-cli' | 'linux-cli';
+	label: string;
+	href: string;
+	releaseLabel: string;
+};
+
+export const fallbackCliDownloadLinks: CliDownloadLink[] = [
+	{
+		id: 'windows-cli',
+		label: 'Windows',
+		href: FOUNDRY_LOCAL_RELEASES_URL,
+		releaseLabel: 'GitHub releases'
+	},
+	{
+		id: 'macos-cli',
+		label: 'macOS',
+		href: FOUNDRY_LOCAL_RELEASES_URL,
+		releaseLabel: 'GitHub releases'
+	},
+	{
+		id: 'linux-cli',
+		label: 'Linux',
+		href: FOUNDRY_LOCAL_RELEASES_URL,
+		releaseLabel: 'GitHub releases'
+	}
+];

--- a/www/src/lib/components/download-dropdown.svelte
+++ b/www/src/lib/components/download-dropdown.svelte
@@ -6,7 +6,7 @@
 	import { IsMobile } from '$lib/hooks/is-mobile.svelte';
 
 	const CLI_RELEASE_URL =
-		'https://github.com/microsoft/Foundry-Local/releases/tag/cli-preview-0.10.0';
+		'https://github.com/microsoft/Foundry-Local/releases';
 
 	interface Props {
 		variant?: 'default' | 'ghost' | 'outline';
@@ -195,7 +195,7 @@
 							<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html item.icon}</span>
 							<div class="flex flex-1 flex-col gap-1 px-2">
 								<span class="font-medium">{item.label}</span>
-								<code class="text-muted-foreground text-xs break-all">cli-preview-0.10.0 on GitHub</code>
+								<code class="text-muted-foreground text-xs break-all">GitHub releases</code>
 							</div>
 							<ExternalLink class="size-4 shrink-0 opacity-50" aria-hidden="true" />
 						</a>

--- a/www/src/lib/components/download-dropdown.svelte
+++ b/www/src/lib/components/download-dropdown.svelte
@@ -4,9 +4,8 @@
 	import { Download, Copy, Check, ExternalLink } from 'lucide-svelte';
 	import { toast } from 'svelte-sonner';
 	import { IsMobile } from '$lib/hooks/is-mobile.svelte';
-
-	const CLI_RELEASE_URL =
-		'https://github.com/microsoft/Foundry-Local/releases';
+	import { page } from '$app/stores';
+	import { fallbackCliDownloadLinks, type CliDownloadLink } from '$lib/cli-downloads';
 
 	interface Props {
 		variant?: 'default' | 'ghost' | 'outline';
@@ -43,6 +42,7 @@
 		id: string;
 		label: string;
 		href: string;
+		releaseLabel: string;
 		icon: string;
 	};
 
@@ -54,26 +54,20 @@
 		crossPlatformCommand: string;
 	};
 
-	const cliInstallOptions: CliInstallOption[] = [
-		{
-			id: 'windows',
-			label: 'Windows CLI',
-			href: CLI_RELEASE_URL,
-			icon: WindowsIcon
-		},
-		{
-			id: 'macos',
-			label: 'macOS CLI',
-			href: CLI_RELEASE_URL,
-			icon: AppleIcon
-		},
-		{
-			id: 'linux',
-			label: 'Linux CLI',
-			href: CLI_RELEASE_URL,
-			icon: LinuxIcon
-		}
-	];
+	const cliIcons = {
+		'windows-cli': WindowsIcon,
+		'macos-cli': AppleIcon,
+		'linux-cli': LinuxIcon
+	};
+
+	function getCliInstallOptions(): CliInstallOption[] {
+		const links = ($page.data.cliDownloadLinks as CliDownloadLink[] | undefined) ?? fallbackCliDownloadLinks;
+		return links.map((link) => ({
+			...link,
+			label: `${link.label} CLI`,
+			icon: cliIcons[link.id]
+		}));
+	}
 
 	const sdkInstallOptions: SdkInstallOption[] = [
 		{
@@ -181,7 +175,7 @@
 		</DropdownMenu.Label>
 
 		<DropdownMenu.Group>
-			{#each cliInstallOptions as item}
+			{#each getCliInstallOptions() as item}
 				<DropdownMenu.Item class="p-0">
 					{#snippet child({ props })}
 						<a
@@ -195,7 +189,7 @@
 							<span class="mt-0.5 inline-flex shrink-0" aria-hidden="true">{@html item.icon}</span>
 							<div class="flex flex-1 flex-col gap-1 px-2">
 								<span class="font-medium">{item.label}</span>
-								<code class="text-muted-foreground text-xs break-all">GitHub releases</code>
+								<code class="text-muted-foreground text-xs break-all">{item.releaseLabel}</code>
 							</div>
 							<ExternalLink class="size-4 shrink-0 opacity-50" aria-hidden="true" />
 						</a>

--- a/www/src/lib/server/cli-release.ts
+++ b/www/src/lib/server/cli-release.ts
@@ -1,0 +1,86 @@
+import { FOUNDRY_LOCAL_RELEASES_URL, fallbackCliDownloadLinks, type CliDownloadLink } from '$lib/cli-downloads';
+
+type GitHubReleaseAsset = {
+	name: string;
+	browser_download_url: string;
+};
+
+type GitHubRelease = {
+	tag_name: string;
+	html_url: string;
+	assets?: GitHubReleaseAsset[];
+};
+
+type FetchLike = typeof fetch;
+
+const RELEASES_API_URL = 'https://api.github.com/repos/microsoft/Foundry-Local/releases';
+const CLI_PREVIEW_TAG = /^cli-preview-(\d+)\.(\d+)\.(\d+)$/i;
+
+export async function getCliDownloadLinks(fetcher: FetchLike): Promise<CliDownloadLink[]> {
+	try {
+		const response = await fetcher(RELEASES_API_URL, {
+			headers: { Accept: 'application/vnd.github+json' }
+		});
+
+		if (!response.ok) {
+			return fallbackCliDownloadLinks;
+		}
+
+		const releases = (await response.json()) as GitHubRelease[];
+		const latestCliRelease = releases
+			.filter((release) => CLI_PREVIEW_TAG.test(release.tag_name))
+			.sort((left, right) => compareCliPreviewTags(right.tag_name, left.tag_name))[0];
+
+		if (!latestCliRelease?.assets?.length) {
+			return fallbackCliDownloadLinks;
+		}
+
+		return buildCliDownloadLinks(latestCliRelease);
+	} catch {
+		return fallbackCliDownloadLinks;
+	}
+}
+
+function compareCliPreviewTags(left: string, right: string): number {
+	const leftVersion = parseCliPreviewTag(left);
+	const rightVersion = parseCliPreviewTag(right);
+
+	for (let i = 0; i < leftVersion.length; i++) {
+		const delta = leftVersion[i] - rightVersion[i];
+		if (delta !== 0) return delta;
+	}
+
+	return 0;
+}
+
+function parseCliPreviewTag(tag: string): [number, number, number] {
+	const match = CLI_PREVIEW_TAG.exec(tag);
+	if (!match) return [0, 0, 0];
+	return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function buildCliDownloadLinks(release: GitHubRelease): CliDownloadLink[] {
+	const fallbackById = new Map(fallbackCliDownloadLinks.map((link) => [link.id, link]));
+	const releaseLabel = release.tag_name;
+
+	return [
+		buildLink(fallbackById.get('windows-cli')!, release, releaseLabel, /win-x64-winml\.msix$/i),
+		buildLink(fallbackById.get('macos-cli')!, release, releaseLabel, /osx-arm64\.pkg$/i),
+		buildLink(fallbackById.get('linux-cli')!, release, releaseLabel, /linux-x64\.tar\.gz$/i)
+	];
+}
+
+function buildLink(
+	fallback: CliDownloadLink,
+	release: GitHubRelease,
+	releaseLabel: string,
+	assetPattern: RegExp
+): CliDownloadLink {
+	const asset = release.assets?.find((candidate) => assetPattern.test(candidate.name));
+
+	return {
+		...fallback,
+		href: asset?.browser_download_url ?? release.html_url ?? FOUNDRY_LOCAL_RELEASES_URL,
+		releaseLabel: asset ? releaseLabel : 'GitHub releases'
+	};
+}

--- a/www/src/routes/+layout.server.ts
+++ b/www/src/routes/+layout.server.ts
@@ -1,0 +1,7 @@
+import { getCliDownloadLinks } from '$lib/server/cli-release';
+
+export async function load({ fetch }) {
+	return {
+		cliDownloadLinks: await getCliDownloadLinks(fetch)
+	};
+}

--- a/www/src/routes/models/+page.svelte
+++ b/www/src/routes/models/+page.svelte
@@ -20,7 +20,7 @@
 	const MODEL_QUERY_PARAM = 'model';
 	const CLI_RUN_COMMAND = 'foundry run qwen2.5-0.5b';
 	const CLI_RELEASE_URL =
-		'https://github.com/microsoft/Foundry-Local/releases/tag/cli-preview-0.10.0';
+		'https://github.com/microsoft/Foundry-Local/releases';
 	const CLI_INSTALL_LINKS = [
 		{
 			id: 'windows-cli',

--- a/www/src/routes/models/+page.svelte
+++ b/www/src/routes/models/+page.svelte
@@ -14,30 +14,15 @@
 	import { ModelFilters, ModelGrid, ModelDetailsModal } from './components';
 	import { Terminal, Copy, Check, ExternalLink } from 'lucide-svelte';
 	import { detectModelFamily } from '$lib/utils/model-helpers';
+	import { fallbackCliDownloadLinks, type CliDownloadLink } from '$lib/cli-downloads';
 
 	// Known device names used as shorthand URL params (e.g. /models?cpu)
 	const KNOWN_DEVICES = ['cpu', 'gpu', 'npu'];
 	const MODEL_QUERY_PARAM = 'model';
 	const CLI_RUN_COMMAND = 'foundry run qwen2.5-0.5b';
-	const CLI_RELEASE_URL =
-		'https://github.com/microsoft/Foundry-Local/releases';
-	const CLI_INSTALL_LINKS = [
-		{
-			id: 'windows-cli',
-			label: 'Windows',
-			href: CLI_RELEASE_URL
-		},
-		{
-			id: 'macos-cli',
-			label: 'macOS',
-			href: CLI_RELEASE_URL
-		},
-		{
-			id: 'linux-cli',
-			label: 'Linux',
-			href: CLI_RELEASE_URL
-		}
-	];
+	function getCliInstallLinks(): CliDownloadLink[] {
+		return ($page.data.cliDownloadLinks as CliDownloadLink[] | undefined) ?? fallbackCliDownloadLinks;
+	}
 
 	// Debounce timer for search
 	let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -535,7 +520,7 @@
 					<div
 						class="grid min-w-0 flex-1 gap-2 md:grid-cols-[repeat(3,minmax(6rem,auto))_minmax(18rem,1fr)]"
 					>
-						{#each CLI_INSTALL_LINKS as item}
+						{#each getCliInstallLinks() as item}
 							<a
 								href={item.href}
 								target="_blank"


### PR DESCRIPTION
## Summary
- Resolve the latest `cli-preview-*` GitHub release at website build/server time.
- Generate platform-specific CLI download links from the latest release assets for Windows, macOS, and Linux.
- Keep a safe fallback to the Foundry Local releases page if GitHub release discovery or asset matching fails.
- Wire the home download dropdown and models page CLI links to the same resolved download data.

## Validation
- Confirmed no remaining `cli-preview-0.10.0` / `releases/tag/cli-preview` references in the touched website files.
- Confirmed the built `/models` page data resolves `cli-preview-0.10.2` direct asset links for Windows, macOS, and Linux.
- `git diff --check`
- `npm run build`

Notes: `npm run check` and `npm run lint` currently fail on pre-existing website type/formatting issues unrelated to this change. No `svelte-check` diagnostics were reported for the files touched by this PR.

Fixes #924