### PR TITLE
fix(python): guard empty choices on final streaming chunk- #922

### DIFF
--- a/samples/python/native-chat-completions/src/app.py
+++ b/samples/python/native-chat-completions/src/app.py
@@ -51,6 +51,8 @@ def main():
     # Stream the response token by token
     print("Assistant: ", end="", flush=True)
     for chunk in client.complete_streaming_chat(messages):
+        if not chunk.choices:  # the final chunk can carry no choices
+            continue
         content = chunk.choices[0].delta.content
         if content:
             print(content, end="", flush=True)

--- a/samples/python/tutorial-chat-assistant/src/app.py
+++ b/samples/python/tutorial-chat-assistant/src/app.py
@@ -63,6 +63,8 @@ def main():
         print("Assistant: ", end="", flush=True)
         full_response = ""
         for chunk in client.complete_streaming_chat(messages):
+            if not chunk.choices:  # the final chunk can carry no choices
+                continue
             content = chunk.choices[0].delta.content
             if content:
                 print(content, end="", flush=True)


### PR DESCRIPTION
Related issue: https://github.com/microsoft/Foundry-Local/issues/905

## Problem
The final chunk yielded by `complete_streaming_chat` can carry an empty `choices` list. The documented example in `chat_client.py` and the streaming samples indexed `chunk.choices[0]` unconditionally, raising `IndexError` **after** the full response had already been produced.

## Fix
Guard with `if not chunk.choices: continue` in:
- `samples/python/native-chat-completions/src/app.py`
- `samples/python/tutorial-chat-assistant/src/app.py`

## Testing
Reproduced on macOS (arm64), Python 3.13, `foundry-local-sdk` 1.2.3, model `qwen2.5-0.5b` via the WebGPU EP. After the fix, streaming completes cleanly with no exception — verified with the interactive `app.py` over a 3-turn conversation and a single-prompt run.