### PR TITLE
Restrict WinML discovery to trusted execution providers

### DIFF
--- a/sdk_v2/cpp/src/ep_detection/winml_ep_bootstrapper.cc
+++ b/sdk_v2/cpp/src/ep_detection/winml_ep_bootstrapper.cc
@@ -7,6 +7,7 @@
 // header (and this file) unconditionally reference WinML 2.x catalog APIs.
 #include "ep_detection/winml_ep_bootstrapper.h"
 
+#include "ep_detection/winml_provider_allowlist.h"
 #include "logger.h"
 
 #include <fmt/format.h>
@@ -287,6 +288,11 @@ std::vector<std::unique_ptr<WinMLEpBootstrapper>> WinMLEpBootstrapper::DiscoverP
         auto* ctx = static_cast<EnumContext*>(context);
 
         std::string provider_name = info->name ? info->name : "";
+        if (!IsTrustedWinMLProvider(provider_name)) {
+          ctx->logger->Log(LogLevel::Information,
+                           fmt::format("WinML EP ignored because it is not trusted: {}", provider_name));
+          return TRUE;
+        }
 
         ctx->logger->Log(
             LogLevel::Information,
@@ -314,7 +320,7 @@ std::vector<std::unique_ptr<WinMLEpBootstrapper>> WinMLEpBootstrapper::DiscoverP
       &ctx);
 
   logger.Log(LogLevel::Information,
-             fmt::format("WinML EP catalog: discovered {} provider(s)", ctx.bootstrappers.size()));
+             fmt::format("WinML EP catalog: discovered {} trusted provider(s)", ctx.bootstrappers.size()));
 
   return std::move(ctx.bootstrappers);
 }

--- a/sdk_v2/cpp/src/ep_detection/winml_ep_bootstrapper.h
+++ b/sdk_v2/cpp/src/ep_detection/winml_ep_bootstrapper.h
@@ -46,7 +46,11 @@ class WinMLEpBootstrapper : public IEpBootstrapper {
                            const ProgressCallback& progress_cb,
                            ILogger& logger) override;
 
-  /// Discovers all WinML EPs available on this system.
+  /// Discovers WinML EPs available on this system.
+  /// EPs discoverable are trusted EPs that have valid Foundry Local models available
+  /// for download in the model catalog. The WinML EPs returned from this function also
+  /// filter out any EP that may conflict with other non-WinML EPs that Foundry Local
+  /// supports (e.g., WebGpuExecutionProvider).
   /// Returns empty on unsupported OS version or missing WinML DLL.
   /// @param register_ep  Callback called after EnsureReady to register the EP with ORT.
   /// @param logger  Logger for diagnostic output.

--- a/sdk_v2/cpp/src/ep_detection/winml_provider_allowlist.h
+++ b/sdk_v2/cpp/src/ep_detection/winml_provider_allowlist.h
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <string_view>
+
+namespace fl {
+
+inline bool IsTrustedWinMLProvider(std::string_view provider_name) {
+  constexpr std::array<std::string_view, 6> trusted_provider_names = {
+      "MIGraphXExecutionProvider",
+      "NvTensorRtRtxExecutionProvider",
+      "OpenVINOExecutionProvider",
+      "QNNExecutionProvider",
+      "RyzenAILightExecutionProvider",
+      "VitisAIExecutionProvider",
+  };
+
+  const auto equals_ignore_case = [](std::string_view lhs, std::string_view rhs) {
+    return lhs.size() == rhs.size() &&
+           std::equal(lhs.begin(), lhs.end(), rhs.begin(), [](char lhs_char, char rhs_char) {
+             return std::tolower(static_cast<unsigned char>(lhs_char)) ==
+                    std::tolower(static_cast<unsigned char>(rhs_char));
+           });
+  };
+
+  return std::any_of(trusted_provider_names.begin(), trusted_provider_names.end(),
+                     [provider_name, equals_ignore_case](std::string_view trusted_name) {
+                       return equals_ignore_case(provider_name, trusted_name);
+                     });
+}
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/manager.cc
+++ b/sdk_v2/cpp/src/manager.cc
@@ -7,7 +7,6 @@
 #include <ort_genai_c.h>
 
 #include <atomic>
-#include <set>
 #include <string_view>
 
 #include "catalog.h"
@@ -245,40 +244,17 @@ Manager::Manager(const Configuration& config)
   // Discover bootstrappers from available EP sources
   std::vector<std::unique_ptr<IEpBootstrapper>> bootstrappers;
 
-  // Detected once and reused below for both the WinML-catalog skip-list and the
-  // Foundry CUDA bootstrapper. HasNvidiaGpu() shells out to nvidia-smi, so caching
-  // the result here avoids a second subprocess spawn.
+  // Detected once and reused below for the Foundry CUDA bootstrapper. HasNvidiaGpu()
+  // shells out to nvidia-smi, so caching the result here avoids a second subprocess spawn.
   const bool has_nvidia_gpu = CudaEpBootstrapper::HasNvidiaGpu();
 
 #if FOUNDRY_LOCAL_HAS_EP_CATALOG
   // WinML EPs — enumerate from the OS EP catalog (Windows 10 19H1+ reg-free runtime).
   // Only present when the WinML EP catalog NuGet package was successfully resolved
   // at CMake time (gated on WinMLEpCatalog_FOUND in sdk_v2/cpp/CMakeLists.txt).
-  //
-  // Skip catalog entries for EPs that Foundry installs and registers itself through
-  // the CDN bootstrappers below — WebGPU always, and CUDA when an NVIDIA GPU is
-  // present. For WebGPU the catalog reports a library path next to onnxruntime.dll
-  // rather than the Foundry cache where the EP is actually installed; that path is
-  // absent in our deployments, so keeping the catalog entry would add a second
-  // bootstrapper for the same provider with a non-existent path and leave
-  // GetDiscoverableEps reporting the EP as unregistered even after the Foundry
-  // bootstrapper registered it under the correct cache path. Names are stored
-  // lowercase and matched case-insensitively because the provider name's casing
-  // ("WebGpu" vs "WebGPU") is not consistent across sources.
-  std::set<std::string> foundry_managed_ep_names;
-  foundry_managed_ep_names.insert("webgpuexecutionprovider");
-  if (has_nvidia_gpu) {
-    foundry_managed_ep_names.insert("cudaexecutionprovider");
-  }
 
   auto winml_providers = WinMLEpBootstrapper::DiscoverProviders(register_ep, *logger_);
   for (auto& p : winml_providers) {
-    if (foundry_managed_ep_names.count(ToLower(p->Name())) != 0) {
-      logger_->Log(LogLevel::Information,
-                   "WinML EP skipped: " + p->Name() +
-                       " (Foundry installs and registers this EP via its own bootstrapper)");
-      continue;
-    }
     bootstrappers.push_back(std::move(p));
   }
 #endif

--- a/sdk_v2/cpp/test/CMakeLists.txt
+++ b/sdk_v2/cpp/test/CMakeLists.txt
@@ -59,6 +59,7 @@ add_executable(foundry_local_tests
     internal_api/toolcalling/grammar_test.cc
     internal_api/utils_test.cc
     internal_api/web_service_test.cc
+    internal_api/winml_provider_allowlist_test.cc
     internal_api/zip_extract_test.cc
 )
 

--- a/sdk_v2/cpp/test/internal_api/winml_provider_allowlist_test.cc
+++ b/sdk_v2/cpp/test/internal_api/winml_provider_allowlist_test.cc
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "ep_detection/winml_provider_allowlist.h"
+
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+using namespace fl;
+
+TEST(WinMLProviderAllowlistTest, AcceptsKnownProvidersCaseInsensitively) {
+  constexpr std::string_view trusted_providers[] = {
+      "MIGraphXExecutionProvider",
+      "NvTensorRtRtxExecutionProvider",
+      "NvTensorRTRTXExecutionProvider",
+      "OpenVINOExecutionProvider",
+      "QNNExecutionProvider",
+      "qnnexecutionprovider",
+      "RyzenAILightExecutionProvider",
+      "VitisAIExecutionProvider",
+  };
+
+  for (const auto provider : trusted_providers) {
+    EXPECT_TRUE(IsTrustedWinMLProvider(provider)) << provider;
+  }
+}
+
+TEST(WinMLProviderAllowlistTest, RejectsUnapprovedProviders) {
+  constexpr std::string_view unapproved_providers[] = {
+      "",
+      "WebGPUExecutionProvider",
+      "CPUExecutionProvider",
+      "DmlExecutionProvider",
+      "FutureExecutionProvider",
+  };
+
+  for (const auto provider : unapproved_providers) {
+    EXPECT_FALSE(IsTrustedWinMLProvider(provider)) << provider;
+  }
+}

--- a/sdk_v2/cpp/test/internal_api/winml_provider_allowlist_test.cc
+++ b/sdk_v2/cpp/test/internal_api/winml_provider_allowlist_test.cc
@@ -30,6 +30,7 @@ TEST(WinMLProviderAllowlistTest, RejectsUnapprovedProviders) {
   constexpr std::string_view unapproved_providers[] = {
       "",
       "WebGPUExecutionProvider",
+      "CUDAExecutionProvider",
       "CPUExecutionProvider",
       "DmlExecutionProvider",
       "FutureExecutionProvider",


### PR DESCRIPTION
Adds a case-insensitive allowlist for WinML execution providers. Untrusted providers are ignored during catalog discovery.

WebGPU ep was being discovered from winml ep catalog as well as from FL's ep catalog causing a conflict. This PR filters our webgpu ep from winml ep catalog.