### PR TITLE
Restore image_data input compatibility

### DIFF
--- a/sdk_v2/cpp/src/contracts/responses.h
+++ b/sdk_v2/cpp/src/contracts/responses.h
@@ -27,6 +27,8 @@ struct InputTextContent {
 struct InputImageContent {
   std::string detail;
   std::optional<std::string> image_url;
+  // Foundry Local v1 extension: raw base64 image payload. image_url takes precedence when both are supplied.
+  std::optional<std::string> image_data;
   std::optional<std::string> file_id;
   // Optional MIME type ("image/png", "image/jpeg", ...). Required by the
   // OpenAI spec when `image_url` is anything other than a `data:` URL,

--- a/sdk_v2/cpp/src/contracts/responses_json.cc
+++ b/sdk_v2/cpp/src/contracts/responses_json.cc
@@ -112,6 +112,7 @@ void from_json(const nlohmann::json& j, InputTextContent& c) {
 void from_json(const nlohmann::json& j, InputImageContent& c) {
   c.detail = j.value("detail", "auto");
   opt_str(j, "image_url", c.image_url);
+  opt_str(j, "image_data", c.image_data);
   opt_str(j, "file_id", c.file_id);
   opt_str(j, "media_type", c.media_type);
 }

--- a/sdk_v2/cpp/src/inferencing/generative/openresponses/response_converter.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/openresponses/response_converter.cc
@@ -259,31 +259,36 @@ std::unique_ptr<ImageItem> MakeImageItemFromLocalFile(const std::string& url,
 }
 
 std::unique_ptr<ImageItem> MakeImageItemFromInputImage(const InputImageContent& c) {
-  if (c.file_id.has_value() && !c.file_id->empty()) {
+  if (c.image_url.has_value() && !c.image_url->empty()) {
+    const std::string& url = *c.image_url;
+
+    if (url.compare(0, kDataUrlPrefix.size(), kDataUrlPrefix) == 0) {
+      return MakeImageItemFromDataUrl(url);
+    }
+
+    // file:// URI or absolute local path.
+    if (url.compare(0, kFileScheme.size(), kFileScheme) == 0 ||
+        (url.size() >= 2 && (url[0] == '/' || url[0] == '\\' ||
+                             (url.size() >= 3 && url[1] == ':' && (url[2] == '/' || url[2] == '\\'))))) {
+      return MakeImageItemFromLocalFile(url, c.media_type);
+    }
+
     FL_THROW(FOUNDRY_LOCAL_ERROR_NOT_IMPLEMENTED,
-             "image input via file_id is not supported on Foundry Local");
+             "image_url must be a data: URL or a local file path; remote http(s) URLs are not supported");
   }
 
-  if (!c.image_url.has_value() || c.image_url->empty()) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-             "input_image content requires a non-empty image_url or file_id");
+  if (c.image_data.has_value() && !c.image_data->empty()) {
+    const std::string media_type =
+        c.media_type.has_value() && !c.media_type->empty() ? *c.media_type : "image/png";
+    return MakeImageItemFromDataUrl("data:" + media_type + ";base64," + *c.image_data);
   }
 
-  const std::string& url = *c.image_url;
-
-  if (url.compare(0, kDataUrlPrefix.size(), kDataUrlPrefix) == 0) {
-    return MakeImageItemFromDataUrl(url);
+  if (c.file_id.has_value() && !c.file_id->empty()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_NOT_IMPLEMENTED, "image input via file_id is not supported on Foundry Local");
   }
 
-  // file:// URI or absolute local path.
-  if (url.compare(0, kFileScheme.size(), kFileScheme) == 0 ||
-      (url.size() >= 2 && (url[0] == '/' || url[0] == '\\' ||
-                           (url.size() >= 3 && url[1] == ':' && (url[2] == '/' || url[2] == '\\'))))) {
-    return MakeImageItemFromLocalFile(url, c.media_type);
-  }
-
-  FL_THROW(FOUNDRY_LOCAL_ERROR_NOT_IMPLEMENTED,
-           "image_url must be a data: URL or a local file path; remote http(s) URLs are not supported");
+  FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+           "input_image content requires a non-empty image_url, image_data, or file_id");
 }
 
 }  // namespace

--- a/sdk_v2/cpp/src/inferencing/generative/openresponses/response_converter.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/openresponses/response_converter.cc
@@ -188,7 +188,7 @@ std::string MimeFromExtension(const std::string& path) {
   return {};
 }
 
-std::unique_ptr<ImageItem> MakeImageItemFromDataUrl(const std::string& url) {
+std::unique_ptr<ImageItem> MakeImageItemFromDataUrl(const std::string& url, std::string_view error_source) {
   // Format: "data:<media-type>;base64,<payload>"
   // Strict: we require base64 encoding (not raw text) and a `;base64,`
   // marker. Anything else throws — vision models can't consume non-base64
@@ -196,7 +196,7 @@ std::unique_ptr<ImageItem> MakeImageItemFromDataUrl(const std::string& url) {
   auto comma = url.find(',');
   if (comma == std::string::npos) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-             "image_url data URL is missing payload separator ','");
+             std::string(error_source) + " is missing payload separator ','");
   }
 
   std::string header = url.substr(kDataUrlPrefix.size(), comma - kDataUrlPrefix.size());
@@ -204,8 +204,7 @@ std::unique_ptr<ImageItem> MakeImageItemFromDataUrl(const std::string& url) {
   constexpr std::string_view kBase64Marker = ";base64";
   auto base64_pos = header.find(kBase64Marker);
   if (base64_pos == std::string::npos) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-             "image_url data URL must use ';base64,' encoding");
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, std::string(error_source) + " must use ';base64,' encoding");
   }
 
   std::string media_type = header.substr(0, base64_pos);
@@ -216,11 +215,11 @@ std::unique_ptr<ImageItem> MakeImageItemFromDataUrl(const std::string& url) {
     bytes = Azure::Core::Convert::Base64Decode(payload);
   } catch (const std::exception& e) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-             std::string("image_url data URL has invalid base64 payload: ") + e.what());
+             std::string(error_source) + " has invalid base64 payload: " + e.what());
   }
 
   if (bytes.empty()) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "image_url data URL decoded to zero bytes");
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, std::string(error_source) + " decoded to zero bytes");
   }
 
   return std::make_unique<ImageItem>(std::move(bytes), std::move(media_type));
@@ -263,7 +262,7 @@ std::unique_ptr<ImageItem> MakeImageItemFromInputImage(const InputImageContent& 
     const std::string& url = *c.image_url;
 
     if (url.compare(0, kDataUrlPrefix.size(), kDataUrlPrefix) == 0) {
-      return MakeImageItemFromDataUrl(url);
+      return MakeImageItemFromDataUrl(url, "image_url data URL");
     }
 
     // file:// URI or absolute local path.
@@ -280,7 +279,7 @@ std::unique_ptr<ImageItem> MakeImageItemFromInputImage(const InputImageContent& 
   if (c.image_data.has_value() && !c.image_data->empty()) {
     const std::string media_type =
         c.media_type.has_value() && !c.media_type->empty() ? *c.media_type : "image/png";
-    return MakeImageItemFromDataUrl("data:" + media_type + ";base64," + *c.image_data);
+    return MakeImageItemFromDataUrl("data:" + media_type + ";base64," + *c.image_data, "image_data");
   }
 
   if (c.file_id.has_value() && !c.file_id->empty()) {

--- a/sdk_v2/cpp/test/internal_api/response_converter_test.cc
+++ b/sdk_v2/cpp/test/internal_api/response_converter_test.cc
@@ -388,6 +388,19 @@ TEST(ResponseConverterTest, ToSessionRequest_InputImage_ImageData_DefaultsToPng)
   EXPECT_EQ(img->format, "image/png");
 }
 
+TEST(ResponseConverterTest, ToSessionRequest_InputImage_InvalidImageData_NamesSourceField) {
+  auto params = MakeImageDataRequest("not-valid-base64");
+
+  try {
+    ToSessionRequest(params);
+    FAIL() << "Expected invalid image_data to throw";
+  } catch (const std::exception& e) {
+    const std::string message = e.what();
+    EXPECT_NE(message.find("image_data"), std::string::npos);
+    EXPECT_EQ(message.find("image_url"), std::string::npos);
+  }
+}
+
 TEST(ResponseConverterTest, ToSessionRequest_InputImage_ImageUrlTakesPrecedenceOverImageData) {
   std::string data_url = std::string("data:image/png;base64,") + kSamplePngBase64;
   auto params = MakeImageRequest(data_url);

--- a/sdk_v2/cpp/test/internal_api/response_converter_test.cc
+++ b/sdk_v2/cpp/test/internal_api/response_converter_test.cc
@@ -320,6 +320,23 @@ ResponseCreateParams MakeImageRequest(const std::string& image_url, const std::s
   return params;
 }
 
+ResponseCreateParams MakeImageDataRequest(const std::string& image_data,
+                                          const std::optional<std::string>& media_type = std::nullopt) {
+  ResponseCreateParams params;
+  params.model = "test-model";
+
+  InputMessage msg;
+  msg.role = "user";
+  InputImageContent image_part;
+  image_part.detail = "auto";
+  image_part.image_data = image_data;
+  image_part.media_type = media_type;
+  msg.content.push_back(image_part);
+
+  params.input = std::vector<InputItem>{msg};
+  return params;
+}
+
 }  // namespace
 
 TEST(ResponseConverterTest, ToSessionRequest_InputImage_DataUrl_DecodesToImageItem) {
@@ -345,6 +362,47 @@ TEST(ResponseConverterTest, ToSessionRequest_InputImage_DataUrl_DecodesToImageIt
   EXPECT_EQ(img->format, "image/png");
   EXPECT_EQ(img->data_size, kSamplePngDecodedSize);
   EXPECT_NE(img->data, nullptr);
+}
+
+TEST(ResponseConverterTest, ToSessionRequest_InputImage_ImageData_DecodesWithMediaType) {
+  auto params = MakeImageDataRequest(kSamplePngBase64, "image/jpeg");
+
+  auto request = ToSessionRequest(params);
+
+  auto* msg = dynamic_cast<MessageItem*>(request.items[0]);
+  ASSERT_NE(msg, nullptr);
+  ASSERT_EQ(msg->content.size(), 2u);
+  const auto* img = static_cast<const ImageItem*>(msg->content[0].view);
+  EXPECT_EQ(img->format, "image/jpeg");
+  EXPECT_EQ(img->data_size, kSamplePngDecodedSize);
+}
+
+TEST(ResponseConverterTest, ToSessionRequest_InputImage_ImageData_DefaultsToPng) {
+  auto params = MakeImageDataRequest(kSamplePngBase64);
+
+  auto request = ToSessionRequest(params);
+
+  auto* msg = dynamic_cast<MessageItem*>(request.items[0]);
+  ASSERT_NE(msg, nullptr);
+  const auto* img = static_cast<const ImageItem*>(msg->content[0].view);
+  EXPECT_EQ(img->format, "image/png");
+}
+
+TEST(ResponseConverterTest, ToSessionRequest_InputImage_ImageUrlTakesPrecedenceOverImageData) {
+  std::string data_url = std::string("data:image/png;base64,") + kSamplePngBase64;
+  auto params = MakeImageRequest(data_url);
+  auto& items = std::get<std::vector<InputItem>>(params.input);
+  auto& msg = std::get<InputMessage>(items[0]);
+  auto& image = std::get<InputImageContent>(msg.content[1]);
+  image.image_data = "not-valid-base64";
+  image.media_type = "image/jpeg";
+
+  auto request = ToSessionRequest(params);
+
+  auto* converted_msg = dynamic_cast<MessageItem*>(request.items[0]);
+  ASSERT_NE(converted_msg, nullptr);
+  const auto* img = static_cast<const ImageItem*>(converted_msg->content[1].view);
+  EXPECT_EQ(img->format, "image/png");
 }
 
 TEST(ResponseConverterTest, ToSessionRequest_InputImage_DataUrl_MissingBase64Marker_Throws) {

--- a/sdk_v2/cpp/test/internal_api/responses_json_test.cc
+++ b/sdk_v2/cpp/test/internal_api/responses_json_test.cc
@@ -58,6 +58,17 @@ TEST(InputContentTest, ImageContentWithUrl) {
   EXPECT_FALSE(c.file_id.has_value());
 }
 
+TEST(InputContentTest, ImageContentWithDataAndMediaType) {
+  auto j = json::parse(R"({"image_data": "aW1hZ2U=", "media_type": "image/jpeg"})");
+  auto c = j.get<InputImageContent>();
+
+  ASSERT_TRUE(c.image_data.has_value());
+  EXPECT_EQ(*c.image_data, "aW1hZ2U=");
+  ASSERT_TRUE(c.media_type.has_value());
+  EXPECT_EQ(*c.media_type, "image/jpeg");
+  EXPECT_FALSE(c.image_url.has_value());
+}
+
 TEST(InputContentTest, ImageContentDefaultDetail) {
   auto j = json::parse(R"({})");
   auto c = j.get<InputImageContent>();

--- a/sdk_v2/cpp/test/sdk_api/responses_vision_test.cc
+++ b/sdk_v2/cpp/test/sdk_api/responses_vision_test.cc
@@ -96,6 +96,38 @@ TEST_F(ResponsesVisionIntegrationTest, DataUrlImageProducesOutput) {
   EXPECT_GT(response["usage"]["output_tokens"].get<int>(), 0);
 }
 
+TEST_F(ResponsesVisionIntegrationTest, ImageDataProducesOutput) {
+  auto client = MakeClient();
+  client.set_read_timeout(600, 0);
+
+  json request_body = {
+      {"model", vision_model_id()},
+      {"input", json::array({
+                    {{"role", "user"},
+                     {"content", json::array({
+                                     {{"type", "input_text"},
+                                      {"text", "Describe this image in one short sentence."}},
+                                     {{"type", "input_image"},
+                                      {"detail", "low"},
+                                      {"image_data", kTinyPngBase64},
+                                      {"media_type", "image/png"}},
+                                 })}},
+                })},
+      {"max_output_tokens", 512},
+      {"temperature", 0},
+      {"store", false},
+  };
+
+  auto result = client.Post("/v1/responses", request_body.dump(), "application/json");
+  ASSERT_TRUE(result) << "HTTP request failed: " << httplib::to_string(result.error());
+  ASSERT_EQ(result->status, 200) << result->body;
+
+  json response = json::parse(result->body);
+  EXPECT_EQ(response["status"], "completed") << response.dump(2);
+  ASSERT_TRUE(response.contains("output_text"));
+  EXPECT_FALSE(response["output_text"].get<std::string>().empty());
+}
+
 TEST_F(ResponsesVisionIntegrationTest, RemoteHttpUrlIsRejected) {
   auto client = MakeClient();
 


### PR DESCRIPTION
## Summary

Restore backward compatibility for Foundry Local v1 Responses API image inputs that send raw base64 data using `image_data` and `media_type`.

https://github.com/microsoft/foundry-local/blob/9856f88c33d81c32dc8609b215ba25f2d0c360e1/samples/js/web-server-responses-vision-example/app.js#L132-L141

We added support for the OpenAI `image_url` in SDK v2 but didn't have handling for the `image_data` field. 

- Parse `image_data` into the Responses input contract.
- Convert raw base64 payloads into image items, defaulting an omitted media type to `image/png`.
- Preserve `image_url` precedence when both representations are supplied.
- Add JSON parsing, conversion, precedence, and HTTP-level vision regression coverage.

## Validation

- Built with `python build.py --configure --build --config RelWithDebInfo --skip_tests`.
- Passed 4 focused `foundry_local_tests` regression tests.
- Passed `ResponsesVisionIntegrationTest.ImageDataProducesOutput`.