### PR TITLE
Fix issue with language bindings caching info

### DIFF
--- a/sdk_v2/cpp/src/model.cc
+++ b/sdk_v2/cpp/src/model.cc
@@ -111,11 +111,11 @@ Model::Model(Model&& other) noexcept
       download_manager_(other.download_manager_),
       model_load_manager_(other.model_load_manager_),
       variants_(std::move(other.variants_)),
-      selected_variant_(other.selected_variant_) {
+      selected_variant_(other.selected_variant_.load(std::memory_order_relaxed)) {
   // After vector move, selected_variant_ still points into the transferred buffer.
   other.download_manager_ = nullptr;
   other.model_load_manager_ = nullptr;
-  other.selected_variant_ = nullptr;
+  other.selected_variant_.store(nullptr, std::memory_order_relaxed);
 }
 
 Model& Model::operator=(Model&& other) noexcept {
@@ -126,10 +126,10 @@ Model& Model::operator=(Model&& other) noexcept {
     download_manager_ = other.download_manager_;
     model_load_manager_ = other.model_load_manager_;
     variants_ = std::move(other.variants_);
-    selected_variant_ = other.selected_variant_;
+    selected_variant_.store(other.selected_variant_.load(std::memory_order_relaxed), std::memory_order_relaxed);
     other.download_manager_ = nullptr;
     other.model_load_manager_ = nullptr;
-    other.selected_variant_ = nullptr;
+    other.selected_variant_.store(nullptr, std::memory_order_relaxed);
   }
 
   return *this;
@@ -163,7 +163,7 @@ Model Model::FromModelInfo(ModelInfo info,
 Model Model::MakeContainer(Model first_variant) {
   Model container;
   container.variants_.push_back(std::make_unique<Model>(std::move(first_variant)));
-  container.selected_variant_ = container.variants_.back().get();
+  container.selected_variant_.store(container.variants_.back().get(), std::memory_order_release);
   return container;
 }
 
@@ -196,12 +196,12 @@ void Model::SelectDefaultVariant() {
 
   for (auto& v : variants_) {
     if (v->IsCached()) {
-      selected_variant_ = v.get();
+      selected_variant_.store(v.get(), std::memory_order_release);
       return;
     }
   }
 
-  selected_variant_ = variants_.front().get();
+  selected_variant_.store(variants_.front().get(), std::memory_order_release);
 }
 
 // ---------------------------------------------------------------------------
@@ -209,24 +209,24 @@ void Model::SelectDefaultVariant() {
 // ---------------------------------------------------------------------------
 
 const std::string& Model::Id() const {
-  if (selected_variant_) {
-    return selected_variant_->Id();
+  if (Model* sv = selected_variant_.load(std::memory_order_acquire)) {
+    return sv->Id();
   }
 
   return info_.model_id;
 }
 
 const std::string& Model::Alias() const {
-  if (selected_variant_) {
-    return selected_variant_->Alias();
+  if (Model* sv = selected_variant_.load(std::memory_order_acquire)) {
+    return sv->Alias();
   }
 
   return info_.alias;
 }
 
 const ModelInfo& Model::Info() const {
-  if (selected_variant_) {
-    return selected_variant_->Info();
+  if (Model* sv = selected_variant_.load(std::memory_order_acquire)) {
+    return sv->Info();
   }
 
   return info_;
@@ -251,16 +251,16 @@ std::vector<Model*> Model::Variants() const {
 }
 
 bool Model::IsCached() const {
-  if (selected_variant_) {
-    return selected_variant_->IsCached();
+  if (Model* sv = selected_variant_.load(std::memory_order_acquire)) {
+    return sv->IsCached();
   }
 
   return cached_;
 }
 
 bool Model::IsLoaded() const {
-  if (selected_variant_) {
-    return selected_variant_->IsLoaded();
+  if (Model* sv = selected_variant_.load(std::memory_order_acquire)) {
+    return sv->IsLoaded();
   }
 
   // ModelLoadManager owns the authoritative loaded-instance map. The pointer is set at
@@ -274,14 +274,20 @@ bool Model::IsLoaded() const {
 // ---------------------------------------------------------------------------
 
 void Model::Download(std::function<int(float)> progress_cb) {
-  if (selected_variant_) {
-    selected_variant_->Download(std::move(progress_cb));
+  if (Model* sv = selected_variant_.load(std::memory_order_acquire)) {
+    sv->Download(std::move(progress_cb));
     return;
   }
 
   // Already cached (scanner found the model on disk during catalog construction).
   // No need to re-derive the path via DownloadManager — local_path_ is authoritative.
-  if (cached_ && !local_path_.empty()) {
+  bool already_cached;
+  {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    already_cached = cached_.load() && !local_path_.empty();
+  }
+
+  if (already_cached) {
     if (progress_cb) {
       // No work remains; cancellation request is meaningless here, so the
       // return value is intentionally ignored.
@@ -291,21 +297,26 @@ void Model::Download(std::function<int(float)> progress_cb) {
   }
 
   auto path = download_manager_->DownloadModel(info_, std::move(progress_cb));
-  local_path_ = std::move(path);
+  {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    local_path_ = std::move(path);
+  }
+  // local_path_ must be published before cached_ flips true: readers gate on IsCached()
+  // and this release store guarantees they observe the completed path. Do not reorder.
   cached_.store(true);
 }
 
 const std::string& Model::GetPath() const {
-  if (selected_variant_) {
-    return selected_variant_->GetPath();
+  if (Model* sv = selected_variant_.load(std::memory_order_acquire)) {
+    return sv->GetPath();
   }
 
   return local_path_;
 }
 
 void Model::Load(ExecutionProvider ep) {
-  if (selected_variant_) {
-    selected_variant_->Load(ep);
+  if (Model* sv = selected_variant_.load(std::memory_order_acquire)) {
+    sv->Load(ep);
     return;
   }
 
@@ -319,8 +330,8 @@ void Model::Load(ExecutionProvider ep) {
 }
 
 void Model::Unload() {
-  if (selected_variant_) {
-    selected_variant_->Unload();
+  if (Model* sv = selected_variant_.load(std::memory_order_acquire)) {
+    sv->Unload();
     return;
   }
 
@@ -329,25 +340,34 @@ void Model::Unload() {
 }
 
 void Model::RemoveFromCache() {
-  if (selected_variant_) {
-    selected_variant_->RemoveFromCache();
+  if (Model* sv = selected_variant_.load(std::memory_order_acquire)) {
+    sv->RemoveFromCache();
     return;
   }
 
-  if (!cached_ || local_path_.empty()) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "model is not cached locally");
+  std::string path;
+  {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    if (!cached_ || local_path_.empty()) {
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "model is not cached locally");
+    }
+    path = local_path_;
   }
 
   if (IsLoaded()) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "cannot remove a loaded model from cache; unload it first");
   }
 
-  if (!Utils::RemoveDirectoryRecursive(local_path_)) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "failed to remove model cache directory: " + local_path_);
+  if (!Utils::RemoveDirectoryRecursive(path)) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "failed to remove model cache directory: " + path);
   }
 
+  // Turn off the published state before tearing down the backing string (mirror of Download's ordering).
   cached_.store(false);
-  local_path_.clear();
+  {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    local_path_.clear();
+  }
 }
 
 void Model::SelectVariant(const Model& variant) {
@@ -359,7 +379,7 @@ void Model::SelectVariant(const Model& variant) {
 
   for (auto& v : variants_) {
     if (v.get() == &variant) {
-      selected_variant_ = v.get();
+      selected_variant_.store(v.get(), std::memory_order_release);
       return;
     }
   }
@@ -434,8 +454,8 @@ Model::IOInfo IOInfoFromCache(const StaticIOCache& cache) {
 }  // namespace
 
 Model::IOInfo Model::GetInputOutputInfo() const {
-  if (selected_variant_) {
-    return selected_variant_->GetInputOutputInfo();
+  if (Model* sv = selected_variant_.load(std::memory_order_acquire)) {
+    return sv->GetInputOutputInfo();
   }
 
   const auto& task = Info().task;

--- a/sdk_v2/cpp/src/model.h
+++ b/sdk_v2/cpp/src/model.h
@@ -116,7 +116,7 @@ class Model {
   IOInfo GetInputOutputInfo() const;
 
   /// True if this is a multi-variant container.
-  bool IsContainer() const { return selected_variant_ != nullptr; }
+  bool IsContainer() const { return selected_variant_.load(std::memory_order_acquire) != nullptr; }
 
   // --- Mutation methods ---
 
@@ -154,9 +154,10 @@ class Model {
   // Loaded state is NOT stored here; it is queried from ModelLoadManager so the load
   // manager remains the single source of truth (Manager::Shutdown clears its map without
   // having to walk every Model and reset a local flag).
-  // local_path_ is set once during Download() (or at construction for already-cached models)
-  // and cleared by RemoveFromCache(). It is intentionally NOT mutex-protected: concurrent
-  // mutation alongside reads on the same Model* is not a supported pattern.
+  // local_path_ is set during Download() (or at construction for already-cached models) and
+  // cleared by RemoveFromCache(). Its mutation is guarded by state_mutex_; the reader-safety
+  // contract is that the path is published before cached_ flips true (and cleared after cached_
+  // flips false), so any reader that gates on IsCached() observes a complete path.
   ModelInfo info_;
   std::atomic<bool> cached_{false};
   std::string local_path_;
@@ -169,7 +170,7 @@ class Model {
   // Container data (empty/null for leaves). unique_ptr keeps Model addresses
   // stable across vector growth/reordering.
   std::vector<std::unique_ptr<Model>> variants_;
-  Model* selected_variant_ = nullptr;  // non-null = this is a container
+  std::atomic<Model*> selected_variant_{nullptr};  // non-null = this is a container
 
   // Guards variants_ across reader/writer threads (catalog refresh adding variants
   // while another thread enumerates via Variants()).

--- a/sdk_v2/cs/src/Detail/Model.cs
+++ b/sdk_v2/cs/src/Detail/Model.cs
@@ -15,13 +15,14 @@ public class Model : IModel
     private readonly ILogger _logger;
     internal NativeModel NativeModel { get; }
 
-    private ModelInfo? _info;
     private IReadOnlyList<IModel>? _variants;
 
     public string Id => NativeModel.GetInfo().Id;
     public string Alias => NativeModel.GetInfo().Alias;
 
-    public ModelInfo Info => _info ??= ModelInfo.FromNative(NativeModel);
+    // The native model is the source of truth. Reading fresh every time keeps metadata correct after
+    // SelectVariant / download / cache changes. Each read returns a point-in-time ModelInfo snapshot.
+    public ModelInfo Info => ModelInfo.FromNative(NativeModel);
 
     public IReadOnlyList<IModel> Variants
     {

--- a/sdk_v2/cs/test/FoundryLocal.Tests/CatalogTests.cs
+++ b/sdk_v2/cs/test/FoundryLocal.Tests/CatalogTests.cs
@@ -66,4 +66,44 @@ internal sealed class CatalogTests
         await Assert.That(async () => await catalog.ListModelsAsync(cts.Token).ConfigureAwait(false))
             .Throws<OperationCanceledException>();
     }
+
+    [Test]
+    public async Task SelectVariant_RefreshesReportedMetadata()
+    {
+        var catalog = await FoundryLocalManager.Instance.GetCatalogAsync();
+
+        var models = await catalog.ListModelsAsync();
+        var modelWithVariants = models.FirstOrDefault(m => m.Variants.Count > 1);
+
+        if (modelWithVariants == null)
+        {
+            // No multi-variant model in the catalog — nothing to exercise.
+            return;
+        }
+
+        var variants = modelWithVariants.Variants.ToList();
+        var defaultVariant = variants[0];
+        var otherVariant = variants.First(v => v.Id != defaultVariant.Id);
+
+        var infoBefore = modelWithVariants.Info;
+        await Assert.That(infoBefore.Id).IsEqualTo(defaultVariant.Id);
+
+        modelWithVariants.SelectVariant(otherVariant);
+
+        // Native is the source of truth: every read must reflect the selected variant.
+        await Assert.That(modelWithVariants.Id).IsEqualTo(otherVariant.Id);
+        await Assert.That(modelWithVariants.Alias).IsEqualTo(otherVariant.Alias);
+
+        var infoAfter = modelWithVariants.Info;
+        await Assert.That(infoAfter.Id).IsEqualTo(otherVariant.Id);
+        await Assert.That(infoAfter.Name).IsEqualTo(otherVariant.Info.Name);
+        await Assert.That(infoAfter.Version).IsEqualTo(otherVariant.Info.Version);
+
+        // The earlier snapshot is an independent point-in-time value.
+        await Assert.That(infoBefore.Id).IsEqualTo(defaultVariant.Id);
+
+        // Selecting back refreshes again.
+        modelWithVariants.SelectVariant(defaultVariant);
+        await Assert.That(modelWithVariants.Info.Id).IsEqualTo(defaultVariant.Id);
+    }
 }

--- a/sdk_v2/cs/test/FoundryLocal.Tests/CatalogTests.cs
+++ b/sdk_v2/cs/test/FoundryLocal.Tests/CatalogTests.cs
@@ -77,16 +77,17 @@ internal sealed class CatalogTests
 
         if (modelWithVariants == null)
         {
-            // No multi-variant model in the catalog — nothing to exercise.
+            Skip.Test("No multi-variant model in the catalog.");
             return;
         }
 
         var variants = modelWithVariants.Variants.ToList();
-        var defaultVariant = variants[0];
-        var otherVariant = variants.First(v => v.Id != defaultVariant.Id);
 
+        // Derive the original variant from the currently-selected Info rather than
+        // assuming variants[0]: native selection prefers the first cached variant.
         var infoBefore = modelWithVariants.Info;
-        await Assert.That(infoBefore.Id).IsEqualTo(defaultVariant.Id);
+        var defaultVariant = variants.First(v => v.Id == infoBefore.Id);
+        var otherVariant = variants.First(v => v.Id != infoBefore.Id);
 
         modelWithVariants.SelectVariant(otherVariant);
 

--- a/sdk_v2/js/src/model.ts
+++ b/sdk_v2/js/src/model.ts
@@ -69,21 +69,21 @@ function normalizeModelInfo(raw: NativeModelInfo, native: NativeModel): ModelInf
     promptTemplate: normalizePromptTemplate(raw.promptTemplate),
     modelSettings: normalizeModelSettings(raw.modelSettings),
     cached: raw.cached ?? native.isCached(),
-    runtime: raw.runtime !== undefined
-      ? {
-          deviceType: toDeviceType(raw.runtime.deviceType),
-          executionProvider: raw.runtime.executionProvider,
-        }
-      : {
-          deviceType,
-          executionProvider,
-        },
+    runtime:
+      raw.runtime !== undefined
+        ? {
+            deviceType: toDeviceType(raw.runtime.deviceType),
+            executionProvider: raw.runtime.executionProvider,
+          }
+        : {
+            deviceType,
+            executionProvider,
+          },
   };
 }
 
 export class Model implements IModel {
   readonly #native: NativeModel;
-  readonly #info: ModelInfo;
 
   /** @internal — wraps a native Model handle. Do not call from user code. */
   constructor(token: typeof internalCtorKey, native: NativeModel) {
@@ -91,23 +91,21 @@ export class Model implements IModel {
       throw new TypeError("Model is internal — obtain instances via Catalog/FoundryLocalManager methods");
     }
     this.#native = native;
-    // Cache the snapshot eagerly. The underlying native getInfo() copies every call, so we avoid repeating that
-    // work for the property getters below. Native variant selection re-wraps with a fresh JS Model, so the
-    // snapshot can never go stale on this instance.
-    this.#info = normalizeModelInfo(native.getInfo(), native);
     nativeByModel.set(this, native);
   }
 
   get id(): string {
-    return this.#info.id;
+    return this.info.id;
   }
 
   get alias(): string {
-    return this.#info.alias;
+    return this.info.alias;
   }
 
   get info(): ModelInfo {
-    return this.#info;
+    // The native model is the source of truth. Read fresh every time so metadata stays correct after
+    // selectVariant / download / cache changes. Each read returns a point-in-time snapshot.
+    return normalizeModelInfo(this.#native.getInfo(), this.#native);
   }
 
   get isCached(): boolean {
@@ -132,23 +130,23 @@ export class Model implements IModel {
   }
 
   get contextLength(): number | null {
-    return this.#info.contextLength ?? null;
+    return this.info.contextLength ?? null;
   }
 
   get inputModalities(): string | null {
-    return this.#info.inputModalities ?? null;
+    return this.info.inputModalities ?? null;
   }
 
   get outputModalities(): string | null {
-    return this.#info.outputModalities ?? null;
+    return this.info.outputModalities ?? null;
   }
 
   get capabilities(): string | null {
-    return this.#info.capabilities ?? null;
+    return this.info.capabilities ?? null;
   }
 
   get supportsToolCalling(): boolean | null {
-    return this.#info.supportsToolCalling ?? null;
+    return this.info.supportsToolCalling ?? null;
   }
 
   async load(): Promise<void> {

--- a/sdk_v2/js/test/_fixtures/cacheOnlyManager.ts
+++ b/sdk_v2/js/test/_fixtures/cacheOnlyManager.ts
@@ -109,6 +109,8 @@ export const TWO_VARIANT_MODELS = [
     task: "chat-completion",
     publisher: "Contoso",
     displayName: "Multi Variant Model",
+    // Cache-only JSON derives info.deviceType from runtime.deviceType, not the id suffix.
+    runtime: { deviceType: "GPU" },
   },
   {
     id: "multi-variant-model-generic-cpu:1",
@@ -121,6 +123,8 @@ export const TWO_VARIANT_MODELS = [
     task: "chat-completion",
     publisher: "Contoso",
     displayName: "Multi Variant Model",
+    // Cache-only JSON derives info.deviceType from runtime.deviceType, not the id suffix.
+    runtime: { deviceType: "CPU" },
   },
 ] as const;
 

--- a/sdk_v2/js/test/_fixtures/cacheOnlyManager.ts
+++ b/sdk_v2/js/test/_fixtures/cacheOnlyManager.ts
@@ -87,7 +87,42 @@ export interface CacheOnlyManagerFixture {
 export interface SetupOptions {
   /** Override the appName. Defaults to a fixed test id. */
   readonly appName?: string;
+  /** Override the catalog model entries. Defaults to the two-model fixture above. */
+  readonly models?: readonly unknown[];
 }
+
+/**
+ * Two variants of a single alias (generic-gpu + generic-cpu). The catalog groups
+ * these into one selectable Model. With nothing cached, the higher-priority GPU
+ * variant is the default selection and `variants` is ordered [gpu, cpu]. Used to
+ * exercise `selectVariant` and verify metadata reads reflect the current selection.
+ */
+export const TWO_VARIANT_MODELS = [
+  {
+    id: "multi-variant-model-generic-gpu:1",
+    name: "multi-variant-model-generic-gpu",
+    version: 1,
+    alias: "multi-variant-model",
+    uri: "azureml://registries/azureml/models/multi-variant-model-generic-gpu/versions/1",
+    providerType: "FoundryLocal",
+    modelType: "ONNX",
+    task: "chat-completion",
+    publisher: "Contoso",
+    displayName: "Multi Variant Model",
+  },
+  {
+    id: "multi-variant-model-generic-cpu:1",
+    name: "multi-variant-model-generic-cpu",
+    version: 1,
+    alias: "multi-variant-model",
+    uri: "azureml://registries/azureml/models/multi-variant-model-generic-cpu/versions/1",
+    providerType: "FoundryLocal",
+    modelType: "ONNX",
+    task: "chat-completion",
+    publisher: "Contoso",
+    displayName: "Multi Variant Model",
+  },
+] as const;
 
 /**
  * Construct a Manager pointed at a fresh temp cache directory pre-populated
@@ -96,7 +131,8 @@ export interface SetupOptions {
  */
 export function setupCacheOnlyManager(opts: SetupOptions = {}): CacheOnlyManagerFixture {
   const tmpDir = mkdtempSync(join(tmpdir(), "fl-js-v2-test-"));
-  writeFileSync(join(tmpDir, "foundry.modelinfo.json"), JSON.stringify(FIXTURE_CATALOG, null, 2));
+  const catalog = opts.models === undefined ? FIXTURE_CATALOG : { ...FIXTURE_CATALOG, models: opts.models };
+  writeFileSync(join(tmpDir, "foundry.modelinfo.json"), JSON.stringify(catalog, null, 2));
   const config: FoundryLocalConfig = {
     appName: opts.appName ?? "foundry-local-js-sdk-v2-tests",
     modelCacheDir: tmpDir,

--- a/sdk_v2/js/test/model.test.ts
+++ b/sdk_v2/js/test/model.test.ts
@@ -67,9 +67,13 @@ describeIfBuilt("Model (cache-only)", () => {
     expect(info.promptTemplate ?? null).toBeNull();
   });
 
-  it("info is a stable snapshot (same object identity across reads)", () => {
-    // V1 surface caches the snapshot eagerly in the wrapper ctor.
-    expect(model.info).toBe(model.info);
+  it("info reads fresh from native each time (native is the source of truth)", () => {
+    // Each read returns a new point-in-time snapshot.
+    // This keeps reported metadata correct after selectVariant / download / cache changes.
+    const a = model.info;
+    const b = model.info;
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
   });
 
   it("isCached returns a boolean", () => {

--- a/sdk_v2/js/test/selectVariant.test.ts
+++ b/sdk_v2/js/test/selectVariant.test.ts
@@ -1,0 +1,94 @@
+// selectVariant regression tests for the v2 JS SDK.
+//
+// The native model is the source of truth for metadata. The JS wrapper must not
+// snapshot `info` — after `selectVariant`, `model.info` / `model.id` must reflect
+// the newly selected variant. Uses a dedicated two-variant fixture (generic-gpu +
+// generic-cpu under one alias) so the switch is observable.
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { Catalog } from "../src/catalog.js";
+import type { IModel } from "../src/imodel.js";
+import type { Model } from "../src/model.js";
+
+import {
+  type CacheOnlyManagerFixture,
+  TWO_VARIANT_MODELS,
+  haveNativePrereqs,
+  nativePrereqsDiagnostic,
+  setupCacheOnlyManager,
+  teardownCacheOnlyManager,
+} from "./_fixtures/cacheOnlyManager.js";
+
+const describeIfBuilt = haveNativePrereqs ? describe : describe.skip;
+
+if (!haveNativePrereqs) {
+  // eslint-disable-next-line no-console
+  console.warn(`[selectVariant tests] SKIPPED — ${nativePrereqsDiagnostic}`);
+}
+
+const GPU_ID = "multi-variant-model-generic-gpu:1";
+const CPU_ID = "multi-variant-model-generic-cpu:1";
+
+function variantById(model: Model, id: string): IModel {
+  const found = model.variants.find((v) => v.info.id === id);
+  if (found === undefined) {
+    throw new Error(`variant ${id} not found`);
+  }
+  return found;
+}
+
+describeIfBuilt("Model.selectVariant (cache-only)", () => {
+  let fixture: CacheOnlyManagerFixture;
+  let catalog: Catalog;
+
+  beforeAll(() => {
+    fixture = setupCacheOnlyManager({
+      appName: "foundry-local-js-sdk-v2-select-variant-tests",
+      models: TWO_VARIANT_MODELS,
+    });
+    catalog = fixture.manager.catalog;
+  });
+
+  afterAll(() => {
+    teardownCacheOnlyManager(fixture);
+  });
+
+  it("exposes both variants under one alias, GPU selected by default", async () => {
+    const model = (await catalog.getModel("multi-variant-model")) as Model;
+    expect(model.info.alias).toBe("multi-variant-model");
+    expect(model.info.id).toBe(GPU_ID);
+
+    const variantIds = model.variants.map((v) => v.info.id).sort();
+    expect(variantIds).toEqual([CPU_ID, GPU_ID]);
+  });
+
+  it("metadata reflects the selected variant after selectVariant", async () => {
+    const model = (await catalog.getModel("multi-variant-model")) as Model;
+
+    // Prime a read of the default (GPU) metadata before selecting.
+    const before = model.info;
+    expect(before.id).toBe(GPU_ID);
+
+    model.selectVariant(variantById(model, CPU_ID));
+
+    // Fresh reads must reflect the CPU variant — no stale snapshot.
+    expect(model.info.id).toBe(CPU_ID);
+    expect(model.id).toBe(CPU_ID);
+    expect(model.info.name).toBe("multi-variant-model-generic-cpu");
+    expect(model.info.deviceType).toBe("CPU");
+
+    // The earlier value object is an independent point-in-time snapshot.
+    expect(before.id).toBe(GPU_ID);
+  });
+
+  it("selecting back to the original variant refreshes metadata again", async () => {
+    const model = (await catalog.getModel("multi-variant-model")) as Model;
+
+    model.selectVariant(variantById(model, CPU_ID));
+    expect(model.info.id).toBe(CPU_ID);
+
+    model.selectVariant(variantById(model, GPU_ID));
+    expect(model.info.id).toBe(GPU_ID);
+    expect(model.info.deviceType).toBe("GPU");
+  });
+});

--- a/sdk_v2/python/src/foundry_local_sdk/imodel.py
+++ b/sdk_v2/python/src/foundry_local_sdk/imodel.py
@@ -251,7 +251,6 @@ class _ModelImpl(IModel):
         # is owned by the catalog; without this reference, GC could release the
         # catalog (and the manager behind it) first and dangle our pointer.
         self._parent = parent
-        self._cached_info: ModelInfo | None = None
         # Callback references — stored to prevent premature GC.
         self._progress_cb = None
         self._progress_cb_handle = None
@@ -262,7 +261,7 @@ class _ModelImpl(IModel):
         return self._ptr
 
     # ------------------------------------------------------------------
-    # Identity properties — read from cached ModelInfo
+    # Identity properties — read from native ModelInfo
     # ------------------------------------------------------------------
 
     @property
@@ -275,10 +274,9 @@ class _ModelImpl(IModel):
 
     @property
     def info(self) -> ModelInfo:
-        # Lazily build and cache — reading native info is non-trivial.
-        if self._cached_info is None:
-            self._cached_info = _model_info_from_native(self._ptr)
-        return self._cached_info
+        # The native model is the source of truth. Read fresh every time so metadata stays correct
+        # after select_variant / download / cache changes. Each read returns a point-in-time snapshot.
+        return _model_info_from_native(self._ptr)
 
     # ------------------------------------------------------------------
     # Live state properties — always go to native for fresh data

--- a/sdk_v2/python/test/integration/test_catalog.py
+++ b/sdk_v2/python/test/integration/test_catalog.py
@@ -93,12 +93,13 @@ class TestSelectVariantMetadata:
             pytest.skip("No multi-variant model in the catalog.")
 
         variants = model.variants
-        default_variant = variants[0]
-        other_variant = next(v for v in variants if v.id != default_variant.id)
 
         # Read info BEFORE selecting — this is what used to prime a stale cache.
+        # Derive the original variant from the currently-selected info rather than
+        # assuming variants[0]: native selection prefers the first cached variant.
         info_before = model.info
-        assert info_before.id == default_variant.id
+        default_variant = next(v for v in variants if v.id == info_before.id)
+        other_variant = next(v for v in variants if v.id != info_before.id)
 
         model.select_variant(other_variant)
 

--- a/sdk_v2/python/test/integration/test_catalog.py
+++ b/sdk_v2/python/test/integration/test_catalog.py
@@ -74,3 +74,46 @@ class TestCatalogShape:
 
         with pytest.raises(FoundryLocalException):
             manager.catalog.get_latest_version("not-an-imodel")  # type: ignore[arg-type]
+
+
+class TestSelectVariantMetadata:
+    """The native model is the source of truth. After select_variant, all reported
+    metadata (info, id, alias, ...) must reflect the selected variant even if info
+    was read before selecting."""
+
+    def _find_multi_variant_model(self, manager):
+        for m in manager.catalog.list_models():
+            if len(m.variants) > 1:
+                return m
+        return None
+
+    def test_select_variant_refreshes_metadata(self, manager):
+        model = self._find_multi_variant_model(manager)
+        if model is None:
+            pytest.skip("No multi-variant model in the catalog.")
+
+        variants = model.variants
+        default_variant = variants[0]
+        other_variant = next(v for v in variants if v.id != default_variant.id)
+
+        # Read info BEFORE selecting — this is what used to prime a stale cache.
+        info_before = model.info
+        assert info_before.id == default_variant.id
+
+        model.select_variant(other_variant)
+
+        # Every read must reflect the selected variant.
+        assert model.id == other_variant.id
+        assert model.alias == other_variant.alias
+
+        info_after = model.info
+        assert info_after.id == other_variant.id
+        assert info_after.name == other_variant.info.name
+        assert info_after.version == other_variant.info.version
+
+        # The earlier snapshot is an independent point-in-time value.
+        assert info_before.id == default_variant.id
+
+        # Selecting back refreshes again.
+        model.select_variant(default_variant)
+        assert model.info.id == default_variant.id


### PR DESCRIPTION
Don't cache current variant info at the language binding level as it can get stale for various reasons. 
Native level is source of truth.