### PR TITLE
PR suggestions

### DIFF
--- a/sdk_v2/cpp/CMakeLists.txt
+++ b/sdk_v2/cpp/CMakeLists.txt
@@ -168,6 +168,7 @@ set(FOUNDRY_LOCAL_SOURCES
     src/exception.cc
     src/inferencing/generative/genai_config.cc
     src/http/http_client.cc
+    src/http/curl_transport.cc
     src/inferencing/generative/genai_model_instance.cc
     src/inferencing/generative/tokenizer.cc
     src/logger.cc

--- a/sdk_v2/cpp/src/download/blob_downloader.cc
+++ b/sdk_v2/cpp/src/download/blob_downloader.cc
@@ -29,6 +29,8 @@
 // does not honor SSL_CERT_FILE. On non-Windows builds we install a CurlTransport preconfigured with
 // CAInfo (see MakeBlobClientOptions below). Desktop Windows uses the default WinHTTP transport.
 #if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
+#include "http/curl_transport.h"
+
 #include <azure/core/http/curl_transport.hpp>
 #endif
 
@@ -50,10 +52,11 @@ constexpr size_t kStreamingBufferBytes = 64 * 1024;
 Azure::Storage::Blobs::BlobClientOptions MakeBlobClientOptions() {
   Azure::Storage::Blobs::BlobClientOptions options;
 #if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
-  if (std::string ca_bundle = fl::http::CaBundleFile(); !ca_bundle.empty()) {
-    Azure::Core::Http::CurlTransportOptions curl_opts;
-    curl_opts.CAInfo = std::move(ca_bundle);
-    options.Transport.Transport = std::make_shared<Azure::Core::Http::CurlTransport>(curl_opts);
+  // Only override the Storage SDK's default transport when a CA bundle is configured; the options are
+  // cached and shared with our other curl transports (see http/curl_transport.h).
+  if (!fl::http::CaBundleFile().empty()) {
+    options.Transport.Transport =
+        std::make_shared<Azure::Core::Http::CurlTransport>(fl::http::CachedCurlTransportOptions());
   }
 #endif
   return options;

--- a/sdk_v2/cpp/src/download/blob_downloader.cc
+++ b/sdk_v2/cpp/src/download/blob_downloader.cc
@@ -52,11 +52,11 @@ constexpr size_t kStreamingBufferBytes = 64 * 1024;
 Azure::Storage::Blobs::BlobClientOptions MakeBlobClientOptions() {
   Azure::Storage::Blobs::BlobClientOptions options;
 #if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
-  // Only override the Storage SDK's default transport when a CA bundle is configured; the options are
-  // cached and shared with our other curl transports (see http/curl_transport.h).
-  if (!fl::http::CaBundleFile().empty()) {
+  // Only override the Storage SDK's default transport when a CA bundle is configured.
+  auto curl_options = fl::http::MakeCurlTransportOptions();
+  if (!curl_options.CAInfo.empty()) {
     options.Transport.Transport =
-        std::make_shared<Azure::Core::Http::CurlTransport>(fl::http::CachedCurlTransportOptions());
+        std::make_shared<Azure::Core::Http::CurlTransport>(curl_options);
   }
 #endif
   return options;

--- a/sdk_v2/cpp/src/http/curl_transport.cc
+++ b/sdk_v2/cpp/src/http/curl_transport.cc
@@ -15,8 +15,8 @@ namespace http {
 const Azure::Core::Http::CurlTransportOptions& CachedCurlTransportOptions() {
   static const Azure::Core::Http::CurlTransportOptions options = [] {
     Azure::Core::Http::CurlTransportOptions opts;
-    if (std::string ca_bundle = CaBundleFile(); !ca_bundle.empty()) {
-      opts.CAInfo = std::move(ca_bundle);
+    if (const std::string& ca_bundle = CaBundleFile(); !ca_bundle.empty()) {
+      opts.CAInfo = ca_bundle;
     }
     return opts;
   }();

--- a/sdk_v2/cpp/src/http/curl_transport.cc
+++ b/sdk_v2/cpp/src/http/curl_transport.cc
@@ -7,19 +7,16 @@
 #include "http/http_client.h"
 
 #include <string>
-#include <utility>
 
 namespace fl {
 namespace http {
 
-const Azure::Core::Http::CurlTransportOptions& CachedCurlTransportOptions() {
-  static const Azure::Core::Http::CurlTransportOptions options = [] {
-    Azure::Core::Http::CurlTransportOptions opts;
-    if (const std::string& ca_bundle = CaBundleFile(); !ca_bundle.empty()) {
-      opts.CAInfo = ca_bundle;
-    }
-    return opts;
-  }();
+Azure::Core::Http::CurlTransportOptions MakeCurlTransportOptions() {
+  Azure::Core::Http::CurlTransportOptions options;
+  if (const std::string& ca_bundle = CABundleFilePath(); !ca_bundle.empty()) {
+    options.CAInfo = ca_bundle;
+  }
+
   return options;
 }
 

--- a/sdk_v2/cpp/src/http/curl_transport.cc
+++ b/sdk_v2/cpp/src/http/curl_transport.cc
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "http/curl_transport.h"
+
+#if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
+
+#include "http/http_client.h"
+
+#include <string>
+#include <utility>
+
+namespace fl {
+namespace http {
+
+const Azure::Core::Http::CurlTransportOptions& CachedCurlTransportOptions() {
+  static const Azure::Core::Http::CurlTransportOptions options = [] {
+    Azure::Core::Http::CurlTransportOptions opts;
+    if (std::string ca_bundle = CaBundleFile(); !ca_bundle.empty()) {
+      opts.CAInfo = std::move(ca_bundle);
+    }
+    return opts;
+  }();
+  return options;
+}
+
+}  // namespace http
+}  // namespace fl
+
+#endif  // !FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT

--- a/sdk_v2/cpp/src/http/curl_transport.h
+++ b/sdk_v2/cpp/src/http/curl_transport.h
@@ -12,12 +12,9 @@
 namespace fl {
 namespace http {
 
-/// Returns the process-wide libcurl transport options, with `CAInfo` populated from `SSL_CERT_FILE`
-/// (via `CaBundleFile`). Built once and shared by every libcurl transport we construct — direct
-/// requests, file downloads, and the Azure Storage blob client — because the CA bundle path is fixed
-/// for the process lifetime. When `SSL_CERT_FILE` is unset, `CAInfo` is empty and libcurl falls back
-/// to its compiled-in default. The returned reference is valid for the lifetime of the process.
-const Azure::Core::Http::CurlTransportOptions& CachedCurlTransportOptions();
+/// Creates libcurl transport options with `CAInfo` populated from `SSL_CERT_FILE` via `CABundleFilePath`.
+/// When `SSL_CERT_FILE` is unset, `CAInfo` is empty and libcurl falls back to its compiled-in default.
+Azure::Core::Http::CurlTransportOptions MakeCurlTransportOptions();
 
 }  // namespace http
 }  // namespace fl

--- a/sdk_v2/cpp/src/http/curl_transport.h
+++ b/sdk_v2/cpp/src/http/curl_transport.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+// Desktop Windows uses the WinHTTP transport and never links libcurl, so the curl transport options
+// are only meaningful for the non-WinHTTP (libcurl) builds. Guard the whole header accordingly so
+// includers on Windows do not pull in the Azure curl transport dependency.
+#if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
+
+#include <azure/core/http/curl_transport.hpp>
+
+namespace fl {
+namespace http {
+
+/// Returns the process-wide libcurl transport options, with `CAInfo` populated from `SSL_CERT_FILE`
+/// (via `CaBundleFile`). Built once and shared by every libcurl transport we construct — direct
+/// requests, file downloads, and the Azure Storage blob client — because the CA bundle path is fixed
+/// for the process lifetime. When `SSL_CERT_FILE` is unset, `CAInfo` is empty and libcurl falls back
+/// to its compiled-in default. The returned reference is valid for the lifetime of the process.
+const Azure::Core::Http::CurlTransportOptions& CachedCurlTransportOptions();
+
+}  // namespace http
+}  // namespace fl
+
+#endif  // !FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT

--- a/sdk_v2/cpp/src/http/http_client.cc
+++ b/sdk_v2/cpp/src/http/http_client.cc
@@ -18,11 +18,12 @@
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
 #include <azure/core/http/win_http_transport.hpp>
 #else
+#include "http/curl_transport.h"
+
 #include <azure/core/http/curl_transport.hpp>
 #endif
 
 #include <chrono>
-#include <cstdlib>
 #include <random>
 #include <string>
 #include <thread>
@@ -33,11 +34,13 @@ namespace fl {
 namespace http {
 
 std::string CaBundleFile() {
-  const char* cert_file = std::getenv("SSL_CERT_FILE");
-  if (cert_file != nullptr && cert_file[0] != '\0') {
-    return cert_file;
-  }
-  return {};
+  // SSL_CERT_FILE is fixed for the process lifetime (callers set it before loading the library), so
+  // read it once and reuse the cached path for every request.
+  static const std::string ca_bundle = [] {
+    auto cert_file = Utils::GetEnv("SSL_CERT_FILE");
+    return (cert_file && !cert_file->empty()) ? std::move(*cert_file) : std::string();
+  }();
+  return ca_bundle;
 }
 
 namespace {
@@ -58,14 +61,10 @@ HttpRawResult HttpRequestRaw(const Azure::Core::Http::HttpMethod& method,
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
   WinHttpTransport transport;
 #else
-  // The bundled libcurl does not honor the SSL_CERT_FILE environment variable (it was built with a
-  // compiled-in default CA path that does not exist on platforms like Android). Explicitly pass the
-  // CA bundle via CAInfo so the caller-provided trust store is actually used for TLS verification.
-  CurlTransportOptions curl_opts;
-  if (std::string ca_bundle = CaBundleFile(); !ca_bundle.empty()) {
-    curl_opts.CAInfo = std::move(ca_bundle);
-  }
-  CurlTransport transport(curl_opts);
+  // libcurl does not honor SSL_CERT_FILE (its compiled-in default CA path is absent on Android), so
+  // we pass the CA bundle explicitly via CAInfo. The options are cached and shared (see
+  // http/curl_transport.h) and copied into the per-request transport.
+  CurlTransport transport(CachedCurlTransportOptions());
 #endif
 
   // Build the request. For methods with a body (POST), attach a MemoryBodyStream.

--- a/sdk_v2/cpp/src/http/http_client.cc
+++ b/sdk_v2/cpp/src/http/http_client.cc
@@ -33,9 +33,9 @@
 namespace fl {
 namespace http {
 
-std::string CaBundleFile() {
+const std::string& CaBundleFile() {
   // SSL_CERT_FILE is fixed for the process lifetime (callers set it before loading the library), so
-  // read it once and reuse the cached path for every request.
+  // read it once and return a reference to the cached path for every request.
   static const std::string ca_bundle = [] {
     auto cert_file = Utils::GetEnv("SSL_CERT_FILE");
     return (cert_file && !cert_file->empty()) ? std::move(*cert_file) : std::string();

--- a/sdk_v2/cpp/src/http/http_client.cc
+++ b/sdk_v2/cpp/src/http/http_client.cc
@@ -33,7 +33,7 @@
 namespace fl {
 namespace http {
 
-const std::string& CaBundleFile() {
+const std::string& CABundleFilePath() {
   // SSL_CERT_FILE is fixed for the process lifetime (callers set it before loading the library), so
   // read it once and return a reference to the cached path for every request.
   static const std::string ca_bundle = [] {
@@ -62,9 +62,8 @@ HttpRawResult HttpRequestRaw(const Azure::Core::Http::HttpMethod& method,
   WinHttpTransport transport;
 #else
   // libcurl does not honor SSL_CERT_FILE (its compiled-in default CA path is absent on Android), so
-  // we pass the CA bundle explicitly via CAInfo. The options are cached and shared (see
-  // http/curl_transport.h) and copied into the per-request transport.
-  CurlTransport transport(CachedCurlTransportOptions());
+  // pass the CA bundle explicitly via CAInfo (see http/curl_transport.h).
+  CurlTransport transport(MakeCurlTransportOptions());
 #endif
 
   // Build the request. For methods with a body (POST), attach a MemoryBodyStream.

--- a/sdk_v2/cpp/src/http/http_client.h
+++ b/sdk_v2/cpp/src/http/http_client.h
@@ -34,7 +34,7 @@ struct HttpRequestOptions {
 /// does not exist on platforms like Android), so every libcurl-based transport we construct — direct
 /// requests, file downloads, and the Azure Storage blob client — must pass this explicitly as
 /// `CAInfo`. On desktop Windows the WinHTTP transport uses the OS trust store and ignores this.
-const std::string& CaBundleFile();
+const std::string& CABundleFilePath();
 
 /// Perform an HTTP POST and return status, headers, and body without throwing on non-2xx responses.
 /// Transport failures are returned as `status == 0` with the error message in `body`.

--- a/sdk_v2/cpp/src/http/http_client.h
+++ b/sdk_v2/cpp/src/http/http_client.h
@@ -28,12 +28,13 @@ struct HttpRequestOptions {
 };
 
 /// Returns the CA bundle file path from the `SSL_CERT_FILE` environment variable, or an empty
-/// string when it is unset/empty. The bundled libcurl does not consult `SSL_CERT_FILE`
-/// automatically (it was built with a compiled-in default CA path that does not exist on platforms
-/// like Android), so every libcurl-based transport we construct — direct requests, file downloads,
-/// and the Azure Storage blob client — must pass this explicitly as `CAInfo`. On desktop Windows the
-/// WinHTTP transport uses the OS trust store and ignores this.
-std::string CaBundleFile();
+/// string when it is unset/empty. The value is read once and cached for the process lifetime, so a
+/// reference to the cached string is returned (valid until process exit). The bundled libcurl does
+/// not consult `SSL_CERT_FILE` automatically (it was built with a compiled-in default CA path that
+/// does not exist on platforms like Android), so every libcurl-based transport we construct — direct
+/// requests, file downloads, and the Azure Storage blob client — must pass this explicitly as
+/// `CAInfo`. On desktop Windows the WinHTTP transport uses the OS trust store and ignores this.
+const std::string& CaBundleFile();
 
 /// Perform an HTTP POST and return status, headers, and body without throwing on non-2xx responses.
 /// Transport failures are returned as `status == 0` with the error message in `body`.

--- a/sdk_v2/cpp/src/http/http_download.cc
+++ b/sdk_v2/cpp/src/http/http_download.cc
@@ -46,8 +46,8 @@ bool HttpDownloadFile(const std::string& url,
   WinHttpTransport transport;
 #else
   // libcurl does not honor SSL_CERT_FILE (its compiled-in default CA path is absent on Android), so
-  // pass the shared CA bundle explicitly via CAInfo (see http/curl_transport.h).
-  CurlTransport transport(http::CachedCurlTransportOptions());
+  // pass the CA bundle explicitly via CAInfo (see http/curl_transport.h).
+  CurlTransport transport(http::MakeCurlTransportOptions());
 #endif
   Request request(HttpMethod::Get, Url(url));
   request.SetHeader("User-Agent", user_agent);

--- a/sdk_v2/cpp/src/http/http_download.cc
+++ b/sdk_v2/cpp/src/http/http_download.cc
@@ -15,6 +15,8 @@
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
 #include <azure/core/http/win_http_transport.hpp>
 #else
+#include "http/curl_transport.h"
+
 #include <azure/core/http/curl_transport.hpp>
 #endif
 
@@ -43,14 +45,9 @@ bool HttpDownloadFile(const std::string& url,
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
   WinHttpTransport transport;
 #else
-  // The bundled libcurl does not honor the SSL_CERT_FILE environment variable (it was built with a
-  // compiled-in default CA path that does not exist on platforms like Android). Explicitly pass the
-  // CA bundle via CAInfo so the caller-provided trust store is actually used for TLS verification.
-  CurlTransportOptions curl_opts;
-  if (std::string ca_bundle = http::CaBundleFile(); !ca_bundle.empty()) {
-    curl_opts.CAInfo = std::move(ca_bundle);
-  }
-  CurlTransport transport(curl_opts);
+  // libcurl does not honor SSL_CERT_FILE (its compiled-in default CA path is absent on Android), so
+  // pass the shared CA bundle explicitly via CAInfo (see http/curl_transport.h).
+  CurlTransport transport(http::CachedCurlTransportOptions());
 #endif
   Request request(HttpMethod::Get, Url(url));
   request.SetHeader("User-Agent", user_agent);


### PR DESCRIPTION
~~The cert file can be quite large on Android (IIRC > 50 system certs on the device tested a while ago). Suggestions to cache that as well as the CurlTransportOptions to minimize cost given the certs (AFAIK) aren't expected to change during the lifetime of the FL manager.~~

Ignore that description. My mental model was off. Changes are a lot more minor after injecting reality.

@sheetalarkadam pick-and-choose anything you want. PR targets your branch if you want it all.