### PR TITLE
fix(cpp): source the GenAI Android AAR from NuGet instead of GitHub Releases

### DIFF
--- a/.pipelines/v2/templates/steps-prefetch-nuget.yml
+++ b/.pipelines/v2/templates/steps-prefetch-nuget.yml
@@ -7,6 +7,10 @@
 # Parameters:
 #   ortVersion     – Microsoft.ML.OnnxRuntime version
 #   genaiVersion   – Microsoft.ML.OnnxRuntimeGenAI.Foundry version
+#   genaiPackageId – GenAI package to pre-download. Defaults to the .Foundry
+#                    meta-package used by the desktop platforms; Android must
+#                    override this with the base Microsoft.ML.OnnxRuntimeGenAI
+#                    package, which is the only one that ships the Android AAR.
 #   winmlVersion   – Microsoft.Windows.AI.MachineLearning version (Windows only)
 #   includeWinml   – Download WinML and emit WINML_EP_CATALOG_FETCH_URL
 #   shell          – 'pwsh' (Windows/macOS) or 'bash' (Linux)
@@ -17,6 +21,9 @@ parameters:
   type: string
 - name: genaiVersion
   type: string
+- name: genaiPackageId
+  type: string
+  default: 'Microsoft.ML.OnnxRuntimeGenAI.Foundry'
 - name: winmlVersion
   type: string
   default: ''
@@ -83,7 +90,7 @@ steps:
         $feed = "https://www.nuget.org/api/v2/package"
 
         $packages = @(
-          @{ key = 'genai'; id = 'Microsoft.ML.OnnxRuntimeGenAI.Foundry'; version = '${{ parameters.genaiVersion }}' },
+          @{ key = 'genai'; id = '${{ parameters.genaiPackageId }}'; version = '${{ parameters.genaiVersion }}' },
           @{ key = 'ort';   id = 'Microsoft.ML.OnnxRuntime';             version = '${{ parameters.ortVersion }}'   }
         )
 
@@ -131,7 +138,7 @@ steps:
       feed="https://www.nuget.org/api/v2/package"
 
       declare -a entries=(
-        "genai:Microsoft.ML.OnnxRuntimeGenAI.Foundry:${{ parameters.genaiVersion }}"
+        "genai:${{ parameters.genaiPackageId }}:${{ parameters.genaiVersion }}"
         "ort:Microsoft.ML.OnnxRuntime:${{ parameters.ortVersion }}"
       )
       if [ "${{ parameters.includeWinml }}" = "True" ]; then

--- a/sdk_v2/cpp/CMakeLists.txt
+++ b/sdk_v2/cpp/CMakeLists.txt
@@ -441,6 +441,18 @@ if(TARGET OnnxRuntime::OnnxRuntime)
                 $<TARGET_FILE_DIR:foundry_local>
         )
 
+        # GenAI 0.15.0+ splits its matrix-multiplication kernels into a separate
+        # libmat.so that libonnxruntime-genai.so links against (DT_NEEDED). It is
+        # absent from older packages and from the desktop builds, so only copy it
+        # when the package actually ships it.
+        if(EXISTS "${ORT_GENAI_LIB_DIR}/libmat.so")
+            add_custom_command(TARGET foundry_local POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${ORT_GENAI_LIB_DIR}/libmat.so"
+                    $<TARGET_FILE_DIR:foundry_local>
+            )
+        endif()
+
         if(EXISTS "${ORT_LIB_DIR}/libonnxruntime_providers_shared.so")
             add_custom_command(TARGET foundry_local POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/sdk_v2/cpp/cmake/FindOnnxRuntimeGenAI.cmake
+++ b/sdk_v2/cpp/cmake/FindOnnxRuntimeGenAI.cmake
@@ -127,7 +127,10 @@ if(NOT ORT_GENAI_VERSION)
 endif()
 
 # Allow the pipeline or caller to override the download URL (e.g., to use a local
-# file:// path when direct nuget.org access is blocked in CI).
+# file:// path when direct nuget.org access is blocked in CI). When cross-compiling
+# for Android the override must point at a package that ships the Android AAR --
+# the base Microsoft.ML.OnnxRuntimeGenAI package, not the desktop-only .Foundry
+# meta-package selected above.
 if(NOT GENAI_FETCH_URL)
     # Dev builds come from the ADO nightly feed; release versions come from nuget.org.
     if(ORT_GENAI_VERSION MATCHES "-dev-")
@@ -173,8 +176,20 @@ if(ANDROID)
     set(_GENAI_ANDROID_DIR "${genailib_SOURCE_DIR}/runtimes/android/native")
     set(_GENAI_AAR_PATH "${_GENAI_ANDROID_DIR}/onnxruntime-genai.aar")
     if(NOT EXISTS "${_GENAI_AAR_PATH}")
-        message(FATAL_ERROR "GenAI Android AAR not found at ${_GENAI_AAR_PATH}. "
-                            "Ensure the package contains Android binaries (e.g. Microsoft.ML.OnnxRuntimeGenAI).")
+        # Most likely cause: the package that was fetched has no Android binaries.
+        # Only the base Microsoft.ML.OnnxRuntimeGenAI package ships them; the
+        # .Foundry meta-package is desktop-only. A caller-supplied
+        # GENAI_FETCH_URL bypasses the package selection above, so it must point
+        # at the base package when cross-compiling for Android.
+        string(CONCAT _GENAI_AAR_HINT
+               "Expected the base Microsoft.ML.OnnxRuntimeGenAI package, which ships Android binaries; "
+               "the .Foundry meta-package does not.")
+        if(GENAI_FETCH_URL)
+            string(CONCAT _GENAI_AAR_HINT "${_GENAI_AAR_HINT}"
+                   " GENAI_FETCH_URL was supplied by the caller (${GENAI_FETCH_URL});"
+                   " point it at the base package for Android builds.")
+        endif()
+        message(FATAL_ERROR "GenAI Android AAR not found at ${_GENAI_AAR_PATH}. ${_GENAI_AAR_HINT}")
     endif()
     if(NOT EXISTS "${_GENAI_ANDROID_DIR}/jni")
         file(ARCHIVE_EXTRACT INPUT "${_GENAI_AAR_PATH}" DESTINATION "${_GENAI_ANDROID_DIR}/")

--- a/sdk_v2/cpp/cmake/FindOnnxRuntimeGenAI.cmake
+++ b/sdk_v2/cpp/cmake/FindOnnxRuntimeGenAI.cmake
@@ -106,6 +106,12 @@ else()
 endif()
 
 set(_GENAI_PACKAGE_NAME "Microsoft.ML.OnnxRuntimeGenAI.Foundry")
+if(ANDROID)
+    # The Foundry meta-package ships desktop RIDs only; the base package embeds
+    # an AAR with the Android headers and native .so files. Mirrors the same
+    # split handled in FindOnnxRuntime.cmake.
+    set(_GENAI_PACKAGE_NAME "Microsoft.ML.OnnxRuntimeGenAI")
+endif()
 
 if(NOT ORT_GENAI_VERSION)
     # Single source of truth: sdk_v2/deps_versions.json. The Python SDK build
@@ -120,75 +126,63 @@ if(NOT ORT_GENAI_VERSION)
     message(STATUS "ORT_GENAI_VERSION=${ORT_GENAI_VERSION} (from ${_GENAI_DEPS_FILE})")
 endif()
 
-if(ANDROID)
-    # GenAI publishes a standalone AAR on GitHub Releases that contains
-    # both C/C++ headers and native .so files — no NuGet package needed.
-    set(_GENAI_AAR_URL "https://github.com/microsoft/onnxruntime-genai/releases/download/v${ORT_GENAI_VERSION}/onnxruntime-genai-android-${ORT_GENAI_VERSION}.aar")
-    set(_GENAI_AAR_DIR "${CMAKE_BINARY_DIR}/_deps/genai-android-aar")
-    set(_GENAI_AAR_FILE "${_GENAI_AAR_DIR}/onnxruntime-genai-android.aar")
-
-    if(NOT EXISTS "${_GENAI_AAR_FILE}")
-        message(STATUS "Downloading ORT GenAI Android AAR v${ORT_GENAI_VERSION} from GitHub Releases")
-        file(DOWNLOAD "${_GENAI_AAR_URL}" "${_GENAI_AAR_FILE}"
-             STATUS _GENAI_DL_STATUS)
-        list(GET _GENAI_DL_STATUS 0 _GENAI_DL_CODE)
-        if(NOT _GENAI_DL_CODE EQUAL 0)
-            list(GET _GENAI_DL_STATUS 1 _GENAI_DL_MSG)
-            message(FATAL_ERROR "Failed to download GenAI AAR: ${_GENAI_DL_MSG}")
-        endif()
-    endif()
-
-    if(NOT EXISTS "${_GENAI_AAR_DIR}/jni")
-        file(ARCHIVE_EXTRACT INPUT "${_GENAI_AAR_FILE}"
-             DESTINATION "${_GENAI_AAR_DIR}")
-    endif()
-
-    set(_GENAI_HEADER_DIR "${_GENAI_AAR_DIR}/headers")
-    set(_GENAI_LIB_DIR "${_GENAI_AAR_DIR}/jni/${ANDROID_ABI}")
-
-    message(STATUS "OnnxRuntimeGenAI via GitHub AAR: ${_GENAI_AAR_DIR}")
-else()
-    # Allow the pipeline or caller to override the download URL (e.g., to use a local
-    # file:// path when direct nuget.org access is blocked in CI).
-    if(NOT GENAI_FETCH_URL)
-        # Dev builds come from the ADO nightly feed; release versions come from nuget.org.
-        if(ORT_GENAI_VERSION MATCHES "-dev-")
-            set(ORT_GENAI_FEED_ORG  "aiinfra")
-            set(ORT_GENAI_FEED_PROJECT "2692857e-05ef-43b4-ba9c-ccf1c22c437c")
-            set(ORT_GENAI_FEED_ID   "7982ae20-ed19-4a35-a362-a96ac99897b7")
-            set(GENAI_FETCH_URL "https://pkgs.dev.azure.com/${ORT_GENAI_FEED_ORG}/${ORT_GENAI_FEED_PROJECT}/_apis/packaging/feeds/${ORT_GENAI_FEED_ID}/nuget/packages/${_GENAI_PACKAGE_NAME}/versions/${ORT_GENAI_VERSION}/content?api-version=6.0-preview.1")
-            message(STATUS "Downloading ${_GENAI_PACKAGE_NAME} ${ORT_GENAI_VERSION} from ORT-Nightly feed")
-        else()
-            string(TOLOWER "${_GENAI_PACKAGE_NAME}" _GENAI_PACKAGE_LOWER)
-            set(GENAI_FETCH_URL "https://api.nuget.org/v3-flatcontainer/${_GENAI_PACKAGE_LOWER}/${ORT_GENAI_VERSION}/${_GENAI_PACKAGE_LOWER}.${ORT_GENAI_VERSION}.nupkg")
-            message(STATUS "Downloading ${_GENAI_PACKAGE_NAME} ${ORT_GENAI_VERSION} from nuget.org")
-        endif()
+# Allow the pipeline or caller to override the download URL (e.g., to use a local
+# file:// path when direct nuget.org access is blocked in CI).
+if(NOT GENAI_FETCH_URL)
+    # Dev builds come from the ADO nightly feed; release versions come from nuget.org.
+    if(ORT_GENAI_VERSION MATCHES "-dev-")
+        set(ORT_GENAI_FEED_ORG  "aiinfra")
+        set(ORT_GENAI_FEED_PROJECT "2692857e-05ef-43b4-ba9c-ccf1c22c437c")
+        set(ORT_GENAI_FEED_ID   "7982ae20-ed19-4a35-a362-a96ac99897b7")
+        set(GENAI_FETCH_URL "https://pkgs.dev.azure.com/${ORT_GENAI_FEED_ORG}/${ORT_GENAI_FEED_PROJECT}/_apis/packaging/feeds/${ORT_GENAI_FEED_ID}/nuget/packages/${_GENAI_PACKAGE_NAME}/versions/${ORT_GENAI_VERSION}/content?api-version=6.0-preview.1")
+        message(STATUS "Downloading ${_GENAI_PACKAGE_NAME} ${ORT_GENAI_VERSION} from ORT-Nightly feed")
     else()
-        message(STATUS "Using caller-provided GENAI_FETCH_URL: ${GENAI_FETCH_URL}")
+        string(TOLOWER "${_GENAI_PACKAGE_NAME}" _GENAI_PACKAGE_LOWER)
+        set(GENAI_FETCH_URL "https://api.nuget.org/v3-flatcontainer/${_GENAI_PACKAGE_LOWER}/${ORT_GENAI_VERSION}/${_GENAI_PACKAGE_LOWER}.${ORT_GENAI_VERSION}.nupkg")
+        message(STATUS "Downloading ${_GENAI_PACKAGE_NAME} ${ORT_GENAI_VERSION} from nuget.org")
     endif()
+else()
+    message(STATUS "Using caller-provided GENAI_FETCH_URL: ${GENAI_FETCH_URL}")
+endif()
 
-    # Normalize to forward slashes — backslashes from Windows paths cause CMake
-    # string-parsing errors inside FetchContent/ExternalProject_Add.
-    string(REPLACE "\\" "/" GENAI_FETCH_URL "${GENAI_FETCH_URL}")
+# Normalize to forward slashes — backslashes from Windows paths cause CMake
+# string-parsing errors inside FetchContent/ExternalProject_Add.
+string(REPLACE "\\" "/" GENAI_FETCH_URL "${GENAI_FETCH_URL}")
 
-    # CMake's ExternalProject doesn't recognize .nupkg as an archive format.
-    # Since .nupkg is just a ZIP file, copy it with a .zip extension if it's a local file.
-    if(GENAI_FETCH_URL MATCHES "\\.nupkg$" AND NOT GENAI_FETCH_URL MATCHES "^https?://")
-        set(_GENAI_ZIP_PATH "${CMAKE_BINARY_DIR}/_deps/genai-download/genai.zip")
-        get_filename_component(_GENAI_ZIP_DIR "${_GENAI_ZIP_PATH}" DIRECTORY)
-        file(MAKE_DIRECTORY "${_GENAI_ZIP_DIR}")
-        file(COPY_FILE "${GENAI_FETCH_URL}" "${_GENAI_ZIP_PATH}")
-        set(GENAI_FETCH_URL "${_GENAI_ZIP_PATH}")
-        message(STATUS "Copied .nupkg to .zip for CMake extraction: ${GENAI_FETCH_URL}")
+# CMake's ExternalProject doesn't recognize .nupkg as an archive format.
+# Since .nupkg is just a ZIP file, copy it with a .zip extension if it's a local file.
+if(GENAI_FETCH_URL MATCHES "\\.nupkg$" AND NOT GENAI_FETCH_URL MATCHES "^https?://")
+    set(_GENAI_ZIP_PATH "${CMAKE_BINARY_DIR}/_deps/genai-download/genai.zip")
+    get_filename_component(_GENAI_ZIP_DIR "${_GENAI_ZIP_PATH}" DIRECTORY)
+    file(MAKE_DIRECTORY "${_GENAI_ZIP_DIR}")
+    file(COPY_FILE "${GENAI_FETCH_URL}" "${_GENAI_ZIP_PATH}")
+    set(GENAI_FETCH_URL "${_GENAI_ZIP_PATH}")
+    message(STATUS "Copied .nupkg to .zip for CMake extraction: ${GENAI_FETCH_URL}")
+endif()
+
+FetchContent_Declare(genailib
+    URL ${GENAI_FETCH_URL}
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    DOWNLOAD_NAME genai.zip  # .nupkg is a ZIP; force CMake to recognize the format
+)
+FetchContent_MakeAvailable(genailib)
+
+if(ANDROID)
+    # The NuGet package embeds an AAR with the headers and native .so files.
+    # Extract it to get headers/ and jni/<abi>/libonnxruntime-genai.so.
+    set(_GENAI_ANDROID_DIR "${genailib_SOURCE_DIR}/runtimes/android/native")
+    set(_GENAI_AAR_PATH "${_GENAI_ANDROID_DIR}/onnxruntime-genai.aar")
+    if(NOT EXISTS "${_GENAI_AAR_PATH}")
+        message(FATAL_ERROR "GenAI Android AAR not found at ${_GENAI_AAR_PATH}. "
+                            "Ensure the package contains Android binaries (e.g. Microsoft.ML.OnnxRuntimeGenAI).")
     endif()
-
-    FetchContent_Declare(genailib
-        URL ${GENAI_FETCH_URL}
-        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-        DOWNLOAD_NAME genai.zip  # .nupkg is a ZIP; force CMake to recognize the format
-    )
-    FetchContent_MakeAvailable(genailib)
-
+    if(NOT EXISTS "${_GENAI_ANDROID_DIR}/jni")
+        file(ARCHIVE_EXTRACT INPUT "${_GENAI_AAR_PATH}" DESTINATION "${_GENAI_ANDROID_DIR}/")
+    endif()
+    set(_GENAI_HEADER_DIR "${_GENAI_ANDROID_DIR}/headers")
+    set(_GENAI_LIB_DIR    "${_GENAI_ANDROID_DIR}/jni/${ANDROID_ABI}")
+    message(STATUS "Extracted GenAI Android AAR: ${_GENAI_AAR_PATH}")
+else()
     set(_GENAI_HEADER_DIR "${genailib_SOURCE_DIR}/build/native/include")
     set(_GENAI_LIB_DIR    "${genailib_SOURCE_DIR}/runtimes/${_GENAI_PLATFORM}/native")
 endif()


### PR DESCRIPTION
## Problem

Android resolved `onnxruntime-genai` from a standalone AAR attached to a **GitHub release**, while every desktop platform resolved it from **NuGet**. The two origins do not publish the same versions:

| Version | nuget.org | GitHub release |
|---|---|---|
| 0.15.2 | yes | **no** |
| **0.15.1** (pin on `main`) | yes | **no release or tag** |
| 0.15.0 | yes | yes |
| 0.14.1 | yes | **no** |

`FindOnnxRuntimeGenAI.cmake` built the URL from the pinned version, so on the current pin the Android build cannot configure at all -- the AAR URL 404s -- while all five desktop legs stay green. Any `.z` bump can reintroduce this.

## Fix

The base `Microsoft.ML.OnnxRuntimeGenAI` package already ships the Android binaries at `runtimes/android/native/onnxruntime-genai.aar` (same headers, both ABIs, 20.57 MB -- byte-identical in content to the GitHub asset). Only the `.Foundry` meta-package omits them.

### Also fixes a silent stale-cache path

The AAR was cached under a version-less filename and re-extraction was skipped when `jni/` already existed, so bumping the pin reused whatever AAR had been downloaded first **while logging the newly pinned version**. CI never saw it (fresh binary dir); developers did. `FetchContent` keys its cache on the URL, so a bump now actually refetches.

## Validation

**Android arm64-v8a, clean tree, against the 0.15.1 pin that previously could not be fetched:**

```
-- ORT_GENAI_VERSION=0.15.1 (from .../deps_versions.json)
-- Downloading Microsoft.ML.OnnxRuntimeGenAI 0.15.1 from nuget.org
-- Extracted GenAI Android AAR: .../runtimes/android/native/onnxruntime-genai.aar
[85/158] Linking CXX shared library bin/libfoundry_local.so
```


## Notes

- Trade-off: Android now downloads the full ~104 MB nupkg rather than a 20 MB AAR.
- The AAR is not published to Maven, so NuGet and GitHub Releases were the only two candidate sources.
- No version divergence is introduced: one pin still drives every platform.
