### PR TITLE
Add gemma4 support

### DIFF
--- a/sdk_v2/cpp/src/inferencing/generative/genai_config.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/genai_config.cc
@@ -10,7 +10,7 @@ namespace fl {
 
 bool GenAIConfig::OnnxModel::IsMultiModal() const {
   return type == "phi3v" || type == "whisper" || type == "phi4mm" || type == "fara" ||
-         type == "qwen2_5_vl" || type == "qwen3_vl" || type == "qwen3_5";
+         type == "qwen2_5_vl" || type == "qwen3_vl" || type == "qwen3_5" || type == "gemma4";
 }
 
 std::string GenAIConfig::DefaultProvider() const {

--- a/sdk_v2/cpp/src/inferencing/generative/genai_config.h
+++ b/sdk_v2/cpp/src/inferencing/generative/genai_config.h
@@ -28,7 +28,7 @@ struct GenAIConfig {
     std::optional<Decoder> decoder;
 
     /// Returns true if the model type is multimodal (phi3v, whisper, phi4mm, fara,
-    /// qwen2_5_vl, qwen3_vl, qwen3_5).
+    /// qwen2_5_vl, qwen3_vl, qwen3_5, gemma4).
     bool IsMultiModal() const;
   };
 

--- a/sdk_v2/cpp/test/internal_api/genai_config_test.cc
+++ b/sdk_v2/cpp/test/internal_api/genai_config_test.cc
@@ -67,6 +67,9 @@ TEST(GenAIConfigModelTest, IsMultiModalTrueForKnownTypes) {
 
   model.type = "qwen3_5";
   EXPECT_TRUE(model.IsMultiModal());
+
+  model.type = "gemma4";
+  EXPECT_TRUE(model.IsMultiModal());
 }
 
 TEST(GenAIConfigModelTest, IsMultiModalFalseForOtherTypes) {


### PR DESCRIPTION
This pull request updates the multi-modal model support in the GenAI configuration by adding a new model type and ensuring documentation and tests reflect this change.

**Multi-modal model support:**
* Added `"gemma4"` to the list of recognized multi-modal model types in the `IsMultiModal()` method in `genai_config.cc`.
* Updated the documentation comment in `genai_config.h` to include `"gemma4"` as a multi-modal model type.

**Testing:**
* Added a test case in `genai_config_test.cc` to verify that `"gemma4"` is correctly identified as a multi-modal model.