### PR TITLE
Validate packaged SDKs with real consumer samples

### DIFF
--- a/.pipelines/v2/templates/stages-build-native.yml
+++ b/.pipelines/v2/templates/stages-build-native.yml
@@ -345,15 +345,18 @@ stages:
             @echo off
             call "$vsDevCmd" -arch=x64 -host_arch=x64
             if errorlevel 1 exit /b %errorlevel%
-            cl /nologo /EHsc /std:c++17 /I"$consumerDir\include" "$source" /Fe:"$consumerDir\basic_chat.exe" /link /LIBPATH:"$consumerDir\lib" foundry_local.lib
+            cl /nologo /EHsc /std:c++17 /I"$consumerDir\include" "$source" /Fe:"$consumerDir\lib\basic_chat.exe" /link /LIBPATH:"$consumerDir\lib" foundry_local.lib
             "@ | Set-Content -Path $cmdFile
             & $cmdFile
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-            $env:PATH = "$consumerDir\lib;$env:PATH"
+            # The executable sits beside every packaged DLL. Keep PATH limited
+            # to Windows system DLLs so an agent-installed ORT cannot mask a
+            # broken bundle.
+            $env:PATH = "$env:SystemRoot\System32"
             $env:FOUNDRY_LOCAL_SAMPLE_CACHE_DIR = Join-Path '$(Agent.TempDirectory)' 'cpp-package-model-cache'
             if (Test-Path $env:FOUNDRY_LOCAL_SAMPLE_CACHE_DIR) {
               Remove-Item $env:FOUNDRY_LOCAL_SAMPLE_CACHE_DIR -Recurse -Force
             }
-            & (Join-Path $consumerDir 'basic_chat.exe')
+            & (Join-Path $consumerDir 'lib\basic_chat.exe')
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.pipelines/v2/templates/stages-build-native.yml
+++ b/.pipelines/v2/templates/stages-build-native.yml
@@ -292,3 +292,68 @@ stages:
         parameters:
           ortVersion: ${{ parameters.ortVersion }}
           genaiVersion: ${{ parameters.genaiVersion }}
+
+  # ====================================================================
+  # Package test — consume the Windows x64 C++ SDK bundle
+  # ====================================================================
+  - stage: cpp_package_test
+    displayName: 'C++ SDK: Test packaged bundle'
+    dependsOn:
+    - cpp_pack_sdk_v2
+    jobs:
+    - job: test
+      pool:
+        name: onnxruntime-Win-CPU-2022
+        os: windows
+      templateContext:
+        inputs:
+        - input: pipelineArtifact
+          artifactName: 'cpp-sdk-v2'
+          targetPath: '$(Pipeline.Workspace)/cpp-sdk-v2'
+      steps:
+      - checkout: self
+        clean: true
+      - task: PowerShell@2
+        displayName: 'Compile and link basic_chat sample'
+        inputs:
+          targetType: inline
+          pwsh: true
+          script: |
+            $ErrorActionPreference = 'Stop'
+
+            $archive = Get-ChildItem '$(Pipeline.Workspace)/cpp-sdk-v2' -Recurse -Filter '*win-x64.tgz' |
+              Select-Object -First 1
+            if (-not $archive) { throw 'Windows x64 C++ SDK archive not found' }
+
+            $consumerDir = Join-Path '$(Agent.TempDirectory)' 'cpp-sdk-package-test'
+            if (Test-Path $consumerDir) { Remove-Item -Recurse -Force $consumerDir }
+            New-Item -ItemType Directory -Force -Path $consumerDir | Out-Null
+            tar -xzf $archive.FullName -C $consumerDir
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+            $source = '$(Build.SourcesDirectory)/sdk_v2/cpp/examples/basic_chat/main.cc'
+            if (-not (Test-Path $source)) { throw "C++ basic_chat sample not found: $source" }
+
+            $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+            $vsInstall = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+              -property installationPath
+            if (-not $vsInstall) { throw 'Visual Studio C++ toolchain not found' }
+            $vsDevCmd = Join-Path $vsInstall 'Common7\Tools\VsDevCmd.bat'
+
+            $cmdFile = Join-Path $consumerDir 'build.cmd'
+            @"
+            @echo off
+            call "$vsDevCmd" -arch=x64 -host_arch=x64
+            if errorlevel 1 exit /b %errorlevel%
+            cl /nologo /EHsc /std:c++17 /I"$consumerDir\include" "$source" /Fe:"$consumerDir\basic_chat.exe" /link /LIBPATH:"$consumerDir\lib" foundry_local.lib
+            "@ | Set-Content -Path $cmdFile
+            & $cmdFile
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+            $env:PATH = "$consumerDir\lib;$env:PATH"
+            $env:FOUNDRY_LOCAL_SAMPLE_CACHE_DIR = Join-Path '$(Agent.TempDirectory)' 'cpp-package-model-cache'
+            if (Test-Path $env:FOUNDRY_LOCAL_SAMPLE_CACHE_DIR) {
+              Remove-Item $env:FOUNDRY_LOCAL_SAMPLE_CACHE_DIR -Recurse -Force
+            }
+            & (Join-Path $consumerDir 'basic_chat.exe')
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.pipelines/v2/templates/stages-cs.yml
+++ b/.pipelines/v2/templates/stages-cs.yml
@@ -279,9 +279,11 @@ stages:
           }
           dotnet restore $project `
             --configfile (Join-Path $consumerDir 'NuGet.config') `
+            --runtime win-x64 `
             /p:FoundryLocalPackageVersion=$version
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          dotnet run --project $project --no-restore /p:FoundryLocalPackageVersion=$version
+          dotnet run --project $project --no-restore --runtime win-x64 `
+            /p:FoundryLocalPackageVersion=$version
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       env:
         FOUNDRY_LOCAL_SAMPLE_CACHE_DIR: '$(Agent.TempDirectory)/cs-package-model-cache'

--- a/.pipelines/v2/templates/stages-cs.yml
+++ b/.pipelines/v2/templates/stages-cs.yml
@@ -268,7 +268,6 @@ stages:
             <packageSources>
               <clear />
               <add key="LocalPackages" value="$feedDir" />
-              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
               <add key="AIFoundryLocal_PublicPackages" value="https://pkgs.dev.azure.com/aiinfra/AIFoundryLocal/_packaging/AIFoundryLocal_PublicPackages/nuget/v3/index.json" />
             </packageSources>
           </configuration>

--- a/.pipelines/v2/templates/stages-cs.yml
+++ b/.pipelines/v2/templates/stages-cs.yml
@@ -198,3 +198,91 @@ stages:
         flNugetDir: '$(Pipeline.Workspace)/cpp-nuget'
         testDataSharedDir: '$(Build.SourcesDirectory)/test-data-shared'
         additionalTestArgs: '--settings $(Build.SourcesDirectory)/sdk_v2/cs/test/FoundryLocal.Tests/sequential.runsettings'
+
+# ====================================================================
+# Package test — restore the published NuGet packages as a consumer
+# ====================================================================
+- stage: cs_package_test
+  displayName: 'C# SDK: Test packaged NuGet'
+  dependsOn:
+  - cs_build
+  jobs:
+  - job: test
+    pool:
+      name: onnxruntime-Win-CPU-2022
+      os: windows
+    templateContext:
+      inputs:
+      - input: pipelineArtifact
+        artifactName: 'version-info'
+        targetPath: '$(Pipeline.Workspace)/version-info'
+      - input: pipelineArtifact
+        artifactName: 'cpp-nuget'
+        targetPath: '$(Pipeline.Workspace)/cpp-nuget'
+      - input: pipelineArtifact
+        artifactName: 'cs-sdk-v2'
+        targetPath: '$(Pipeline.Workspace)/cs-sdk-v2'
+    steps:
+    - checkout: self
+      clean: true
+    - task: UseDotNet@2
+      displayName: 'Use .NET 10 SDK'
+      inputs:
+        packageType: sdk
+        version: '10.0.x'
+    - task: UseDotNet@2
+      displayName: 'Install .NET 9 runtime'
+      inputs:
+        packageType: runtime
+        version: '9.0.x'
+    - task: NuGetAuthenticate@1
+      displayName: 'Authenticate NuGet feeds'
+    - task: PowerShell@2
+      displayName: 'Run packaged C# basic chat sample'
+      inputs:
+        targetType: inline
+        pwsh: true
+        script: |
+          $ErrorActionPreference = 'Stop'
+
+          $consumerDir = Join-Path '$(Agent.TempDirectory)' 'cs-sdk-package-test'
+          $feedDir = Join-Path $consumerDir 'feed'
+          if (Test-Path $consumerDir) { Remove-Item -Recurse -Force $consumerDir }
+          New-Item -ItemType Directory -Force -Path $feedDir | Out-Null
+
+          $packages = @(
+            Get-ChildItem '$(Pipeline.Workspace)/cpp-nuget' -Recurse -Filter '*.nupkg' |
+              Where-Object { $_.Name -notlike '*.snupkg' } | Select-Object -First 1
+            Get-ChildItem '$(Pipeline.Workspace)/cs-sdk-v2' -Recurse -Filter '*.nupkg' |
+              Where-Object { $_.Name -notlike '*.snupkg' } | Select-Object -First 1
+          )
+          if ($packages.Count -ne 2 -or $packages -contains $null) {
+            throw 'Expected both runtime and C# SDK NuGet packages'
+          }
+          $packages | ForEach-Object { Copy-Item $_.FullName -Destination $feedDir -Force }
+
+          $version = (Get-Content '$(Pipeline.Workspace)/version-info/sdkVersion.txt' -Raw).Trim()
+          @"
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="LocalPackages" value="$feedDir" />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+              <add key="AIFoundryLocal_PublicPackages" value="https://pkgs.dev.azure.com/aiinfra/AIFoundryLocal/_packaging/AIFoundryLocal_PublicPackages/nuget/v3/index.json" />
+            </packageSources>
+          </configuration>
+          "@ | Set-Content (Join-Path $consumerDir 'NuGet.config')
+
+          $project = '$(Build.SourcesDirectory)/sdk_v2/cs/examples/BasicChat/BasicChat.csproj'
+          if (Test-Path $env:FOUNDRY_LOCAL_SAMPLE_CACHE_DIR) {
+            Remove-Item $env:FOUNDRY_LOCAL_SAMPLE_CACHE_DIR -Recurse -Force
+          }
+          dotnet restore $project `
+            --configfile (Join-Path $consumerDir 'NuGet.config') `
+            /p:FoundryLocalPackageVersion=$version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          dotnet run --project $project --no-restore /p:FoundryLocalPackageVersion=$version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      env:
+        FOUNDRY_LOCAL_SAMPLE_CACHE_DIR: '$(Agent.TempDirectory)/cs-package-model-cache'

--- a/.pipelines/v2/templates/stages-js.yml
+++ b/.pipelines/v2/templates/stages-js.yml
@@ -392,3 +392,59 @@ stages:
     - template: steps-pack-js.yml
       parameters:
         outputDir: '$(Build.ArtifactStagingDirectory)/js-sdk-v2'
+
+# =====================================================================
+# Package test — install the tarball as a clean npm consumer
+# =====================================================================
+
+- stage: js_package_test
+  displayName: 'JS SDK: Test packaged tarball'
+  dependsOn:
+  - js_pack
+  jobs:
+  - job: test
+    pool:
+      name: onnxruntime-Win-CPU-2022
+      os: windows
+    templateContext:
+      inputs:
+      - input: pipelineArtifact
+        artifactName: 'js-sdk-v2'
+        targetPath: '$(Pipeline.Workspace)/js-sdk-v2'
+    steps:
+    - checkout: self
+      clean: true
+    - task: NodeTool@0
+      displayName: 'Use Node.js 20'
+      inputs:
+        versionSpec: '20.x'
+    - task: PowerShell@2
+      displayName: 'Run packaged JS basic_chat sample'
+      inputs:
+        targetType: inline
+        pwsh: true
+        script: |
+          $ErrorActionPreference = 'Stop'
+
+          $package = Get-ChildItem '$(Pipeline.Workspace)/js-sdk-v2' -Recurse -Filter '*.tgz' |
+            Select-Object -First 1
+          if (-not $package) { throw 'JS SDK tarball not found' }
+
+          $consumerDir = Join-Path '$(Agent.TempDirectory)' 'js-sdk-package-test'
+          if (Test-Path $consumerDir) { Remove-Item -Recurse -Force $consumerDir }
+          if (Test-Path $env:FOUNDRY_LOCAL_SAMPLE_CACHE_DIR) {
+            Remove-Item $env:FOUNDRY_LOCAL_SAMPLE_CACHE_DIR -Recurse -Force
+          }
+          New-Item -ItemType Directory -Force -Path $consumerDir | Out-Null
+          Set-Location $consumerDir
+
+          npm init -y | Out-Null
+          npm install $package.FullName --no-audit --no-fund
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          $sample = Join-Path $consumerDir 'basic_chat.mjs'
+          Copy-Item '$(Build.SourcesDirectory)/sdk_v2/js/examples/basic_chat.mjs' -Destination $sample -Force
+          node $sample
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      env:
+        FOUNDRY_LOCAL_SAMPLE_CACHE_DIR: '$(Agent.TempDirectory)/js-package-model-cache'

--- a/.pipelines/v2/templates/stages-python.yml
+++ b/.pipelines/v2/templates/stages-python.yml
@@ -388,3 +388,58 @@ stages:
           Get-ChildItem -Path $outDir -Filter '*.whl' | ForEach-Object {
             Write-Host "  $($_.Name)"
           }
+
+# ====================================================================
+# Package test — install the aggregated Windows x64 wheel
+# ====================================================================
+- stage: python_package_test
+  displayName: 'Python SDK: Test packaged wheel'
+  dependsOn:
+  - python_pack_all_wheels
+  jobs:
+  - job: test
+    pool:
+      name: onnxruntime-Win-CPU-2022
+      os: windows
+    templateContext:
+      inputs:
+      - input: pipelineArtifact
+        artifactName: 'python-sdk-v2'
+        targetPath: '$(Pipeline.Workspace)/python-sdk-v2'
+    steps:
+    - checkout: self
+      clean: true
+    - task: UsePythonVersion@0
+      displayName: 'Use Python 3.12'
+      inputs:
+        versionSpec: '3.12'
+        addToPath: true
+        architecture: 'x64'
+    - task: PowerShell@2
+      displayName: 'Run packaged Python chat_completion sample'
+      inputs:
+        targetType: inline
+        pwsh: true
+        script: |
+          $ErrorActionPreference = 'Stop'
+
+          $wheel = Get-ChildItem '$(Pipeline.Workspace)/python-sdk-v2' -Recurse -Filter '*win_amd64.whl' |
+            Select-Object -First 1
+          if (-not $wheel) { throw 'Windows x64 Python wheel not found' }
+
+          $venvDir = Join-Path '$(Agent.TempDirectory)' 'python-sdk-package-test'
+          if (Test-Path $venvDir) { Remove-Item -Recurse -Force $venvDir }
+          if (Test-Path $env:FOUNDRY_LOCAL_SAMPLE_CACHE_DIR) {
+            Remove-Item $env:FOUNDRY_LOCAL_SAMPLE_CACHE_DIR -Recurse -Force
+          }
+          python -m venv $venvDir
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $python = Join-Path $venvDir 'Scripts\python.exe'
+
+          & $python -m pip install $wheel.FullName --disable-pip-version-check
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & $python '$(Build.SourcesDirectory)/sdk_v2/python/examples/chat_completion.py'
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      env:
+        FOUNDRY_LOCAL_SAMPLE_CACHE_DIR: '$(Agent.TempDirectory)/python-package-model-cache'
+        FOUNDRY_LOCAL_SKIP_EP_REGISTRATION: '1'

--- a/.pipelines/v2/templates/steps-build-linux.yml
+++ b/.pipelines/v2/templates/steps-build-linux.yml
@@ -80,13 +80,9 @@ steps:
   displayName: 'Dump vcpkg error logs'
   condition: failed()
 
-# Stage the redistributable native artifact. Vcpkg uses static linkage on
-# Linux (see sdk_v2/cpp/triplets/x64-linux.cmake), so libfoundry_local.so
-# carries its transitive deps (azure-*, spdlog, fmt, libcurl, libssl/libcrypto,
-# zlib, brotli*) inside itself — the only file we need to forward downstream
-# is libfoundry_local.so. ORT/GenAI .so files are also present in bin/ but are
-# supplied to consumers separately (pip on the Python side, NuGet on the C#
-# side); test/example binaries are not part of the redistributable surface.
+# Stage the native build artifacts. The C++ SDK bundle consumes the co-located
+# ORT/GenAI libraries directly. Python wheel staging filters them out because
+# its pip dependencies provide and preload those libraries.
 - bash: |
     set -euo pipefail
     src='$(Build.SourcesDirectory)/sdk_v2/cpp/build/Linux/${{ parameters.buildConfig }}/bin'
@@ -100,6 +96,19 @@ steps:
     fi
     cp -P "$primary" "$dst/"
     echo "  staged libfoundry_local.so"
+
+    for required in libonnxruntime.so libonnxruntime-genai.so; do
+      if [ ! -e "$src/$required" ]; then
+        echo "ERROR: $required not found at $src/$required" >&2
+        exit 1
+      fi
+    done
+    for runtime in "$src"/libonnxruntime.so* "$src"/libonnxruntime-genai.so* "$src"/libonnxruntime_providers_shared.so; do
+      if [ -e "$runtime" ]; then
+        cp -P "$runtime" "$dst/"
+        echo "  staged $(basename "$runtime")"
+      fi
+    done
 
   displayName: 'Stage native artifacts'
 

--- a/.pipelines/v2/templates/steps-build-macos.yml
+++ b/.pipelines/v2/templates/steps-build-macos.yml
@@ -81,12 +81,9 @@ steps:
   displayName: 'Dump vcpkg error logs'
   condition: failed()
 
-# Stage the redistributable native artifact. macOS has no triplet overlay so
-# vcpkg uses its default arm64-osx triplet, which is static — libfoundry_local.dylib
-# carries its transitive deps (azure-*, spdlog, fmt, libcurl, libssl/libcrypto,
-# zlib, brotli*) inside itself. ORT/GenAI .dylib files are supplied to consumers
-# separately (pip on the Python side, NuGet on the C# side); test/example binaries
-# are not part of the redistributable surface.
+# Stage the native build artifacts. The C++ SDK bundle consumes the co-located
+# ORT/GenAI libraries directly. Python wheel staging filters them out because
+# its pip dependencies provide and preload those libraries.
 - bash: |
     set -euo pipefail
     src='$(Build.SourcesDirectory)/sdk_v2/cpp/build/macOS/${{ parameters.buildConfig }}/bin'
@@ -100,6 +97,19 @@ steps:
     fi
     cp -P "$primary" "$dst/"
     echo "  staged libfoundry_local.dylib"
+
+    for required in libonnxruntime.dylib libonnxruntime-genai.dylib; do
+      if [ ! -e "$src/$required" ]; then
+        echo "ERROR: $required not found at $src/$required" >&2
+        exit 1
+      fi
+    done
+    for runtime in "$src"/libonnxruntime*.dylib; do
+      if [ -e "$runtime" ]; then
+        cp -P "$runtime" "$dst/"
+        echo "  staged $(basename "$runtime")"
+      fi
+    done
 
   displayName: 'Stage native artifacts'
 

--- a/.pipelines/v2/templates/steps-build-python.yml
+++ b/.pipelines/v2/templates/steps-build-python.yml
@@ -113,17 +113,16 @@ steps:
         if (Test-Path $dest) { Remove-Item -Recurse -Force $dest }
         New-Item -ItemType Directory -Force -Path $dest | Out-Null
 
-        # The native artifact is produced by steps-build-{windows,linux,macos}.yml
-        # which is responsible for staging exactly the right contents for the
-        # downstream wheel. Vcpkg is statically linked on every platform, so each
-        # artifact is just the primary foundry_local library plus (on Windows)
-        # its .pdb and .lib companions:
+        # The native artifact is produced by steps-build-{windows,linux,macos}.yml.
+        # C++ bundles consume its co-located ORT/GenAI libraries, but Python gets
+        # those libraries from pip dependencies, so filter them out here. The
+        # remaining files are the primary foundry_local library plus (on Windows)
+        # its .pdb, .lib, and optional WinML companions:
         #   - Windows:  foundry_local.{dll,pdb,lib}
         #   - Linux:    libfoundry_local.so
         #   - macOS:    libfoundry_local.dylib
-        # ORT/GenAI come from pip dependencies; this artifact contains only the
-        # curated Foundry Local native files.
-        $files = Get-ChildItem -Path "${{ parameters.nativeArtifactDir }}" -Recurse -File
+        $files = Get-ChildItem -Path "${{ parameters.nativeArtifactDir }}" -Recurse -File |
+            Where-Object { $_.Name -notlike 'onnxruntime*' -and $_.Name -notlike 'libonnxruntime*' }
         if ($files.Count -eq 0) {
             throw "No native artifacts found under ${{ parameters.nativeArtifactDir }}"
         }

--- a/.pipelines/v2/templates/steps-build-windows.yml
+++ b/.pipelines/v2/templates/steps-build-windows.yml
@@ -199,15 +199,9 @@ steps:
         VCPKG_ROOT: $(Build.BinariesDirectory)\vcpkg
         FOUNDRY_TEST_DATA_DIR: $(Agent.BuildDirectory)\test-data-shared
 
-# Stage the redistributable native artifacts. vcpkg statically links
-# ORT/GenAI/azure-*/spdlog/fmt/libcurl/libssl/zlib/brotli* into foundry_local.dll
-# (see sdk_v2/cpp/triplets/x64-windows.cmake), so foundry_local.dll carries that
-# payload itself. It also picks up one extra runtime dependency,
-# Microsoft.Windows.AI.MachineLearning.dll, which must travel with the wheel.
-# The WinML DLL is delay-loaded (see /DELAYLOAD in CMakeLists.txt) so it is
-# NOT needed at foundry_local.dll load time, but the cmake post-build copy
-# stages it next to foundry_local.dll for runtime EP discovery. ORT/GenAI
-# come from the onnxruntime / onnxruntime-genai-core pip deps.
+# Stage the native build artifacts. The C++ SDK bundle consumes the co-located
+# ORT/GenAI DLLs directly. Python wheel staging filters them out because its
+# pip dependencies provide and preload those libraries.
 - task: PowerShell@2
   displayName: 'Stage native artifacts'
   inputs:
@@ -223,6 +217,8 @@ steps:
         (Join-Path $binDir  'foundry_local.dll'),
         (Join-Path $binDir  'foundry_local.pdb'),
         (Join-Path $linkDir 'foundry_local.lib'),
+        (Join-Path $binDir  'onnxruntime.dll'),
+        (Join-Path $binDir  'onnxruntime-genai.dll'),
         (Join-Path $binDir  'Microsoft.Windows.AI.MachineLearning.dll')
       )
 
@@ -235,6 +231,11 @@ steps:
         Write-Host "  staged $(Split-Path -Leaf $s)"
       }
 
+      $providersShared = Join-Path $binDir 'onnxruntime_providers_shared.dll'
+      if (Test-Path $providersShared) {
+        Copy-Item -Path $providersShared -Destination $dst -Force
+        Write-Host "  staged onnxruntime_providers_shared.dll"
+      }
 
 - ${{ if eq(parameters.stageHeaders, true) }}:
   - task: CopyFiles@2

--- a/.pipelines/v2/templates/steps-pack-cpp-sdk.yml
+++ b/.pipelines/v2/templates/steps-pack-cpp-sdk.yml
@@ -42,6 +42,7 @@ steps:
           [string]$Rid,
           [string]$NativeArtifact,
           [string[]]$Files,
+          [string[]]$OptionalFiles = @(),
           # Optional: separate artifact containing companion symbol files (.dbg / .dSYM).
           # Items may be files or directory bundles; directories are copied recursively.
           [string]$SymbolsArtifact = '',
@@ -61,9 +62,9 @@ steps:
 
         Copy-Item -Path (Join-Path $includeSrc '*') -Destination $includeDst -Recurse -Force
 
-        # The SDK tgz should include only public wrapper headers.
+        # The SDK tgz should include the public wrapper headers and their public
+        # ms-gsl dependency. Only pipeline artifact metadata is excluded.
         $pathsToPrune = @(
-          (Join-Path $includeDst 'gsl'),
           (Join-Path $includeDst '_manifest')
         )
         foreach ($pathToPrune in $pathsToPrune) {
@@ -79,6 +80,14 @@ steps:
           }
           $dst = Join-Path $libDst (Split-Path -Leaf $src)
           Copy-Item -Path $src -Destination $dst -Force
+        }
+
+        foreach ($f in $OptionalFiles) {
+          $matches = @(Get-ChildItem -Path (Join-Path $nativeSrc $f) -ErrorAction SilentlyContinue)
+          foreach ($src in $matches) {
+            $dst = Join-Path $libDst $src.Name
+            Copy-Item -Path $src.FullName -Destination $dst -Force
+          }
         }
 
         if ($SymbolsArtifact) {
@@ -115,29 +124,53 @@ steps:
       New-SdkArchive -Rid 'win-x64' -NativeArtifact 'cpp-native-win-x64' -Files @(
         'foundry_local.dll',
         'foundry_local.pdb',
-        'foundry_local.lib'
+        'foundry_local.lib',
+        'onnxruntime.dll',
+        'onnxruntime-genai.dll'
+      ) -OptionalFiles @(
+        'onnxruntime_providers_shared.dll',
+        'Microsoft.Windows.AI.MachineLearning.dll'
       )
 
       New-SdkArchive -Rid 'win-arm64' -NativeArtifact 'cpp-native-win-arm64' -Files @(
         'foundry_local.dll',
         'foundry_local.pdb',
-        'foundry_local.lib'
+        'foundry_local.lib',
+        'onnxruntime.dll',
+        'onnxruntime-genai.dll'
+      ) -OptionalFiles @(
+        'onnxruntime_providers_shared.dll',
+        'Microsoft.Windows.AI.MachineLearning.dll'
       )
 
       New-SdkArchive -Rid 'linux-x64' -NativeArtifact 'cpp-native-linux-x64' -Files @(
-        'libfoundry_local.so'
+        'libfoundry_local.so',
+        'libonnxruntime.so',
+        'libonnxruntime-genai.so'
+      ) -OptionalFiles @(
+        'libonnxruntime.so.*',
+        'libonnxruntime_providers_shared.so'
       ) -SymbolsArtifact 'cpp-native-symbols-linux-x64' -SymbolItems @(
         'libfoundry_local.so.dbg'
       )
 
       New-SdkArchive -Rid 'linux-arm64' -NativeArtifact 'cpp-native-linux-arm64' -Files @(
-        'libfoundry_local.so'
+        'libfoundry_local.so',
+        'libonnxruntime.so',
+        'libonnxruntime-genai.so'
+      ) -OptionalFiles @(
+        'libonnxruntime.so.*',
+        'libonnxruntime_providers_shared.so'
       ) -SymbolsArtifact 'cpp-native-symbols-linux-arm64' -SymbolItems @(
         'libfoundry_local.so.dbg'
       )
 
       New-SdkArchive -Rid 'osx-arm64' -NativeArtifact 'cpp-native-osx-arm64' -Files @(
-        'libfoundry_local.dylib'
+        'libfoundry_local.dylib',
+        'libonnxruntime.dylib',
+        'libonnxruntime-genai.dylib'
+      ) -OptionalFiles @(
+        'libonnxruntime.*.dylib'
       ) -SymbolsArtifact 'cpp-native-symbols-osx-arm64' -SymbolItems @(
         'libfoundry_local.dylib.dSYM'
       )

--- a/sdk_v2/cpp/examples/basic_chat/main.cc
+++ b/sdk_v2/cpp/examples/basic_chat/main.cc
@@ -8,7 +8,9 @@
 
 #include <foundry_local/foundry_local_cpp.h>
 
+#include <cstdlib>
 #include <iostream>
+#include <memory>
 #include <string>
 
 using namespace foundry_local;
@@ -132,6 +134,9 @@ int main() {
     // 1. Create a configuration and manager. Manager should be a long-lived object in your app and must remain valid
     // while using the FL SDK.
     Configuration config("basic_chat");
+    if (const char* cache_dir = std::getenv("FOUNDRY_LOCAL_SAMPLE_CACHE_DIR")) {
+      config.SetModelCacheDir(cache_dir);
+    }
     Manager manager(std::move(config));
 
     // 2. Get the catalog and list all available models.
@@ -150,22 +155,31 @@ int main() {
     // 3. Look up a specific model by alias. This will return the default selected variant.
     //    Use GetModel(alias) to get a Model that contains all variants for an alias (and GetVariants/SelectVariant to choose),
     //    or GetModelVariant(id) to get a specific variant by ID.
-    auto model = catalog.GetModel("qwen2.5-0.5b");
+    std::unique_ptr<IModel> model;
+    for (const std::string alias : {"qwen2.5-0.5b", "qwen3.5-0.8b"}) {
+      auto candidate = catalog.GetModel(alias);
+      if (!candidate) {
+        continue;
+      }
+
+      ModelList variants = candidate->GetVariants();
+      for (const auto& variant : variants.Models()) {
+        ModelInfo variant_info = variant->GetInfo();
+        if (variant_info.DeviceType() == FOUNDRY_LOCAL_DEVICE_CPU &&
+            (variant_info.Task() == "chat-completion" || variant_info.Task() == "vision-language-chat")) {
+          candidate->SelectVariant(*variant);
+          model = std::move(candidate);
+          break;
+        }
+      }
+      if (model) {
+        break;
+      }
+    }
     if (!model) {
-      std::cerr << "Model not found.\n";
+      std::cerr << "No supported CPU chat model found.\n";
       return 1;
     }
-
-    // Example code to pick a variant if the default isn't suitable.
-    //
-    // // Select a CPU variant if available (the default may be GPU which requires CUDA).
-    // ModelList variants = model.GetVariants();
-    // for (Model& v : variants) {
-    //   if (v.GetInfo().DeviceType() == FOUNDRY_LOCAL_DEVICE_CPU) {
-    //     model.SelectVariant(v);
-    //     break;
-    //   }
-    // }
 
     ModelInfo info = model->GetInfo();
     std::cout << "\nUsing model: " << info.Name() << "\n";

--- a/sdk_v2/cpp/examples/basic_chat/main.cc
+++ b/sdk_v2/cpp/examples/basic_chat/main.cc
@@ -187,9 +187,9 @@ int main() {
     // 4. Download if not already cached (with cancellable progress).
     if (!model->IsCached()) {
       std::cout << "Downloading...\n";
-      model->Download([](float progress) -> bool {
+      model->Download([](float progress) -> int {
         std::cout << "\r  " << static_cast<int>(progress) << "%" << std::flush;
-        return true;  // return false to cancel
+        return 0;  // return non-zero to cancel
       });
       std::cout << "\n";
     }

--- a/sdk_v2/cs/examples/BasicChat/BasicChat.csproj
+++ b/sdk_v2/cs/examples/BasicChat/BasicChat.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAotCompatible>true</IsAotCompatible>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(FoundryLocalPackageVersion)' == ''">
+    <ProjectReference Include="../../src/Microsoft.AI.Foundry.Local.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(FoundryLocalPackageVersion)' != ''">
+    <PackageReference Include="Microsoft.AI.Foundry.Local"
+                      Version="$(FoundryLocalPackageVersion)" />
+  </ItemGroup>
+</Project>

--- a/sdk_v2/cs/examples/BasicChat/Program.cs
+++ b/sdk_v2/cs/examples/BasicChat/Program.cs
@@ -1,0 +1,123 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright company="Microsoft">
+//   Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace BasicChat;
+
+using Microsoft.AI.Foundry.Local;
+using Microsoft.Extensions.Logging.Abstractions;
+
+internal static class Program
+{
+    private static readonly string[] s_preferredModels = ["qwen2.5-0.5b", "qwen3.5-0.8b"];
+
+    public static async Task Main()
+    {
+        var modelCacheDir = Environment.GetEnvironmentVariable("FOUNDRY_LOCAL_SAMPLE_CACHE_DIR");
+        var configuration = new Configuration
+        {
+            AppName = "FoundryLocalBasicChat",
+            ModelCacheDir = string.IsNullOrWhiteSpace(modelCacheDir) ? null : modelCacheDir,
+        };
+
+        await FoundryLocalManager.CreateAsync(configuration, NullLogger.Instance).ConfigureAwait(false);
+        using var manager = FoundryLocalManager.Instance;
+
+        var catalog = await manager.GetCatalogAsync().ConfigureAwait(false);
+        var cachedModels = await catalog.GetCachedModelsAsync().ConfigureAwait(false);
+        var model = cachedModels
+            .Where(IsCpuChatModel)
+            .OrderBy(model => IsPreferredModel(model) ? 0 : 1)
+            .ThenBy(model => model.Info.FileSizeMb ?? int.MaxValue)
+            .ThenBy(model => model.Id, StringComparer.Ordinal)
+            .FirstOrDefault();
+
+        if (model is null)
+        {
+            foreach (var alias in s_preferredModels)
+            {
+                var candidate = await catalog.GetModelAsync(alias).ConfigureAwait(false);
+                var cpuVariant = candidate?.Variants
+                    .Where(IsCpuChatModel)
+                    .OrderBy(variant => variant.Info.FileSizeMb ?? int.MaxValue)
+                    .FirstOrDefault();
+                if (candidate is not null && cpuVariant is not null)
+                {
+                    candidate.SelectVariant(cpuVariant);
+                    model = candidate;
+                    break;
+                }
+            }
+            if (model is null)
+            {
+                throw new InvalidOperationException("No supported CPU chat model is available.");
+            }
+        }
+
+        Console.WriteLine($"Using model: {model.Id}");
+        if (!await model.IsCachedAsync().ConfigureAwait(false))
+        {
+            Console.WriteLine("Downloading model...");
+            await model.DownloadAsync(progress => Console.Write($"\r  {progress:F1}%")).ConfigureAwait(false);
+            Console.WriteLine();
+        }
+        await model.LoadAsync().ConfigureAwait(false);
+
+        try
+        {
+            using var session = new ChatSession(model);
+            using var request = new Request();
+            request.AddItem(MessageItem.User(
+                "What is the capital of France? Answer with only the city name."));
+
+            using var response = await session.ProcessRequestAsync(request).ConfigureAwait(false);
+            var responseText = string.Join(
+                Environment.NewLine,
+                response
+                    .OfType<MessageItem>()
+                    .Where(message => message.IsSimpleText())
+                    .Select(message => message.GetSimpleText()));
+
+            Console.WriteLine($"Assistant: {responseText}");
+
+            if (string.IsNullOrWhiteSpace(responseText))
+            {
+                throw new InvalidOperationException("The model returned an empty response.");
+            }
+
+            if (!responseText.Contains("Paris", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"Expected the response to identify Paris, but received: {responseText}");
+            }
+        }
+        finally
+        {
+            await model.UnloadAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static bool IsCpuChatModel(IModel model)
+    {
+        var info = model.Info;
+        var isChat = string.Equals(info.Task, "chat-completion", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(info.Task, "vision-language-chat", StringComparison.OrdinalIgnoreCase);
+        var isCpu = info.Runtime?.DeviceType == DeviceType.CPU
+            || string.Equals(
+                info.Runtime?.ExecutionProvider,
+                "CPUExecutionProvider",
+                StringComparison.OrdinalIgnoreCase);
+
+        return isChat && isCpu;
+    }
+
+    private static bool IsPreferredModel(IModel model)
+    {
+        return s_preferredModels.Any(preferred =>
+            string.Equals(model.Alias, preferred, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(model.Info.Name, preferred, StringComparison.OrdinalIgnoreCase)
+            || model.Id.StartsWith(preferred, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/sdk_v2/js/examples/basic_chat.mjs
+++ b/sdk_v2/js/examples/basic_chat.mjs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ChatSession, FoundryLocalManager, Item, Request } from "foundry-local-sdk";
+
+const preferredModelNames = ["qwen2.5-0.5b", "qwen3.5-0.8b"];
+const modelCacheDir = process.env.FOUNDRY_LOCAL_SAMPLE_CACHE_DIR;
+const managerConfig = { appName: "FoundryLocalBasicChat" };
+
+if (modelCacheDir?.trim()) {
+  managerConfig.modelCacheDir = modelCacheDir;
+}
+
+function isCpuChatModel(model) {
+  const info = model.info;
+  const executionProvider = info.runtime?.executionProvider ?? info.executionProvider;
+
+  return (
+    ["chat-completion", "vision-language-chat"].includes(info.task?.toLowerCase()) &&
+    (info.deviceType === "CPU" ||
+      info.runtime?.deviceType === "CPU" ||
+      executionProvider?.toLowerCase() === "cpuexecutionprovider")
+  );
+}
+
+function isPreferredModel(model) {
+  const names = [model.alias, model.info.name, model.id];
+  return names.some((name) => preferredModelNames.some((preferred) => name.toLowerCase().startsWith(preferred)));
+}
+
+function compareModels(left, right) {
+  const preferenceDifference = Number(isPreferredModel(right)) - Number(isPreferredModel(left));
+  if (preferenceDifference !== 0) {
+    return preferenceDifference;
+  }
+
+  const leftSize = left.info.fileSizeMb ?? Number.POSITIVE_INFINITY;
+  const rightSize = right.info.fileSizeMb ?? Number.POSITIVE_INFINITY;
+  if (leftSize !== rightSize) {
+    return leftSize - rightSize;
+  }
+
+  return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+}
+
+function extractText(item) {
+  if (item.type === "text") {
+    return item.text;
+  }
+  if (item.type !== "message") {
+    return "";
+  }
+  if (typeof item.content === "string") {
+    return item.content;
+  }
+  return (
+    item.parts
+      ?.filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("") ?? ""
+  );
+}
+
+const manager = await FoundryLocalManager.createAsync(managerConfig);
+let model;
+let modelLoaded = false;
+
+try {
+  const cachedModels = await manager.catalog.getCachedModels();
+  model = cachedModels.filter(isCpuChatModel).sort(compareModels)[0];
+  if (model === undefined) {
+    for (const alias of preferredModelNames) {
+      let candidate;
+      try {
+        candidate = await manager.catalog.getModel(alias);
+      } catch {
+        continue;
+      }
+      const cpuVariant = candidate.variants.filter(isCpuChatModel).sort(compareModels)[0];
+      if (cpuVariant !== undefined) {
+        candidate.selectVariant(cpuVariant);
+        model = candidate;
+        break;
+      }
+    }
+  }
+  if (model === undefined) {
+    throw new Error("No supported CPU chat model is available.");
+  }
+
+  console.log(`Using model: ${model.id}`);
+  if (!model.isCached) {
+    console.log("Downloading model...");
+    await model.download((progress) => process.stdout.write(`\r  ${progress.toFixed(1)}%`));
+    process.stdout.write("\n");
+  }
+  await model.load();
+  modelLoaded = true;
+
+  const session = new ChatSession(model);
+  try {
+    const request = new Request()
+      .addItem(Item.systemMessage("Answer accurately with only the requested city name."))
+      .addItem(Item.userMessage("What is the capital of France?"))
+      .setOptions({
+        search: {
+          doSample: false,
+          maxOutputTokens: 64,
+          seed: 42,
+          temperature: 0,
+        },
+      });
+    const response = await session.processRequest(request);
+    const responseText = response.output.map(extractText).filter(Boolean).join("\n").trim();
+
+    console.log(`Assistant: ${responseText}`);
+    if (!responseText.toLowerCase().includes("paris")) {
+      throw new Error(`Expected the response to identify Paris, but received: ${responseText}`);
+    }
+  } finally {
+    session.dispose();
+  }
+} finally {
+  try {
+    if (modelLoaded) {
+      await model.unload();
+    }
+  } finally {
+    manager.dispose();
+  }
+}

--- a/sdk_v2/js/package.json
+++ b/sdk_v2/js/package.json
@@ -27,6 +27,8 @@
     "configure:native": "node-gyp configure",
     "copy-native:dev": "node script/copy-native.mjs",
     "pack:prebuild": "node script/pack-prebuilds.mjs",
+    "stage:deps": "node script/stage-deps-versions.mjs",
+    "prepack": "npm run stage:deps",
     "install-native": "node script/install-native.cjs",
     "install": "node script/install-native.cjs",
     "build:ts": "tsc -p tsconfig.build.json",

--- a/sdk_v2/js/script/pack-prebuilds.mjs
+++ b/sdk_v2/js/script/pack-prebuilds.mjs
@@ -5,8 +5,8 @@
 // machine (see ort-loading-contract.instructions.md). The .node addon itself
 // is already produced into prebuilds/<plat>-<arch>/ by `node-gyp rebuild`.
 //
-// Also copies sdk_v2/deps_versions.json next to package.json so the published
-// tarball carries the ORT/ORT-GenAI versions that install-native.cjs needs.
+// The prepack hook separately stages sdk_v2/deps_versions.json next to
+// package.json so the tarball carries the native dependency versions.
 import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -53,8 +53,7 @@ const wanted = (() => {
 // Optional native siblings — copied when present, skipped (with a warning) when
 // not. The reg-free WinML 2.x runtime ships next to foundry_local.dll on Windows
 // so WinML hardware EPs work out of the box without an install-time download.
-const optional =
-  process.platform === "win32" ? ["Microsoft.Windows.AI.MachineLearning.dll"] : [];
+const optional = process.platform === "win32" ? ["Microsoft.Windows.AI.MachineLearning.dll"] : [];
 
 let copied = 0;
 const available = new Set(readdirSync(sourceDir));
@@ -85,14 +84,3 @@ for (const file of optional) {
 }
 
 console.log(`[pack-prebuilds] Copied ${copied} file(s) to ${destDir}`);
-
-// Also copy deps_versions.json to the package root so install-native.cjs can
-// find it when the published tarball is installed by an end user.
-const depsSrc = resolve(repoRoot, "sdk_v2", "deps_versions.json");
-const depsDst = resolve(pkgRoot, "deps_versions.json");
-if (!existsSync(depsSrc)) {
-  console.error(`[pack-prebuilds] deps_versions.json not found at ${depsSrc}`);
-  process.exit(1);
-}
-copyFileSync(depsSrc, depsDst);
-console.log(`[pack-prebuilds] Staged deps_versions.json -> ${depsDst}`);

--- a/sdk_v2/js/script/stage-deps-versions.mjs
+++ b/sdk_v2/js/script/stage-deps-versions.mjs
@@ -1,0 +1,16 @@
+import { copyFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const pkgRoot = resolve(here, "..");
+const repoRoot = resolve(pkgRoot, "..", "..");
+const depsSrc = resolve(repoRoot, "sdk_v2", "deps_versions.json");
+const depsDst = resolve(pkgRoot, "deps_versions.json");
+
+if (!existsSync(depsSrc)) {
+  throw new Error(`[stage-deps-versions] deps_versions.json not found at ${depsSrc}`);
+}
+
+copyFileSync(depsSrc, depsDst);
+console.log(`[stage-deps-versions] Staged deps_versions.json -> ${depsDst}`);

--- a/sdk_v2/python/examples/chat_completion.py
+++ b/sdk_v2/python/examples/chat_completion.py
@@ -16,7 +16,9 @@ import os
 from foundry_local_sdk import (
     ChatSession,
     Configuration,
+    DeviceType,
     FoundryLocalManager,
+    IModel,
     MessageItem,
     Request,
     RequestOptions,
@@ -25,7 +27,57 @@ from foundry_local_sdk import (
 )
 
 
-CACHED_MODEL_ALIAS = "qwen2.5-0.5b"
+PREFERRED_MODEL_PREFIXES = ("qwen2.5-0.5b", "qwen3.5-0.8b")
+SKIP_EP_REGISTRATION_ENV = "FOUNDRY_LOCAL_SKIP_EP_REGISTRATION"
+
+
+def _is_cpu_chat_model(model: IModel) -> bool:
+    info = model.info
+    return (
+        info.task in ("chat-completion", "vision-language-chat")
+        and info.runtime is not None
+        and info.runtime.device_type == DeviceType.CPU
+    )
+
+
+def _model_size_key(model: IModel) -> tuple[bool, int, str]:
+    size = model.info.file_size_mb
+    return (size is None or size <= 0, size or 0, model.id.casefold())
+
+
+def _is_preferred_model(model: IModel) -> bool:
+    info = model.info
+    return any(
+        value.casefold().startswith(prefix.casefold())
+        for prefix in PREFERRED_MODEL_PREFIXES
+        for value in (model.alias, info.name, model.id)
+        if value
+    )
+
+
+def _select_cached_cpu_chat_model(models: list[IModel]) -> IModel | None:
+    candidates = [model for model in models if _is_cpu_chat_model(model)]
+    if not candidates:
+        return None
+
+    preferred = [model for model in candidates if _is_preferred_model(model)]
+    return min(preferred or candidates, key=_model_size_key)
+
+
+def _select_downloadable_preferred_model(manager: FoundryLocalManager) -> IModel | None:
+    """Resolve the preferred model and explicitly select its CPU chat variant."""
+    for prefix in PREFERRED_MODEL_PREFIXES:
+        model = manager.catalog.get_model(prefix)
+        if model is None:
+            continue
+        if _is_cpu_chat_model(model):
+            return model
+
+        for variant in model.variants:
+            if _is_cpu_chat_model(variant):
+                model.select_variant(variant)
+                return model
+    return None
 
 
 def _print_response_text(response) -> None:
@@ -47,21 +99,26 @@ def _print_response_text(response) -> None:
 
 def main() -> None:
     # 1. Initialize the SDK
+    sample_cache_dir = os.environ.get("FOUNDRY_LOCAL_SAMPLE_CACHE_DIR") or None
     config = Configuration(
         app_name="ChatCompletionExample",
+        model_cache_dir=sample_cache_dir,
     )
     print("Initializing Foundry Local Manager")
     FoundryLocalManager.initialize(config)
     manager = FoundryLocalManager.instance
 
-    # Discover available EPs and register them so hardware-accelerated providers are usable.
-    eps = manager.discover_eps()
-    print("Available execution providers:")
-    for ep in eps:
-        print(f"  - {ep.name} (registered: {ep.is_registered})")
+    if os.environ.get(SKIP_EP_REGISTRATION_ENV) == "1":
+        print(f"Skipping execution provider registration ({SKIP_EP_REGISTRATION_ENV}=1).")
+    else:
+        # Discover and register EPs so hardware-accelerated providers are usable.
+        eps = manager.discover_eps()
+        print("Available execution providers:")
+        for ep in eps:
+            print(f"  - {ep.name} (registered: {ep.is_registered})")
 
-    ep_result = manager.download_and_register_eps()
-    print(f"EP registration success: {ep_result.success} ({ep_result.status})")
+        ep_result = manager.download_and_register_eps()
+        print(f"EP registration success: {ep_result.success} ({ep_result.status})")
 
     # 2. Print available models in the catalog and cache
     print("\nAvailable models in catalog:")
@@ -72,11 +129,16 @@ def main() -> None:
     for m in manager.catalog.get_cached_models():
         print(f"  - {m.alias} ({m.id})")
 
-    # 3. Find a model (download if not cached)
-    model = manager.catalog.get_model(CACHED_MODEL_ALIAS)
+    # 3. Prefer the known small model, but accept any cached CPU chat model.
+    model = _select_cached_cpu_chat_model(manager.catalog.get_cached_models())
     if model is None:
-        print(f"\nModel '{CACHED_MODEL_ALIAS}' not found in catalog.")
-        return
+        model = _select_downloadable_preferred_model(manager)
+        if model is None:
+            print(
+                f"\nCPU chat model matching {PREFERRED_MODEL_PREFIXES} "
+                "not found in catalog."
+            )
+            return
 
     if not model.is_cached:
         print(f"\nDownloading {model.alias}...")

--- a/sdk_v2/python/examples/chat_completion.py
+++ b/sdk_v2/python/examples/chat_completion.py
@@ -134,11 +134,10 @@ def main() -> None:
     if model is None:
         model = _select_downloadable_preferred_model(manager)
         if model is None:
-            print(
+            raise RuntimeError(
                 f"\nCPU chat model matching {PREFERRED_MODEL_PREFIXES} "
                 "not found in catalog."
             )
-            return
 
     if not model.is_cached:
         print(f"\nDownloading {model.alias}...")


### PR DESCRIPTION
## Summary

This change fixes the JavaScript SDK package installation failure and adds post-packaging validation for the C++, C#, Python, and JavaScript SDKs.

The JavaScript package install script requires `deps_versions.json` to determine which ONNX Runtime dependencies to install. The packaging pipeline previously ran `npm pack` without staging that file into the JavaScript package root, causing consumers to receive an installation error. The package now stages the shared dependency manifest automatically through npm's `prepack` lifecycle.

Each SDK packaging flow now has a Windows x64 consumer test that uses the generated package rather than source build outputs. The test installs or extracts the package, runs a checked-in basic chat sample with a clean model cache, downloads a CPU chat model, loads it, and performs inference.