### PR TITLE
Leak the Manager singleton instead of destroying it at process exit

### DIFF
--- a/sdk_v2/cpp/src/manager.cc
+++ b/sdk_v2/cpp/src/manager.cc
@@ -179,7 +179,7 @@ void SetOgaLogCallback(ILogger* logger) {
 }  // namespace
 
 std::mutex Manager::s_mutex_;
-std::unique_ptr<Manager> Manager::s_instance_;
+Manager* Manager::s_instance_ = nullptr;
 
 Manager::Manager(const Configuration& config) : config_(config) {
   config_.Validate();
@@ -414,7 +414,7 @@ Manager& Manager::Create(const Configuration& config) {
 
   created->GetLogger().Log(LogLevel::Information, "Manager initialized successfully.");
 
-  s_instance_ = std::move(created);
+  s_instance_ = created.release();
   return *s_instance_;
 }
 
@@ -431,7 +431,8 @@ Manager& Manager::Instance() {
 
 void Manager::Destroy() {
   std::lock_guard<std::mutex> lock(s_mutex_);
-  s_instance_.reset();
+  delete s_instance_;
+  s_instance_ = nullptr;
 }
 
 ICatalog& Manager::GetCatalog() { return *catalog_; }

--- a/sdk_v2/cpp/src/manager.h
+++ b/sdk_v2/cpp/src/manager.h
@@ -153,7 +153,11 @@ class Manager {
   Model CreateModel(ModelInfo info, std::string local_path);
 
   static std::mutex s_mutex_;
-  static std::unique_ptr<Manager> s_instance_;
+  // Raw pointer, deleted only in Destroy(). If a caller never calls Destroy(), the Manager is
+  // intentionally leaked at process exit rather than run through a static destructor: its native
+  // teardown (e.g. 1DS telemetry) must not run during C-runtime static destruction, after the
+  // libraries it depends on are already gone, which would crash.
+  static Manager* s_instance_;
 };
 
 }  // namespace fl


### PR DESCRIPTION
Apps that create a `FoundryLocalManager` but never destroy it crash with a segfault (exit code 139) when the process exits.

## Why

When the manager isn't destroyed, the native side is cleaned up very late, during C runtime shutdown. By that point the telemetry (1DS) library it depends on has already been torn down, so the cleanup call ends up jumping through a null pointer and the process crashes.

## Fix

Users should call destroy. But if not, don't crash by leaking.