### PR TITLE
Don't fail EP registration when an accelerator EP can't be registered

### DIFF
--- a/sdk_v2/cpp/include/foundry_local/foundry_local_c.h
+++ b/sdk_v2/cpp/include/foundry_local/foundry_local_c.h
@@ -683,7 +683,10 @@ typedef struct flApi {
   /// Download and register execution providers. Blocking.
   /// ep_names is an optional array of EP names to download. NULL = all discoverable EPs.
   /// num_ep_names is the number of entries in ep_names. Ignored when ep_names is NULL.
-  /// Returns nullptr on full success, non-null flStatus* when at least one EP failed.
+  /// A failure to download or register an optional EP is non-fatal: the SDK continues with the
+  /// remaining execution providers (CPU is always available), and per-EP status is observable via
+  /// Manager_GetDiscoverableEps (is_registered == false). Returns nullptr on success, including
+  /// such partial failures; returns a non-null flStatus* only if the operation was cancelled.
   FL_API_STATUS(Manager_DownloadAndRegisterEps, _In_ flManager* manager,
                 _In_opt_ const char* const* ep_names,
                 size_t num_ep_names,

--- a/sdk_v2/cpp/src/c_api.cc
+++ b/sdk_v2/cpp/src/c_api.cc
@@ -527,10 +527,9 @@ FL_API_STATUS_IMPL(Manager_DownloadAndRegisterEpsImpl, flManager* manager,
     return MakeStatus(FOUNDRY_LOCAL_ERROR_OPERATION_CANCELLED, "EP download cancelled by user");
   }
 
-  if (!result.success) {
-    return MakeStatus(FOUNDRY_LOCAL_ERROR_INTERNAL, result.status);
-  }
-
+  // A failed EP registration is not fatal: CPU is always available and any EPs that did register
+  // remain usable, so only a cancellation is treated as an error. The failure is logged in
+  // Manager::DownloadAndRegisterEps and observable via GetDiscoverableEps (is_registered == false).
   return nullptr;
   API_IMPL_END
 }

--- a/sdk_v2/cpp/src/c_api.cc
+++ b/sdk_v2/cpp/src/c_api.cc
@@ -527,8 +527,8 @@ FL_API_STATUS_IMPL(Manager_DownloadAndRegisterEpsImpl, flManager* manager,
     return MakeStatus(FOUNDRY_LOCAL_ERROR_OPERATION_CANCELLED, "EP download cancelled by user");
   }
 
-  // A failed EP registration is not fatal: CPU is always available and any EPs that did register
-  // remain usable, so only a cancellation is treated as an error. The failure is logged in
+  // A failed EP download/registration is not fatal: CPU is always available and any EPs that did
+  // register remain usable, so only a cancellation is treated as an error. The failure is logged in
   // Manager::DownloadAndRegisterEps and observable via GetDiscoverableEps (is_registered == false).
   return nullptr;
   API_IMPL_END

--- a/sdk_v2/cpp/src/manager.cc
+++ b/sdk_v2/cpp/src/manager.cc
@@ -559,14 +559,15 @@ EpDownloadResult Manager::DownloadAndRegisterEps(const std::vector<std::string>*
                                                  const IEpBootstrapper::ProgressCallback& progress_cb) {
   auto result = ep_detector_->DownloadAndRegisterEps(names, progress_cb);
 
-  // EP registration changes which device/EP filters the catalog uses.
-  // Invalidate so the next catalog query re-fetches with updated filters.
-  if (result.success && !result.registered_eps.empty()) {
+  // EP registration changes which device/EP filters the catalog uses. Invalidate whenever at
+  // least one EP registered — including partial success, where result.success is false because
+  // another EP failed — so the next catalog query re-fetches with the updated filters.
+  if (!result.registered_eps.empty()) {
     catalog_->InvalidateCache();
   }
 
-  // Warn if any EPs failed to register, but keep going: CPU is always available and any EPs that
-  // did register remain usable. This is not treated as an error.
+  // Warn if any EPs failed to download or register, but keep going: CPU is always available and
+  // any EPs that did register remain usable. This is not treated as an error.
   if (!result.cancelled && !result.failed_eps.empty()) {
     const auto join = [](const std::vector<std::string>& eps) {
       std::string joined;
@@ -576,7 +577,7 @@ EpDownloadResult Manager::DownloadAndRegisterEps(const std::vector<std::string>*
       return joined;
     };
 
-    std::string message = "EP registration failed for [" + join(result.failed_eps) +
+    std::string message = "Failed to download or register EP(s) [" + join(result.failed_eps) +
                           "]; continuing with the remaining execution providers (CPU is always "
                           "available";
     if (!result.registered_eps.empty()) {

--- a/sdk_v2/cpp/src/manager.cc
+++ b/sdk_v2/cpp/src/manager.cc
@@ -565,6 +565,27 @@ EpDownloadResult Manager::DownloadAndRegisterEps(const std::vector<std::string>*
     catalog_->InvalidateCache();
   }
 
+  // Warn if any EPs failed to register, but keep going: CPU is always available and any EPs that
+  // did register remain usable. This is not treated as an error.
+  if (!result.cancelled && !result.failed_eps.empty()) {
+    const auto join = [](const std::vector<std::string>& eps) {
+      std::string joined;
+      for (size_t i = 0; i < eps.size(); ++i) {
+        joined += (i ? ", " : "") + eps[i];
+      }
+      return joined;
+    };
+
+    std::string message = "EP registration failed for [" + join(result.failed_eps) +
+                          "]; continuing with the remaining execution providers (CPU is always "
+                          "available";
+    if (!result.registered_eps.empty()) {
+      message += "; also registered: [" + join(result.registered_eps) + "]";
+    }
+    message += "). See earlier logs for the underlying cause.";
+    logger_->Log(LogLevel::Warning, message);
+  }
+
   return result;
 }
 


### PR DESCRIPTION
`download_and_register_eps()` threw a `FoundryLocalException` whenever an execution provider failed to register (for example, the CUDA EP on a machine that has an NVIDIA GPU but is missing the matching CUDA runtime). Because most apps call this at startup, a single unavailable accelerator aborted the whole app; even though CPU inference was fully available.

The CPU execution provider is always available, and any other EPs that *did* register are still usable. A failed optional accelerator shouldn't be fatal.