### PR TITLE
Fix Windows CUDA EP GenAI DLL loading

### DIFF
--- a/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.cc
+++ b/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.cc
@@ -34,13 +34,15 @@ struct ExpectedBinary {
   const char* sha256;
 };
 
+constexpr const char* kCudaProviderDll = "onnxruntime_providers_cuda.dll";
+constexpr const char* kCudaGenaiDll = "onnxruntime-genai-cuda.dll";
+
 constexpr ExpectedBinary kExpectedBinaries[] = {
-    {"onnxruntime_providers_cuda.dll", "DD540FCFECFBC68B4675C9ADF09C2858CF6B054563859D79598AA2524406A76F"},
-    {"onnxruntime-genai-cuda.dll", "BC953F8E2AAFC6219B2D723B65AB8F1A9426A6B7724D6A01ED756FAE8C3DE6AE"},
+    {kCudaProviderDll, "DD540FCFECFBC68B4675C9ADF09C2858CF6B054563859D79598AA2524406A76F"},
+    {kCudaGenaiDll, "BC953F8E2AAFC6219B2D723B65AB8F1A9426A6B7724D6A01ED756FAE8C3DE6AE"},
 };
 
 constexpr const char* kRegistrationName = "Foundry.CUDA";
-constexpr const char* kCudaProviderDll = "onnxruntime_providers_cuda.dll";
 constexpr const char* kCudaProviderOverrideEnv = "FOUNDRY_LOCAL_CUDA_EP_LIBRARY";
 
 }  // anonymous namespace
@@ -95,6 +97,25 @@ bool CudaEpBootstrapper::DownloadAndRegister(bool force,
         progress_cb(name_, 90.0f);
       }
 
+#ifdef _WIN32
+      // FOUNDRY_LOCAL_CUDA_EP_LIBRARY only names the provider DLL; the GenAI runtime DLL is
+      // expected to live alongside it, same as the normal install layout. Preload it explicitly
+      // and fail now rather than deferring to model-load time, where a missing or unloadable
+      // sibling surfaces as an opaque Win32 error 126 deep inside GenAI's own lookup.
+      auto override_genai_dll_path = provider_path.parent_path() / kCudaGenaiDll;
+      if (!std::filesystem::exists(override_genai_dll_path)) {
+        logger.Log(LogLevel::Warning,
+                   fmt::format("CUDA EP: {} set but sibling {} not found ({})",
+                               kCudaProviderOverrideEnv, kCudaGenaiDll, override_genai_dll_path.string()));
+        return false;
+      }
+      if (!PreloadAbsoluteDll(override_genai_dll_path, logger)) {
+        logger.Log(LogLevel::Warning,
+                   fmt::format("CUDA EP: failed to preload {}", override_genai_dll_path.string()));
+        return false;
+      }
+#endif
+
       // Prepend the override directory to PATH so sibling dependency DLLs are discoverable,
       // matching the normal install path. The provider DLL delay-loads CUDA/cuDNN dependencies.
       PrependDirToProcessPath(provider_path.parent_path());
@@ -123,8 +144,8 @@ bool CudaEpBootstrapper::DownloadAndRegister(bool force,
 
     // Check if package already exists and is valid
     if (fl::VerifyEpPackage(ep_dir,
-            {{kExpectedBinaries[0].filename, kExpectedBinaries[0].sha256},
-             {kExpectedBinaries[1].filename, kExpectedBinaries[1].sha256}},
+            {{kCudaProviderDll, kExpectedBinaries[0].sha256},
+             {kCudaGenaiDll, kExpectedBinaries[1].sha256}},
             "CUDA EP", logger)) {
       logger.Log(LogLevel::Information, "CUDA EP: package already valid, skipping download");
     } else {
@@ -169,8 +190,8 @@ bool CudaEpBootstrapper::DownloadAndRegister(bool force,
 
       // Verify
       if (!fl::VerifyEpPackage(ep_dir,
-               {{kExpectedBinaries[0].filename, kExpectedBinaries[0].sha256},
-                {kExpectedBinaries[1].filename, kExpectedBinaries[1].sha256}},
+               {{kCudaProviderDll, kExpectedBinaries[0].sha256},
+                {kCudaGenaiDll, kExpectedBinaries[1].sha256}},
                "CUDA EP", logger)) {
         logger.Log(LogLevel::Warning, "CUDA EP: verification failed after download");
         return false;
@@ -181,13 +202,26 @@ bool CudaEpBootstrapper::DownloadAndRegister(bool force,
       progress_cb(name_, 90.0f);
     }
 
-    // Register with ORT
 #ifdef _WIN32
-    // Permanently prepend the EP directory to PATH. The zip bundles all
-    // required CUDA/cuDNN DLLs, so no system CUDA install is needed.
-    // PATH must stay modified for the process lifetime because:
+    // Explicitly preload onnxruntime-genai-cuda.dll from its absolute, hash-verified path before
+    // registering the provider. It's loaded later, at model-load time, by GenAI's own
+    // module-name lookup rather than through the ORT registration call below, so "present and
+    // hash-verified" here doesn't guarantee that later lookup succeeds — it can still fail with
+    // Win32 error 126 ("module not found") if the search order used for that specific call
+    // doesn't include this directory. Preloading now with LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
+    // LOAD_LIBRARY_SEARCH_DEFAULT_DIRS pins the resolved module in the process for good.
+    auto genai_dll_path = ep_dir / kCudaGenaiDll;
+    if (!PreloadAbsoluteDll(genai_dll_path, logger)) {
+      logger.Log(LogLevel::Warning,
+                 fmt::format("CUDA EP: failed to preload {}", genai_dll_path.string()));
+      return false;
+    }
+
+    // Register with ORT.
+    // Permanently prepend the EP directory to PATH. The zip bundles all required CUDA/cuDNN
+    // DLLs, so no system CUDA install is needed. PATH must stay modified for the process
+    // lifetime because:
     //   - onnxruntime_providers_cuda.dll delay-loads some dependencies
-    //   - onnxruntime-genai-cuda.dll is loaded later at model-load time
     //   - ORT creates CUDA sessions after registration
     PrependDirToProcessPath(ep_dir);
 #endif

--- a/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.h
+++ b/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.h
@@ -14,7 +14,7 @@ class ILogger;
 /// Bootstrapper for the CUDA execution provider.
 ///
 /// Windows x64: downloads CUDA EP binaries from Azure CDN, extracts,
-/// verifies SHA256, then registers with ORT via SetDllDirectory + callback.
+/// verifies SHA256, preloads the GenAI runtime DLL, then registers with ORT via callback.
 ///
 /// Linux x64: registers from co-located .so files (no download needed).
 ///

--- a/sdk_v2/cpp/src/ep_detection/ep_utils.cc
+++ b/sdk_v2/cpp/src/ep_detection/ep_utils.cc
@@ -9,7 +9,9 @@
 
 #include <algorithm>
 #include <cctype>
+#include <mutex>
 #include <string>
+#include <vector>
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
@@ -57,6 +59,36 @@ void PrependDirToProcessPath([[maybe_unused]] const std::filesystem::path& dir) 
 
   std::wstring new_path = dir.wstring() + L";" + prev_path;
   SetEnvironmentVariableW(L"PATH", new_path.c_str());
+#endif
+}
+
+bool PreloadAbsoluteDll([[maybe_unused]] const std::filesystem::path& dll_path,
+                        [[maybe_unused]] ILogger& logger) {
+#ifdef _WIN32
+  HMODULE module = ::LoadLibraryExW(
+      dll_path.c_str(), nullptr,
+      LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+
+  if (!module) {
+    DWORD load_err = ::GetLastError();
+    logger.Log(LogLevel::Warning,
+               fmt::format("PreloadAbsoluteDll: LoadLibraryExW failed for '{}' (GetLastError={})",
+                           dll_path.string(), load_err));
+    return false;
+  }
+
+  // Retain the handle for the lifetime of the process. Callers depend on the module staying
+  // mapped long after this function returns (e.g. GenAI resolves it by name at model-load time),
+  // so we deliberately never call FreeLibrary. Guard the static registry with a mutex since
+  // bootstrappers can run preload calls from multiple threads.
+  static std::mutex preloaded_modules_mutex;
+  static std::vector<HMODULE> preloaded_modules;
+  std::lock_guard<std::mutex> lock(preloaded_modules_mutex);
+  preloaded_modules.push_back(module);
+
+  return true;
+#else
+  return false;
 #endif
 }
 

--- a/sdk_v2/cpp/src/ep_detection/ep_utils.h
+++ b/sdk_v2/cpp/src/ep_detection/ep_utils.h
@@ -34,4 +34,27 @@ bool VerifyEpPackage(
 /// @param dir Directory to prepend to `PATH`.
 void PrependDirToProcessPath(const std::filesystem::path& dir);
 
+/// Explicitly preload a DLL from an absolute path on Windows via `LoadLibraryExW` with
+/// `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS`.
+///
+/// `PrependDirToProcessPath` only changes the *default* DLL search order — it helps callers that
+/// do an unqualified `LoadLibrary("name.dll")` or rely on delay-load imports, but it does not help
+/// every loader. In particular, onnxruntime-genai resolves its native runtime DLL by name at
+/// model-load time (well after EP registration finishes), and that lookup can still fail with
+/// Win32 error 126 ("module not found") even though the file is present on disk and its directory
+/// is on `PATH` — the search order the OS ends up using for that specific call is not guaranteed
+/// to include a `PATH`-prepended directory. Preloading the DLL up front with explicit search flags
+/// sidesteps that ambiguity: once the module is mapped into the process, any later lookup by name
+/// finds the already-loaded module instead of re-resolving it from scratch.
+///
+/// The returned module handle is intentionally leaked (never passed to `FreeLibrary`) — the DLL
+/// must stay mapped for the lifetime of the process, since model loading can happen long after
+/// this call returns.
+///
+/// @param dll_path Absolute path to the DLL to preload.
+/// @param logger   Logger used to report the path and Win32 error code if the load fails.
+/// @return true if the DLL is now loaded (freshly loaded or already resident). Always false on
+///         non-Windows platforms.
+bool PreloadAbsoluteDll(const std::filesystem::path& dll_path, ILogger& logger);
+
 }  // namespace fl

--- a/sdk_v2/cpp/test/CMakeLists.txt
+++ b/sdk_v2/cpp/test/CMakeLists.txt
@@ -23,10 +23,12 @@ add_executable(foundry_local_tests
     internal_api/chat_completions_converter_test.cc
     internal_api/configuration_test.cc
     internal_api/cross_process_file_lock_test.cc
+    internal_api/cuda_ep_bootstrapper_test.cc
     internal_api/download_test.cc
     internal_api/embeddings/contracts_embeddings_test.cc
     internal_api/embeddings/fp16_test.cc
     internal_api/ep_detector_test.cc
+    internal_api/ep_utils_test.cc
     internal_api/exception_test.cc
     internal_api/execution_provider_test.cc
     internal_api/file_lock_test.cc

--- a/sdk_v2/cpp/test/internal_api/cuda_ep_bootstrapper_test.cc
+++ b/sdk_v2/cpp/test/internal_api/cuda_ep_bootstrapper_test.cc
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Focused unit tests for CudaEpBootstrapper's FOUNDRY_LOCAL_CUDA_EP_LIBRARY override path,
+// specifically the GenAI runtime DLL preload added to fix Win32 error 126 at model-load time
+// (root-caused in cuda_ep_bootstrapper.cc: the DLL was present and hash-verified but GenAI's own
+// module-name lookup still failed to find it). These tests never touch the network — the
+// override branch resolves purely from local files, so DownloadAndRegister never reaches the
+// download/extract code path.
+#include "ep_detection/cuda_ep_bootstrapper.h"
+
+#include "internal_api/test_helpers.h"
+#include "logger.h"
+#include "utils.h"
+
+#include <gtest/gtest.h>
+
+#ifdef _WIN32
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <system_error>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+using namespace fl;
+
+namespace {
+
+constexpr const char* kOverrideEnv = "FOUNDRY_LOCAL_CUDA_EP_LIBRARY";
+constexpr const char* kProviderDllName = "onnxruntime_providers_cuda.dll";
+constexpr const char* kGenaiDllName = "onnxruntime-genai-cuda.dll";
+
+/// Saves/restores FOUNDRY_LOCAL_CUDA_EP_LIBRARY around a test so tests don't leak global env
+/// state into other tests running in the same process (gtest_discover_tests launches one process
+/// per test case by default, but keeping this scoped costs nothing and removes that assumption).
+class ScopedOverrideEnv {
+ public:
+  explicit ScopedOverrideEnv(const std::filesystem::path& value) {
+    auto existing = Utils::GetEnv(kOverrideEnv);
+    if (existing.has_value()) {
+      previous_ = *existing;
+    }
+    _putenv_s(kOverrideEnv, value.string().c_str());
+  }
+
+  ~ScopedOverrideEnv() { _putenv_s(kOverrideEnv, previous_.value_or("").c_str()); }
+
+  ScopedOverrideEnv(const ScopedOverrideEnv&) = delete;
+  ScopedOverrideEnv& operator=(const ScopedOverrideEnv&) = delete;
+
+ private:
+  std::optional<std::string> previous_;
+};
+
+/// Copies a known-loadable system DLL to `dest` so PreloadAbsoluteDll has a real PE image.
+void WriteValidDll(const std::filesystem::path& dest) {
+  wchar_t system_dir[MAX_PATH];
+  ASSERT_NE(::GetSystemDirectoryW(system_dir, MAX_PATH), 0u);
+  std::filesystem::copy_file(std::filesystem::path(system_dir) / L"kernel32.dll", dest,
+                             std::filesystem::copy_options::overwrite_existing);
+}
+
+/// Writes a file that exists but is not a valid PE image, to exercise the preload-failure path.
+void WriteBogusFile(const std::filesystem::path& dest) {
+  std::ofstream out(dest, std::ios::binary);
+  out << "not a real PE image";
+}
+
+}  // namespace
+
+class CudaEpBootstrapperOverrideTest : public ::testing::Test {
+ protected:
+  std::filesystem::path dir_;
+  fl::test::NullLogger logger_;
+
+  void SetUp() override {
+    dir_ = fl::test::MakeUniqueTempPath("foundry-cuda-ep-override-test-");
+    std::filesystem::create_directories(dir_);
+  }
+
+  void TearDown() override {
+    // Tests that preload a real DLL (e.g. SiblingGenaiDllValid_RegistersSuccessfully) keep its
+    // backing file locked by design — PreloadAbsoluteDll deliberately never calls FreeLibrary,
+    // since the module must stay resident for the life of the process. That can make removal of
+    // this directory fail with ERROR_SHARING_VIOLATION; that's expected, not a test failure, so
+    // use the non-throwing overload and ignore the result.
+    std::error_code ec;
+    std::filesystem::remove_all(dir_, ec);
+  }
+};
+
+TEST_F(CudaEpBootstrapperOverrideTest, SiblingGenaiDllMissing_FailsBeforeRegistration) {
+  // Provider DLL "exists" (existence is all the bootstrapper checks for it), but its sibling
+  // GenAI runtime DLL is absent — the override should fail up front instead of registering an EP
+  // that will blow up later at model-load time.
+  auto provider_path = dir_ / kProviderDllName;
+  WriteValidDll(provider_path);
+
+  bool register_called = false;
+  CudaEpBootstrapper bootstrapper(
+      (dir_ / "unused-ep-dir").string(),
+      [&](const std::string&, const std::filesystem::path&) {
+        register_called = true;
+        return true;
+      });
+
+  ScopedOverrideEnv scoped_env(provider_path);
+  EXPECT_FALSE(bootstrapper.DownloadAndRegister(/*force=*/false, nullptr, logger_));
+  EXPECT_FALSE(register_called);
+  EXPECT_FALSE(bootstrapper.IsRegistered());
+}
+
+TEST_F(CudaEpBootstrapperOverrideTest, SiblingGenaiDllInvalidPeImage_FailsBeforeRegistration) {
+  // Sibling file exists at the expected name but isn't a loadable PE image — PreloadAbsoluteDll
+  // must fail, and that failure must block registration rather than being silently ignored.
+  auto provider_path = dir_ / kProviderDllName;
+  WriteValidDll(provider_path);
+  WriteBogusFile(dir_ / kGenaiDllName);
+
+  bool register_called = false;
+  CudaEpBootstrapper bootstrapper(
+      (dir_ / "unused-ep-dir").string(),
+      [&](const std::string&, const std::filesystem::path&) {
+        register_called = true;
+        return true;
+      });
+
+  ScopedOverrideEnv scoped_env(provider_path);
+  EXPECT_FALSE(bootstrapper.DownloadAndRegister(/*force=*/false, nullptr, logger_));
+  EXPECT_FALSE(register_called);
+  EXPECT_FALSE(bootstrapper.IsRegistered());
+}
+
+TEST_F(CudaEpBootstrapperOverrideTest, SiblingGenaiDllValid_RegistersSuccessfully) {
+  // Both the provider DLL and its GenAI sibling are present and loadable — the override should
+  // preload the sibling and proceed to register exactly as before.
+  auto provider_path = dir_ / kProviderDllName;
+  WriteValidDll(provider_path);
+  WriteValidDll(dir_ / kGenaiDllName);
+
+  bool register_called = false;
+  std::filesystem::path registered_path;
+  CudaEpBootstrapper bootstrapper(
+      (dir_ / "unused-ep-dir").string(),
+      [&](const std::string& reg_name, const std::filesystem::path& lib_path) {
+        register_called = true;
+        registered_path = lib_path;
+        EXPECT_EQ(reg_name, "Foundry.CUDA");
+        return true;
+      });
+
+  ScopedOverrideEnv scoped_env(provider_path);
+  EXPECT_TRUE(bootstrapper.DownloadAndRegister(/*force=*/false, nullptr, logger_));
+  EXPECT_TRUE(register_called);
+  EXPECT_EQ(registered_path, provider_path);
+  EXPECT_TRUE(bootstrapper.IsRegistered());
+}
+
+TEST_F(CudaEpBootstrapperOverrideTest, ProviderDllMissing_FailsWithoutTouchingGenaiCheck) {
+  // Pre-existing behavior: if the override path itself doesn't exist, fail immediately. This
+  // guards against a regression where the new sibling-DLL check would run before this one.
+  auto provider_path = dir_ / kProviderDllName;  // never written
+
+  bool register_called = false;
+  CudaEpBootstrapper bootstrapper(
+      (dir_ / "unused-ep-dir").string(),
+      [&](const std::string&, const std::filesystem::path&) {
+        register_called = true;
+        return true;
+      });
+
+  ScopedOverrideEnv scoped_env(provider_path);
+  EXPECT_FALSE(bootstrapper.DownloadAndRegister(/*force=*/false, nullptr, logger_));
+  EXPECT_FALSE(register_called);
+}
+
+#endif  // _WIN32

--- a/sdk_v2/cpp/test/internal_api/ep_utils_test.cc
+++ b/sdk_v2/cpp/test/internal_api/ep_utils_test.cc
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Unit tests for ep_detection/ep_utils.h — package verification and the Windows
+// DLL-preload helper used by CudaEpBootstrapper to work around GenAI's own
+// module-name lookup at model-load time (see cuda_ep_bootstrapper.cc).
+#include "ep_detection/ep_utils.h"
+
+#include "logger.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+using namespace fl;
+
+namespace {
+
+/// Captures log output so tests can assert the helper logged the path and error details.
+class RecordingLogger : public ILogger {
+ public:
+  std::vector<std::pair<LogLevel, std::string>> entries;
+
+  void Log(LogLevel level, std::string_view message) override {
+    entries.emplace_back(level, std::string(message));
+  }
+};
+
+}  // namespace
+
+// ========================================================================
+// PreloadAbsoluteDll
+// ========================================================================
+
+#ifdef _WIN32
+
+TEST(PreloadAbsoluteDllTest, ExistingSystemDll_ReturnsTrue) {
+  RecordingLogger logger;
+
+  wchar_t system_dir[MAX_PATH];
+  ASSERT_NE(::GetSystemDirectoryW(system_dir, MAX_PATH), 0u);
+  auto dll_path = std::filesystem::path(system_dir) / L"kernel32.dll";
+
+  EXPECT_TRUE(PreloadAbsoluteDll(dll_path, logger));
+  EXPECT_TRUE(logger.entries.empty()) << "should not log anything on success";
+}
+
+TEST(PreloadAbsoluteDllTest, CalledTwiceForSamePath_BothCallsSucceed) {
+  RecordingLogger logger;
+
+  wchar_t system_dir[MAX_PATH];
+  ASSERT_NE(::GetSystemDirectoryW(system_dir, MAX_PATH), 0u);
+  auto dll_path = std::filesystem::path(system_dir) / L"kernel32.dll";
+
+  // Preloading the same already-resident module twice must not fail or double-log.
+  EXPECT_TRUE(PreloadAbsoluteDll(dll_path, logger));
+  EXPECT_TRUE(PreloadAbsoluteDll(dll_path, logger));
+  EXPECT_TRUE(logger.entries.empty());
+}
+
+TEST(PreloadAbsoluteDllTest, NonexistentPath_ReturnsFalseAndLogsPathAndError) {
+  RecordingLogger logger;
+
+  auto dll_path = std::filesystem::temp_directory_path() / "definitely-does-not-exist-foundry.dll";
+  ASSERT_FALSE(std::filesystem::exists(dll_path));
+
+  EXPECT_FALSE(PreloadAbsoluteDll(dll_path, logger));
+
+  ASSERT_EQ(logger.entries.size(), 1u);
+  EXPECT_EQ(logger.entries[0].first, LogLevel::Warning);
+  EXPECT_NE(logger.entries[0].second.find(dll_path.string()), std::string::npos)
+      << "log message should include the failing path: " << logger.entries[0].second;
+  EXPECT_NE(logger.entries[0].second.find("GetLastError"), std::string::npos)
+      << "log message should include the Win32 error code: " << logger.entries[0].second;
+}
+
+TEST(PreloadAbsoluteDllTest, ExistingButNotAValidDll_ReturnsFalse) {
+  RecordingLogger logger;
+
+  // A file that exists but isn't a valid PE image (e.g. an accidental text file at the expected
+  // DLL path) should fail to load rather than crash, and be reported the same way as a missing file.
+  auto bogus_path = std::filesystem::temp_directory_path() / "foundry-preload-test-bogus.dll";
+  {
+    std::ofstream out(bogus_path, std::ios::binary);
+    out << "not a real PE image";
+  }
+
+  EXPECT_FALSE(PreloadAbsoluteDll(bogus_path, logger));
+  ASSERT_EQ(logger.entries.size(), 1u);
+  EXPECT_NE(logger.entries[0].second.find(bogus_path.string()), std::string::npos);
+
+  std::filesystem::remove(bogus_path);
+}
+
+#else
+
+TEST(PreloadAbsoluteDllTest, NonWindows_AlwaysReturnsFalse) {
+  RecordingLogger logger;
+  EXPECT_FALSE(PreloadAbsoluteDll("/nonexistent/path.so", logger));
+}
+
+#endif  // _WIN32


### PR DESCRIPTION
## Summary

Fix TensorRT RTX / CUDA EP startup on Windows by preloading the absolute `onnxruntime-genai-cuda.dll` before EP registration.

The CUDA EP package can be present and hash-verified while model creation still fails with Win32 error 126 because GenAI resolves the DLL by name later through the process DLL search path.

## Changes

- Add a Windows absolute-path DLL preload helper using `LoadLibraryExW` with safe search flags.
- Keep the loaded module resident for the process lifetime.
- Preload the sibling GenAI CUDA DLL before registering the CUDA EP, including the override-path flow.
- Add focused unit coverage for valid, missing, and invalid DLL paths and bootstrapper behavior.

## Validation

Built with `python sdk_v2\\cpp\\build.py --build --config RelWithDebInfo` and ran the focused suite:

```text
foundry_local_tests.exe --gtest_filter="PreloadAbsoluteDllTest*:CudaEpBootstrapperOverrideTest*"
[  PASSED  ] 8 tests.
```

## Root cause

This is a Windows loader/search-path issue rather than a missing download. The DLL exists in the EP cache, but a later bare-name load during model creation is not guaranteed to resolve from that cache directory. Preloading the absolute path removes that loader-order dependency.