### PR TITLE
Fix TensorRT RTX GenAI CUDA bridge loading on Windows

### DIFF
--- a/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.cc
+++ b/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.cc
@@ -69,7 +69,7 @@ namespace fl {
 
 CudaEpBootstrapper::CudaEpBootstrapper(std::string root_dir, EpRegistrationCallback register_ep,
                                        EpBundleManifestFactory manifest_factory, EpArtifactDownloadFn download_fn
-#if defined(__linux__)
+#if defined(__linux__) || defined(_WIN32)
                                        ,
                                        CudaGenAiDependencyLoader genai_cuda_loader
 #endif
@@ -78,7 +78,7 @@ CudaEpBootstrapper::CudaEpBootstrapper(std::string root_dir, EpRegistrationCallb
       manifest_factory_(manifest_factory ? std::move(manifest_factory)
                                          : [] { return BuildCudaEpManifest(HostCudaEpPlatform()); }),
       installer_(std::filesystem::path(root_dir), kLockFileName, "CUDA EP", std::move(download_fn))
-#if defined(__linux__)
+#if defined(__linux__) || defined(_WIN32)
       ,
       genai_cuda_loader_(genai_cuda_loader ? std::move(genai_cuda_loader) : platform::LoadSharedLibrary)
 #endif
@@ -121,10 +121,15 @@ bool CudaEpBootstrapper::DownloadAndRegister(bool force, const ProgressCallback&
         return false;
       }
 
+      bundle_dir_ = provider_path.parent_path();
 #if defined(__linux__)
       std::pair<std::filesystem::path, std::shared_ptr<void>> provisional_genai_cuda_library;
       if (!LoadGenAiCudaLibrary(provider_path.parent_path() / kGenAiCudaLibrary, genai_cuda_libraries_,
                                 genai_cuda_loader_, provisional_genai_cuda_library, logger)) {
+        return false;
+      }
+#elif defined(_WIN32)
+      if (!LoadGenAiCudaBridge(logger)) {
         return false;
       }
 #endif
@@ -142,8 +147,6 @@ bool CudaEpBootstrapper::DownloadAndRegister(bool force, const ProgressCallback&
 #endif
 
       registered_ = true;
-      bundle_dir_ = provider_path.parent_path();
-      LoadGenAiCudaBridge(logger);
 
       if (progress_cb) {
         progress_cb(name_, 100.0f);
@@ -172,10 +175,16 @@ bool CudaEpBootstrapper::DownloadAndRegister(bool force, const ProgressCallback&
     }
 
     const auto provider_path = txn->provider_path();
+    bundle_dir_ = txn->bin_dir();
 #if defined(__linux__)
     std::pair<std::filesystem::path, std::shared_ptr<void>> provisional_genai_cuda_library;
     if (!LoadGenAiCudaLibrary(txn->bin_dir() / kGenAiCudaLibrary, genai_cuda_libraries_, genai_cuda_loader_,
                               provisional_genai_cuda_library, logger)) {
+      txn->Rollback();
+      return false;
+    }
+#elif defined(_WIN32)
+    if (!LoadGenAiCudaBridge(logger)) {
       txn->Rollback();
       return false;
     }
@@ -194,8 +203,6 @@ bool CudaEpBootstrapper::DownloadAndRegister(bool force, const ProgressCallback&
 #endif
 
     registered_ = true;
-    bundle_dir_ = txn->bin_dir();
-    LoadGenAiCudaBridge(logger);
     txn->Finalize();
 
     if (progress_cb) {
@@ -218,15 +225,19 @@ bool CudaEpBootstrapper::PrepareForModelLoad([[maybe_unused]] ILogger& logger) {
 #endif
 }
 
-void CudaEpBootstrapper::LoadGenAiCudaBridge([[maybe_unused]] ILogger& logger) {
+bool CudaEpBootstrapper::LoadGenAiCudaBridge([[maybe_unused]] ILogger& logger) {
 #if defined(_WIN32)
   // NvTensorRTRTX reuses the GenAI CUDA bridge (onnxruntime-genai-cuda.dll) but, unlike the CUDA
   // path, never adds the cuda-ep bundle to the DLL search path. Load it here and keep the handle so
-  // it stays resident and resolves by name for any later model load. Best-effort: CUDA inference
-  // itself does not depend on it (LoadSharedLibrary logs on failure).
+  // it stays resident and resolves by name for any later model load. Treated as a hard dependency
+  // (mirrors the Linux path): if it cannot be loaded, registration fails so the caller is not told
+  // the CUDA EP is ready when a dependent NvTensorRTRTX model load would still fail.
   if (!genai_cuda_library_) {
-    genai_cuda_library_ = platform::LoadSharedLibrary(bundle_dir_ / kGenAiCudaLibrary, logger);
+    genai_cuda_library_ = genai_cuda_loader_(bundle_dir_ / kGenAiCudaLibrary, logger);
   }
+  return genai_cuda_library_ != nullptr;
+#else
+  return true;
 #endif
 }
 

--- a/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.cc
+++ b/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.cc
@@ -23,6 +23,8 @@ constexpr const char* kRegistrationName = "CUDAExecutionProvider";
 constexpr const char* kCudaProviderOverrideEnv = "FOUNDRY_LOCAL_CUDA_EP_LIBRARY";
 #if defined(__linux__)
 constexpr const char* kGenAiCudaLibrary = "libonnxruntime-genai-cuda.so";
+#elif defined(_WIN32)
+constexpr const char* kGenAiCudaLibrary = "onnxruntime-genai-cuda.dll";
 #endif
 
 fl::CudaEpPlatform HostCudaEpPlatform() {
@@ -141,6 +143,7 @@ bool CudaEpBootstrapper::DownloadAndRegister(bool force, const ProgressCallback&
 
       registered_ = true;
       bundle_dir_ = provider_path.parent_path();
+      LoadGenAiCudaBridge(logger);
 
       if (progress_cb) {
         progress_cb(name_, 100.0f);
@@ -192,6 +195,7 @@ bool CudaEpBootstrapper::DownloadAndRegister(bool force, const ProgressCallback&
 
     registered_ = true;
     bundle_dir_ = txn->bin_dir();
+    LoadGenAiCudaBridge(logger);
     txn->Finalize();
 
     if (progress_cb) {
@@ -211,6 +215,18 @@ bool CudaEpBootstrapper::PrepareForModelLoad([[maybe_unused]] ILogger& logger) {
   return platform::SetDynamicLibrarySearchDirectory(bundle_dir_, logger);
 #else
   return true;
+#endif
+}
+
+void CudaEpBootstrapper::LoadGenAiCudaBridge([[maybe_unused]] ILogger& logger) {
+#if defined(_WIN32)
+  // NvTensorRTRTX reuses the GenAI CUDA bridge (onnxruntime-genai-cuda.dll) but, unlike the CUDA
+  // path, never adds the cuda-ep bundle to the DLL search path. Load it here and keep the handle so
+  // it stays resident and resolves by name for any later model load. Best-effort: CUDA inference
+  // itself does not depend on it (LoadSharedLibrary logs on failure).
+  if (!genai_cuda_library_) {
+    genai_cuda_library_ = platform::LoadSharedLibrary(bundle_dir_ / kGenAiCudaLibrary, logger);
+  }
 #endif
 }
 

--- a/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.h
+++ b/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.h
@@ -55,6 +55,11 @@ class CudaEpBootstrapper : public IEpBootstrapper {
   static bool IsSupportedPlatform();
 
  private:
+  /// Windows: load onnxruntime-genai-cuda.dll (the GenAI CUDA bridge) from the installed bundle and
+  /// hold it resident, so WinML EPs that reuse it (e.g. NvTensorRTRTX) resolve it by name regardless
+  /// of EP/model load order. No-op on other platforms.
+  void LoadGenAiCudaBridge(ILogger& logger);
+
   std::string name_ = "CUDAExecutionProvider";
   bool registered_ = false;
   int attempts_ = 0;
@@ -62,6 +67,9 @@ class CudaEpBootstrapper : public IEpBootstrapper {
   EpBundleManifestFactory manifest_factory_;
   EpBundleInstaller installer_;
   std::filesystem::path bundle_dir_;
+#if defined(_WIN32)
+  std::shared_ptr<void> genai_cuda_library_;
+#endif
 #if defined(__linux__)
   std::vector<std::pair<std::filesystem::path, std::shared_ptr<void>>> genai_cuda_libraries_;
   CudaGenAiDependencyLoader genai_cuda_loader_;

--- a/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.h
+++ b/sdk_v2/cpp/src/ep_detection/cuda_ep_bootstrapper.h
@@ -17,7 +17,7 @@ namespace fl {
 
 class ILogger;
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(_WIN32)
 using CudaGenAiDependencyLoader =
     std::function<std::shared_ptr<void>(const std::filesystem::path&, ILogger&)>;
 #endif
@@ -32,7 +32,7 @@ class CudaEpBootstrapper : public IEpBootstrapper {
   CudaEpBootstrapper(std::string root_dir, EpRegistrationCallback register_ep,
                      EpBundleManifestFactory manifest_factory = nullptr,
                      EpArtifactDownloadFn download_fn = nullptr
-#if defined(__linux__)
+#if defined(__linux__) || defined(_WIN32)
                      ,
                      CudaGenAiDependencyLoader genai_cuda_loader = nullptr
 #endif
@@ -57,8 +57,10 @@ class CudaEpBootstrapper : public IEpBootstrapper {
  private:
   /// Windows: load onnxruntime-genai-cuda.dll (the GenAI CUDA bridge) from the installed bundle and
   /// hold it resident, so WinML EPs that reuse it (e.g. NvTensorRTRTX) resolve it by name regardless
-  /// of EP/model load order. No-op on other platforms.
-  void LoadGenAiCudaBridge(ILogger& logger);
+  /// of EP/model load order. Returns false if the bridge cannot be loaded so registration can fail
+  /// rather than report a CUDA EP that a dependent NvTensorRTRTX load would still find broken.
+  /// Always returns true on non-Windows platforms.
+  bool LoadGenAiCudaBridge(ILogger& logger);
 
   std::string name_ = "CUDAExecutionProvider";
   bool registered_ = false;
@@ -72,6 +74,8 @@ class CudaEpBootstrapper : public IEpBootstrapper {
 #endif
 #if defined(__linux__)
   std::vector<std::pair<std::filesystem::path, std::shared_ptr<void>>> genai_cuda_libraries_;
+#endif
+#if defined(__linux__) || defined(_WIN32)
   CudaGenAiDependencyLoader genai_cuda_loader_;
 #endif
 };

--- a/sdk_v2/cpp/src/ep_detection/ep_detector.cc
+++ b/sdk_v2/cpp/src/ep_detection/ep_detector.cc
@@ -134,6 +134,27 @@ EpDownloadResult EpDetector::DownloadAndRegisterEps(const std::vector<std::strin
   EpDownloadResult result;
   result.success = true;
 
+  // Expand the requested set for EPs that depend on another EP's runtime. NvTensorRTRTX (a WinML EP)
+  // reuses the GenAI CUDA bridge that ships in the CUDA EP bundle, so requesting it by name must also
+  // register the CUDA EP. Only applies when a CUDA bootstrapper exists (i.e. an NVIDIA GPU is present).
+  std::vector<std::string> expanded_names;
+  if (names != nullptr) {
+    constexpr const char* kTrtRtxEp = "NvTensorRTRTXExecutionProvider";
+    constexpr const char* kCudaEp = "CUDAExecutionProvider";
+    const bool wants_trtrtx = std::find(names->begin(), names->end(), kTrtRtxEp) != names->end();
+    const bool cuda_requested = std::find(names->begin(), names->end(), kCudaEp) != names->end();
+    const bool has_cuda_bootstrapper =
+        std::any_of(bootstrappers_.begin(), bootstrappers_.end(),
+                    [&](const auto& bs) { return bs->Name() == kCudaEp; });
+    if (wants_trtrtx && has_cuda_bootstrapper && !cuda_requested) {
+      expanded_names = *names;
+      expanded_names.emplace_back(kCudaEp);
+      names = &expanded_names;
+      logger_.Log(LogLevel::Information,
+                  "Auto-registering CUDA EP alongside NvTensorRTRTX (shared GenAI CUDA bridge)");
+    }
+  }
+
   // Track cancellation from the progress callback
   bool cancelled = false;
   IEpBootstrapper::ProgressCallback wrapped_cb;

--- a/sdk_v2/cpp/src/ep_detection/ep_detector.cc
+++ b/sdk_v2/cpp/src/ep_detection/ep_detector.cc
@@ -136,17 +136,22 @@ EpDownloadResult EpDetector::DownloadAndRegisterEps(const std::vector<std::strin
 
   // Expand the requested set for EPs that depend on another EP's runtime. NvTensorRTRTX (a WinML EP)
   // reuses the GenAI CUDA bridge that ships in the CUDA EP bundle, so requesting it by name must also
-  // register the CUDA EP. Only applies when a CUDA bootstrapper exists (i.e. an NVIDIA GPU is present).
+  // register the CUDA EP. Only applies when both bootstrappers exist: the NvTensorRTRTX bootstrapper
+  // (so we don't act on an unknown name on hosts without it, e.g. Linux) and the CUDA bootstrapper
+  // (i.e. an NVIDIA GPU is present).
   std::vector<std::string> expanded_names;
   if (names != nullptr) {
     constexpr const char* kTrtRtxEp = "NvTensorRTRTXExecutionProvider";
     constexpr const char* kCudaEp = "CUDAExecutionProvider";
     const bool wants_trtrtx = std::find(names->begin(), names->end(), kTrtRtxEp) != names->end();
     const bool cuda_requested = std::find(names->begin(), names->end(), kCudaEp) != names->end();
+    const bool has_trtrtx_bootstrapper =
+        std::any_of(bootstrappers_.begin(), bootstrappers_.end(),
+                    [&](const auto& bs) { return bs->Name() == kTrtRtxEp; });
     const bool has_cuda_bootstrapper =
         std::any_of(bootstrappers_.begin(), bootstrappers_.end(),
                     [&](const auto& bs) { return bs->Name() == kCudaEp; });
-    if (wants_trtrtx && has_cuda_bootstrapper && !cuda_requested) {
+    if (wants_trtrtx && has_trtrtx_bootstrapper && has_cuda_bootstrapper && !cuda_requested) {
       expanded_names = *names;
       expanded_names.emplace_back(kCudaEp);
       names = &expanded_names;

--- a/sdk_v2/cpp/src/platform/dynlib_loader.h
+++ b/sdk_v2/cpp/src/platform/dynlib_loader.h
@@ -14,9 +14,9 @@ namespace fl::platform {
 #ifdef _WIN32
 /// Set the directory used for subsequent bare-name dynamic library loads.
 bool SetDynamicLibrarySearchDirectory(const std::filesystem::path& directory, ILogger& logger);
-#else
+#endif
+
 /// Load one shared library and keep it resident for the lifetime of the returned handle.
 std::shared_ptr<void> LoadSharedLibrary(const std::filesystem::path& path, fl::ILogger& logger);
-#endif
 
 }  // namespace fl::platform

--- a/sdk_v2/cpp/src/platform/windows/dynlib_loader.cc
+++ b/sdk_v2/cpp/src/platform/windows/dynlib_loader.cc
@@ -5,6 +5,8 @@
 
 #include <fmt/format.h>
 
+#include <memory>
+
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
@@ -21,6 +23,26 @@ bool SetDynamicLibrarySearchDirectory(const std::filesystem::path& directory, IL
   logger.Log(LogLevel::Warning,
              fmt::format("Failed to set DLL search directory '{}' ({})", absolute_directory.string(), GetLastError()));
   return false;
+}
+
+std::shared_ptr<void> LoadSharedLibrary(const std::filesystem::path& path, fl::ILogger& logger) {
+  const auto absolute_path = std::filesystem::absolute(path).lexically_normal();
+  // LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR lets the library resolve its sibling dependencies (the CUDA
+  // runtime + provider DLLs staged alongside it) from its own directory; DEFAULT_DIRS keeps System32
+  // and the process directories (where onnxruntime.dll is already resident) on the search path.
+  HMODULE handle = ::LoadLibraryExW(absolute_path.c_str(), nullptr,
+                                    LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+  if (handle == nullptr) {
+    logger.Log(LogLevel::Warning,
+               fmt::format("EP: failed to load '{}' ({})", absolute_path.string(), GetLastError()));
+    return {};
+  }
+
+  return std::shared_ptr<void>(handle, [](void* h) {
+    if (h != nullptr) {
+      ::FreeLibrary(static_cast<HMODULE>(h));
+    }
+  });
 }
 
 }  // namespace fl::platform

--- a/sdk_v2/cpp/test/internal_api/cuda_ep_bootstrapper_test.cc
+++ b/sdk_v2/cpp/test/internal_api/cuda_ep_bootstrapper_test.cc
@@ -79,6 +79,8 @@ constexpr const char* kProviderRelativePath = "libonnxruntime_providers_cuda.so"
 #endif
 #if defined(__linux__)
 constexpr const char* kGenAiCudaLibrary = "libonnxruntime-genai-cuda.so";
+#elif defined(_WIN32)
+constexpr const char* kGenAiCudaLibrary = "onnxruntime-genai-cuda.dll";
 #endif
 
 EpBundleManifest MakeRawManifest(FakeDownloads& downloads, const std::string& bundle_id) {
@@ -125,7 +127,7 @@ EpBundleManifest MakeRawManifest(FakeDownloads& downloads, const std::string& bu
 template <typename RegisterEp>
 CudaEpBootstrapper MakeInstalledBundleBootstrapper(std::string root_dir, RegisterEp register_ep,
                                                    const EpBundleManifest& manifest, EpArtifactDownloadFn download_fn) {
-#if defined(__linux__)
+#if defined(__linux__) || defined(_WIN32)
   auto loader = [](const std::filesystem::path&, ILogger&) -> std::shared_ptr<void> {
     return std::shared_ptr<void>(new int(0), [](void* token) {
       delete static_cast<int*>(token);
@@ -355,6 +357,39 @@ TEST(CudaEpBootstrapperTest, SuccessfulBundleRegistrationFinalizesPreviousGenera
   EXPECT_FALSE(std::filesystem::exists(root.path() / "bundles" / active_v1));
   EXPECT_TRUE(std::filesystem::exists(root.path() / "bundles" / active_v2));
 }
+
+#if defined(_WIN32)
+// On Windows the GenAI CUDA bridge is a hard dependency: if it cannot be loaded, CUDA registration
+// must fail (before calling register_ep) rather than report a ready EP that a dependent
+// NvTensorRTRTX model load would still find broken.
+TEST(CudaEpBootstrapperTest, InstalledBundleGenAiBridgeLoadFailureSkipsRegistration) {
+  auto root = test::TempPath::CreateTempDir("fl_cuda_bootstrapper_");
+  FakeDownloads downloads;
+  const auto manifest = MakeRawManifest(downloads, "bundle-v1");
+  NullLogger logger;
+
+  int registration_count = 0;
+  std::vector<std::filesystem::path> requested_paths;
+  auto loader = [&](const std::filesystem::path& path, ILogger&) -> std::shared_ptr<void> {
+    requested_paths.push_back(path);
+    return {};  // simulate a bridge that cannot be loaded (e.g. a missing sibling dependency)
+  };
+
+  CudaEpBootstrapper bootstrapper(
+      root.string(),
+      [&](const std::string&, const std::filesystem::path&) {
+        ++registration_count;
+        return true;
+      },
+      [manifest] { return std::optional<EpBundleManifest>(manifest); }, downloads.AsFn(), loader);
+
+  EXPECT_FALSE(bootstrapper.DownloadAndRegister(false, /*progress_cb=*/nullptr, logger));
+  EXPECT_EQ(registration_count, 0);  // bridge load precedes and gates ORT registration
+  EXPECT_FALSE(bootstrapper.IsRegistered());
+  ASSERT_EQ(requested_paths.size(), 1u);
+  EXPECT_EQ(requested_paths[0].filename().string(), kGenAiCudaLibrary);
+}
+#endif
 #endif
 
 #if defined(__linux__)

--- a/sdk_v2/cpp/test/internal_api/ep_detector_test.cc
+++ b/sdk_v2/cpp/test/internal_api/ep_detector_test.cc
@@ -236,3 +236,49 @@ TEST_F(EpDetectorTest, DownloadFiltered_AllNamesUnknown_SucceedsWithNothing) {
 
   EXPECT_FALSE(mocks[0]->download_called_);
 }
+
+// NvTensorRTRTX reuses the GenAI CUDA bridge shipped in the CUDA EP bundle, so requesting it by
+// name must also auto-register the CUDA EP (when a CUDA bootstrapper is present).
+TEST_F(EpDetectorTest, DownloadFiltered_TrtRtxAlsoRegistersCuda) {
+  std::vector<MockEpBootstrapper*> mocks;
+  auto detector = MakeDetector(mocks, {{"NvTensorRTRTXExecutionProvider", true},
+                                       {"CUDAExecutionProvider", true}});
+
+  std::vector<std::string> names = {"NvTensorRTRTXExecutionProvider"};
+  auto result = detector->DownloadAndRegisterEps(&names, nullptr);
+
+  EXPECT_TRUE(result.success);
+  EXPECT_TRUE(mocks[0]->download_called_);
+  EXPECT_TRUE(mocks[1]->download_called_);
+  EXPECT_NE(std::find(result.registered_eps.begin(), result.registered_eps.end(), "CUDAExecutionProvider"),
+            result.registered_eps.end());
+}
+
+// The auto-injection must not fabricate a CUDA registration when no CUDA bootstrapper exists
+// (e.g. no NVIDIA GPU present).
+TEST_F(EpDetectorTest, DownloadFiltered_TrtRtxWithoutCudaBootstrapper_NoInjection) {
+  std::vector<MockEpBootstrapper*> mocks;
+  auto detector = MakeDetector(mocks, {{"NvTensorRTRTXExecutionProvider", true}});
+
+  std::vector<std::string> names = {"NvTensorRTRTXExecutionProvider"};
+  auto result = detector->DownloadAndRegisterEps(&names, nullptr);
+
+  EXPECT_TRUE(result.success);
+  ASSERT_EQ(result.registered_eps.size(), 1u);
+  EXPECT_EQ(result.registered_eps[0], "NvTensorRTRTXExecutionProvider");
+}
+
+// Requesting an unrelated EP must not pull in CUDA.
+TEST_F(EpDetectorTest, DownloadFiltered_NonTrtRtxDoesNotRegisterCuda) {
+  std::vector<MockEpBootstrapper*> mocks;
+  auto detector = MakeDetector(mocks, {{"WebGpuExecutionProvider", true},
+                                       {"CUDAExecutionProvider", true}});
+
+  std::vector<std::string> names = {"WebGpuExecutionProvider"};
+  auto result = detector->DownloadAndRegisterEps(&names, nullptr);
+
+  EXPECT_TRUE(result.success);
+  ASSERT_EQ(result.registered_eps.size(), 1u);
+  EXPECT_EQ(result.registered_eps[0], "WebGpuExecutionProvider");
+  EXPECT_FALSE(mocks[1]->download_called_);
+}

--- a/sdk_v2/cpp/test/internal_api/ep_detector_test.cc
+++ b/sdk_v2/cpp/test/internal_api/ep_detector_test.cc
@@ -254,31 +254,18 @@ TEST_F(EpDetectorTest, DownloadFiltered_TrtRtxAlsoRegistersCuda) {
             result.registered_eps.end());
 }
 
-// The auto-injection must not fabricate a CUDA registration when no CUDA bootstrapper exists
-// (e.g. no NVIDIA GPU present).
-TEST_F(EpDetectorTest, DownloadFiltered_TrtRtxWithoutCudaBootstrapper_NoInjection) {
+// A host with a CUDA bootstrapper but no NvTensorRTRTX bootstrapper (e.g. Linux + NVIDIA GPU) must
+// preserve unknown-name behavior: requesting the unknown NvTensorRTRTX name must NOT pull in CUDA.
+TEST_F(EpDetectorTest, DownloadFiltered_TrtRtxUnknownWithCudaPresent_NoInjection) {
   std::vector<MockEpBootstrapper*> mocks;
-  auto detector = MakeDetector(mocks, {{"NvTensorRTRTXExecutionProvider", true}});
+  auto detector = MakeDetector(mocks, {{"CUDAExecutionProvider", true},
+                                       {"WebGpuExecutionProvider", true}});
 
   std::vector<std::string> names = {"NvTensorRTRTXExecutionProvider"};
   auto result = detector->DownloadAndRegisterEps(&names, nullptr);
 
   EXPECT_TRUE(result.success);
-  ASSERT_EQ(result.registered_eps.size(), 1u);
-  EXPECT_EQ(result.registered_eps[0], "NvTensorRTRTXExecutionProvider");
-}
-
-// Requesting an unrelated EP must not pull in CUDA.
-TEST_F(EpDetectorTest, DownloadFiltered_NonTrtRtxDoesNotRegisterCuda) {
-  std::vector<MockEpBootstrapper*> mocks;
-  auto detector = MakeDetector(mocks, {{"WebGpuExecutionProvider", true},
-                                       {"CUDAExecutionProvider", true}});
-
-  std::vector<std::string> names = {"WebGpuExecutionProvider"};
-  auto result = detector->DownloadAndRegisterEps(&names, nullptr);
-
-  EXPECT_TRUE(result.success);
-  ASSERT_EQ(result.registered_eps.size(), 1u);
-  EXPECT_EQ(result.registered_eps[0], "WebGpuExecutionProvider");
+  EXPECT_TRUE(result.registered_eps.empty());
+  EXPECT_FALSE(mocks[0]->download_called_);  // CUDA must not be injected
   EXPECT_FALSE(mocks[1]->download_called_);
 }


### PR DESCRIPTION
## Summary
- register CUDA alongside TensorRT RTX because its GenAI bridge depends on the CUDA EP bundle
- preload and retain onnxruntime-genai-cuda.dll with its bundle directory in the Windows DLL search path
- add regression coverage for the TensorRT RTX-to-CUDA registration dependency and bridge preload failure

## Why this is needed
#952 configures the CUDA bundle only when the required provider is CUDAExecutionProvider. TensorRT RTX model variants instead request NvTensorRTRTXExecutionProvider, so the CUDA bootstrapper was skipped and GenAI later tried to resolve its CUDA bridge by bare name. This change establishes the dependency explicitly and loads the bridge from its verified absolute path before registration.

## Validation
- python sdk_v2\cpp\build.py --configure --build --config RelWithDebInfo`n- focused oundry_local_tests.exe filter: 12 passed
- live registration using the built DLL: requesting NvTensorRTRTXExecutionProvider registered both TensorRT RTX and CUDA successfully