### PR TITLE
Harden Python SDK version resolution

### DIFF
--- a/sdk_v2/python/src/foundry_local_sdk/version.py
+++ b/sdk_v2/python/src/foundry_local_sdk/version.py
@@ -1,1 +1,46 @@
-__version__ = "0.1.0"
+"""Package version resolution."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version as _dist_version
+from pathlib import Path
+
+_DISTRIBUTION_NAME = "foundry-local-sdk"
+_UNKNOWN = "0.0.0.dev0"
+
+
+def _version_from_pyproject(pyproject: Path) -> str | None:
+    if not pyproject.is_file():
+        return None
+
+    try:
+        import tomllib
+
+        with pyproject.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, ValueError, tomllib.TOMLDecodeError):
+        return None
+
+    found = data.get("project", {}).get("version")
+    return found if isinstance(found, str) and found else None
+
+
+def _version_from_source_tree() -> str | None:
+    # src/foundry_local_sdk/version.py -> sdk_v2/python/pyproject.toml
+    return _version_from_pyproject(Path(__file__).resolve().parents[2] / "pyproject.toml")
+
+
+def _resolve_version() -> str:
+    # Prefer the adjacent source project's version when this module is imported
+    # from a checkout, even if a different wheel is installed in the environment.
+    source_version = _version_from_source_tree()
+    if source_version is not None:
+        return source_version
+
+    try:
+        return _dist_version(_DISTRIBUTION_NAME)
+    except PackageNotFoundError:
+        return _UNKNOWN
+
+
+__version__ = _resolve_version()

--- a/sdk_v2/python/test/unit/test_version.py
+++ b/sdk_v2/python/test/unit/test_version.py
@@ -1,0 +1,41 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for Python SDK package version resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import foundry_local_sdk.version as version_module
+
+
+def test_source_tree_version_takes_precedence(monkeypatch):
+    monkeypatch.setattr(version_module, "_version_from_source_tree", lambda: "2.0.0.dev20260812")
+    monkeypatch.setattr(version_module, "_dist_version", lambda _: "9.9.9")
+
+    assert version_module._resolve_version() == "2.0.0.dev20260812"
+
+
+def test_installed_distribution_version_is_used_without_source_tree(monkeypatch):
+    monkeypatch.setattr(version_module, "_version_from_source_tree", lambda: None)
+    monkeypatch.setattr(version_module, "_dist_version", lambda _: "2.1.0")
+
+    assert version_module._resolve_version() == "2.1.0"
+
+
+def test_missing_pyproject_returns_none(tmp_path: Path):
+    assert version_module._version_from_pyproject(tmp_path / "missing.toml") is None
+
+
+def test_malformed_pyproject_falls_back_to_unknown(monkeypatch, tmp_path: Path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project\n", encoding="utf-8")
+    monkeypatch.setattr(version_module, "_version_from_source_tree", lambda: version_module._version_from_pyproject(pyproject))
+
+    def missing_distribution(_):
+        raise version_module.PackageNotFoundError
+
+    monkeypatch.setattr(version_module, "_dist_version", missing_distribution)
+    assert version_module._resolve_version() == "0.0.0.dev0"


### PR DESCRIPTION
## Summary

Address Copilot review feedback for Python SDK version resolution.

## Changes

- Prefer the adjacent source checkout's `pyproject.toml` version before consulting installed distribution metadata, preventing an unrelated installed wheel from masking the local source version.
- Add focused unit tests for source-tree precedence, installed metadata, missing `pyproject.toml`, malformed configuration, and unknown-version fallback.

## Validation

- `python -m pytest sdk_v2/python/test/unit/test_version.py sdk_v2/python/test/unit/test_imports.py -q` — 18 passed