### PR TITLE
GetCachedModels to return valid and accurate entries

### DIFF
--- a/sdk_v2/cpp/include/foundry_local/foundry_local_cpp.h
+++ b/sdk_v2/cpp/include/foundry_local/foundry_local_cpp.h
@@ -767,7 +767,7 @@ class ICatalog {
   virtual std::string_view GetName() const = 0;
   virtual ModelList GetModels() const = 0;
 
-  /// Get every leaf model variant currently present in the local cache.
+  /// Get every individual model variant currently present in the local cache.
   virtual ModelList GetCachedModels() const = 0;
 
   virtual ModelList GetLoadedModels() const = 0;

--- a/sdk_v2/cpp/include/foundry_local/foundry_local_cpp.h
+++ b/sdk_v2/cpp/include/foundry_local/foundry_local_cpp.h
@@ -766,7 +766,10 @@ class ICatalog {
   virtual ~ICatalog() = default;
   virtual std::string_view GetName() const = 0;
   virtual ModelList GetModels() const = 0;
+
+  /// Get every leaf model variant currently present in the local cache.
   virtual ModelList GetCachedModels() const = 0;
+
   virtual ModelList GetLoadedModels() const = 0;
   virtual std::unique_ptr<IModel> GetModel(const std::string& alias) const = 0;
   virtual std::unique_ptr<IModel> GetModelVariant(const std::string& model_id) const = 0;

--- a/sdk_v2/cpp/src/catalog.h
+++ b/sdk_v2/cpp/src/catalog.h
@@ -51,7 +51,7 @@ class ICatalog {
                                                 const std::string& variant_name,
                                                 int max_versions = 0) = 0;
 
-  /// Lists every leaf model variant that is cached locally.
+  /// Lists every individual model variant that is cached locally.
   /// Results preserve catalog alias order and each alias's best-first variant order.
   virtual std::vector<Model*> GetCachedModels() const = 0;
 

--- a/sdk_v2/cpp/src/catalog.h
+++ b/sdk_v2/cpp/src/catalog.h
@@ -51,7 +51,8 @@ class ICatalog {
                                                 const std::string& variant_name,
                                                 int max_versions = 0) = 0;
 
-  /// Lists only models that are cached locally.
+  /// Lists every leaf model variant that is cached locally.
+  /// Results preserve catalog alias order and each alias's best-first variant order.
   virtual std::vector<Model*> GetCachedModels() const = 0;
 
   /// Lists only models that are currently loaded into a runtime.

--- a/sdk_v2/cpp/src/catalog/azure_model_catalog.cc
+++ b/sdk_v2/cpp/src/catalog/azure_model_catalog.cc
@@ -12,9 +12,43 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <iterator>
+#include <unordered_set>
 #include <utility>
 
 namespace fl {
+
+namespace {
+
+ModelInfo MakeByomModelInfo(const std::string& model_id) {
+  auto [name, version] = Utils::SplitModelNameAndVersion(model_id);
+
+  ModelInfo info;
+  info.model_id = model_id;
+  info.name = name;
+  info.alias = name;
+  info.uri = "local://" + name;
+  info.version = version;
+  info.string_properties[FOUNDRY_LOCAL_MODEL_PROP_MODEL_PROVIDER_STR] = "Local";
+  info.string_properties[FOUNDRY_LOCAL_MODEL_PROP_MODEL_TYPE_STR] = "ONNX";
+  return info;
+}
+
+std::vector<ModelInfo> DeduplicateByModelId(std::vector<ModelInfo> model_infos) {
+  std::vector<ModelInfo> deduplicated;
+  deduplicated.reserve(model_infos.size());
+
+  std::unordered_set<std::string> model_ids;
+  for (auto& info : model_infos) {
+    if (model_ids.insert(info.model_id).second) {
+      deduplicated.push_back(std::move(info));
+    }
+  }
+
+  return deduplicated;
+}
+
+}  // namespace
 
 AzureModelCatalog::AzureModelCatalog(std::vector<std::pair<std::string, std::optional<std::string>>> catalog_urls,
                                      std::string cache_dir,
@@ -44,92 +78,95 @@ AzureModelCatalog::AzureModelCatalog(std::vector<std::pair<std::string, std::opt
 
 AzureModelCatalog::~AzureModelCatalog() = default;
 
-std::vector<Model> AzureModelCatalog::FetchModels() const {
-  // In cache-only mode, read only from the disk cache file — no network calls, no local model scanning.
-  // The cache file already includes local models from the last full catalog refresh by the long-running service
-  // process.
-  // TODO: For our CLI usage the catalog file would be current as we use an ephemeral port for the web service and
-  // therefore have to run FL first to acquire the external URL value, and that run would have updated the cached
-  // catalog info.
-  // If someone had a hardcoded web service URL they were using that sequence of events isn't guaranteed. If we care,
-  // we could update 'cache_only_' mode to enable refreshing the cache info if it is old. The cache file has a
-  // savedAtUnix timestamp property that can be used.
-  if (cache_only_) {
-    CatalogCache cache(cache_dir_, logger_);
-    cache.Load();
-    auto cached = cache.GetCachedModels();
+std::unique_ptr<ICatalogClient> AzureModelCatalog::CreateCatalogClient(const std::string& url,
+                                                                       const std::string& filter) const {
+  return MakeCatalogClient(url, filter, ep_detector_, logger_, cache_dir_, catalog_region_, disable_region_fallback_);
+}
 
-    std::vector<Model> models;
+AzureModelCatalog::CatalogResult AzureModelCatalog::GetLiveCatalogOrLocalSnapshot(
+    const std::vector<std::string>& cached_model_ids) const {
+  if (!cache_only_) {
+    std::vector<ModelInfo> live_model_infos;
+    bool any_url_succeeded = false;
 
-    if (cached) {
-      for (const auto& info : *cached) {
-        models.push_back(model_factory_(ModelInfo(info), /*local_path=*/""));
+    for (const auto& [url, filter] : catalog_urls_) {
+      try {
+        auto client = CreateCatalogClient(url, filter.value_or(""));
+        auto model_infos = FetchAllModelInfosWithCachedModels(*client, cached_model_ids, logger_);
+        any_url_succeeded = true;
+
+        live_model_infos.insert(live_model_infos.end(), std::make_move_iterator(model_infos.begin()),
+                                std::make_move_iterator(model_infos.end()));
+      } catch (const std::exception& ex) {
+        logger_.Log(LogLevel::Error, fmt::format("failed to fetch catalog from {}: {}", url, ex.what()));
+      } catch (...) {
+        logger_.Log(LogLevel::Error, fmt::format("failed to fetch catalog from {}: unknown error", url));
       }
     }
 
-    logger_.Log(LogLevel::Information,
-                fmt::format("Cache-only mode: populated {} models from cache file.", models.size()));
+    if (any_url_succeeded) {
+      return {
+          .model_infos = DeduplicateByModelId(std::move(live_model_infos)),
+          .source = CatalogSource::kLive,
+      };
+    }
+  }
 
-    return models;
+  CatalogCache cache(cache_dir_, logger_);
+  cache.Load();
+  auto cached = cache.GetCachedModels();
+
+  return {
+      .model_infos = cached ? DeduplicateByModelId(std::move(*cached)) : std::vector<ModelInfo>{},
+      .source = CatalogSource::kSnapshot,
+  };
+}
+
+std::vector<Model> AzureModelCatalog::AddLocalModels(std::vector<ModelInfo>& model_infos,
+                                                     const LocalModels& local_models) const {
+  std::unordered_set<std::string> model_ids;
+  model_ids.reserve(model_infos.size() + local_models.size());
+  for (const auto& info : model_infos) {
+    model_ids.insert(info.model_id);
+  }
+
+  for (const auto& local_model : local_models) {
+    if (model_ids.insert(local_model.first).second) {
+      model_infos.push_back(MakeByomModelInfo(local_model.first));
+    }
   }
 
   std::vector<Model> models;
-  std::vector<ModelInfo> fetched_infos;
-  const std::string& cache_dir = cache_dir_;
+  models.reserve(model_infos.size());
+  for (const auto& info : model_infos) {
+    auto local_model = local_models.find(info.model_id);
+    auto local_path = local_model != local_models.end() ? local_model->second : std::string{};
+    models.push_back(model_factory_(ModelInfo(info), std::move(local_path)));
+  }
 
-  logger_.Log(LogLevel::Information,
-              "Getting latest info from the Azure catalog and for locally cached models.");
+  return models;
+}
 
-  // Discover locally cached models.
-  auto local_models = ScanLocalModels(cache_dir, logger_);
+std::vector<Model> AzureModelCatalog::FetchModels() const {
+  logger_.Log(LogLevel::Information, "Getting catalog metadata and locally cached models.");
+
+  auto local_models = ScanLocalModels(cache_dir_, logger_);
   std::vector<std::string> cached_model_ids;
   cached_model_ids.reserve(local_models.size());
-  for (const auto& [id, path] : local_models) {
-    cached_model_ids.push_back(id);
+  for (const auto& local_model : local_models) {
+    cached_model_ids.push_back(local_model.first);
   }
 
-  logger_.Log(LogLevel::Information,
-              fmt::format("Found {} locally cached models.", cached_model_ids.size()));
+  logger_.Log(LogLevel::Information, fmt::format("Found {} locally cached models.", cached_model_ids.size()));
 
-  auto fetch_from = [&](const std::string& url, const std::optional<std::string>& filter) {
-    // Preserve byte-identical behavior for the "no override" case (previously stored as ""),
-    // while letting callers explicitly request "" as a real filter override.
-    auto client = MakeCatalogClient(url, filter.value_or(""), ep_detector_, logger_, cache_dir,
-                                    catalog_region_, disable_region_fallback_);
-    auto model_infos = FetchAllModelInfosWithCachedModels(*client, cached_model_ids, logger_);
+  auto catalog_result = GetLiveCatalogOrLocalSnapshot(cached_model_ids);
+  auto models = AddLocalModels(catalog_result.model_infos, local_models);
 
-    for (const auto& info : model_infos) {
-      // Check if the model is locally cached and pass the path if so.
-      std::string local_path;
-      auto it = local_models.find(info.model_id);
-      if (it != local_models.end()) {
-        local_path = it->second;
-      }
+  logger_.Log(LogLevel::Information, fmt::format("Populated model info for {} models.", models.size()));
 
-      fetched_infos.push_back(info);
-      models.push_back(model_factory_(ModelInfo(info), std::move(local_path)));
-    }
-  };
-
-  for (const auto& [url, filter] : catalog_urls_) {
-    try {
-      fetch_from(url, filter);
-    } catch (const std::exception& ex) {
-      // One failing URL shouldn't block others — skip and continue.
-      logger_.Log(LogLevel::Error,
-                  fmt::format("failed to fetch catalog from {}: {}", url, ex.what()));
-    }
-  }
-
-  logger_.Log(LogLevel::Information,
-              fmt::format("Populated model info for {} models.", models.size()));
-
-  // Save the fetched catalog for cache-only mode. This is best-effort: Save handles
-  // its own errors and freshness checks. If nothing was fetched, leave the existing
-  // cache untouched.
-  if (!fetched_infos.empty()) {
+  if (catalog_result.source == CatalogSource::kLive && !catalog_result.model_infos.empty()) {
     CatalogCache cache(cache_dir_, logger_);
-    cache.Save(fetched_infos);
+    cache.Save(catalog_result.model_infos);
   }
 
   return models;
@@ -148,8 +185,7 @@ std::vector<Model> AzureModelCatalog::FetchModelVersions(
 
   for (const auto& [url, filter] : catalog_urls_) {
     try {
-      auto client = MakeCatalogClient(url, filter.value_or(""), ep_detector_, logger_, cache_dir_,
-                                      catalog_region_, disable_region_fallback_);
+      auto client = CreateCatalogClient(url, filter.value_or(""));
       auto model_infos = client->FetchAllVersionsByAlias(model_alias, model_name);
 
       out.reserve(out.size() + model_infos.size());
@@ -193,8 +229,7 @@ std::vector<Model> AzureModelCatalog::FetchModelsByIds(const std::vector<std::st
     }
 
     try {
-      auto client = MakeCatalogClient(url, filter.value_or(""), ep_detector_, logger_, cache_dir_,
-                                      catalog_region_, disable_region_fallback_);
+      auto client = CreateCatalogClient(url, filter.value_or(""));
       auto model_infos = client->FetchModelsByIds(remaining);
 
       for (auto& info : model_infos) {

--- a/sdk_v2/cpp/src/catalog/azure_model_catalog.cc
+++ b/sdk_v2/cpp/src/catalog/azure_model_catalog.cc
@@ -124,24 +124,26 @@ AzureModelCatalog::CatalogResult AzureModelCatalog::GetLiveCatalogOrLocalSnapsho
 
 std::vector<Model> AzureModelCatalog::AddLocalModels(std::vector<ModelInfo>& model_infos,
                                                      const LocalModels& local_models) const {
+  std::vector<Model> models;
+  models.reserve(model_infos.size() + local_models.size());
+
   std::unordered_set<std::string> model_ids;
   model_ids.reserve(model_infos.size() + local_models.size());
   for (const auto& info : model_infos) {
     model_ids.insert(info.model_id);
-  }
 
-  for (const auto& local_model : local_models) {
-    if (model_ids.insert(local_model.first).second) {
-      model_infos.push_back(MakeByomModelInfo(local_model.first));
-    }
-  }
-
-  std::vector<Model> models;
-  models.reserve(model_infos.size());
-  for (const auto& info : model_infos) {
     auto local_model = local_models.find(info.model_id);
     auto local_path = local_model != local_models.end() ? local_model->second : std::string{};
     models.push_back(model_factory_(ModelInfo(info), std::move(local_path)));
+  }
+
+  for (const auto& [model_id, local_path] : local_models) {
+    if (!model_ids.insert(model_id).second) {
+      continue;
+    }
+
+    model_infos.push_back(MakeByomModelInfo(model_id));
+    models.push_back(model_factory_(ModelInfo(model_infos.back()), local_path));
   }
 
   return models;

--- a/sdk_v2/cpp/src/catalog/azure_model_catalog.h
+++ b/sdk_v2/cpp/src/catalog/azure_model_catalog.h
@@ -7,12 +7,16 @@
 #include "logger.h"
 
 #include <functional>
+#include <map>
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
 namespace fl {
+
+class ICatalogClient;
 
 /// Azure-specific catalog. Fetches from Azure Foundry catalog API,
 /// scans local cache, merges results.
@@ -36,10 +40,27 @@ class AzureModelCatalog : public BaseModelCatalog {
   std::vector<Model> FetchModelVersions(const std::string& model_alias,
                                         const std::string& model_name = "") const override;
   std::vector<Model> FetchModelsByIds(const std::vector<std::string>& model_ids) const override;
+  virtual std::unique_ptr<ICatalogClient> CreateCatalogClient(const std::string& url,
+                                                              const std::string& filter) const;
 
  private:
+  using LocalModels = std::map<std::string, std::string>;
+
+  enum class CatalogSource {
+    kLive,
+    kSnapshot,
+  };
+
+  struct CatalogResult {
+    std::vector<ModelInfo> model_infos;
+    CatalogSource source;
+  };
+
   static constexpr const char* kDefaultCatalogUrl = "https://ai.azure.com/api/centralus/ux/v1.0";
   static constexpr const char* kDefaultCatalogFilter = "''";
+
+  CatalogResult GetLiveCatalogOrLocalSnapshot(const std::vector<std::string>& cached_model_ids) const;
+  std::vector<Model> AddLocalModels(std::vector<ModelInfo>& model_infos, const LocalModels& local_models) const;
 
   std::vector<std::pair<std::string, std::optional<std::string>>> catalog_urls_;
   std::string cache_dir_;

--- a/sdk_v2/cpp/src/catalog/base_model_catalog.cc
+++ b/sdk_v2/cpp/src/catalog/base_model_catalog.cc
@@ -347,8 +347,10 @@ std::vector<Model*> BaseModelCatalog::GetCachedModels() const {
   std::lock_guard<std::mutex> lock(mutex_);
   std::vector<Model*> result;
   for (auto& m : models_) {
-    if (m->IsCached()) {
-      result.push_back(m.get());
+    for (auto* variant : m->Variants()) {
+      if (variant->IsCached()) {
+        result.push_back(variant);
+      }
     }
   }
 

--- a/sdk_v2/cpp/src/catalog/catalog_client.cc
+++ b/sdk_v2/cpp/src/catalog/catalog_client.cc
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "catalog/catalog_client.h"
-#include "utils.h"
-
-#include <foundry_local/foundry_local_c.h>
 
 #include <fmt/format.h>
 
@@ -48,26 +45,6 @@ std::vector<ModelInfo> FetchAllModelInfosWithCachedModels(
                  fmt::format("catalog: failed to fetch cached model IDs — {}", ex.what()));
     } catch (...) {
       logger.Log(LogLevel::Warning, "catalog: failed to fetch cached model IDs — unknown error");
-    }
-
-    // Step 4: Create basic entries for any IDs still unresolved (BYO models).
-    for (const auto& id : unresolved_ids) {
-      if (resolved_ids.find(id) != resolved_ids.end()) {
-        continue;
-      }
-
-      auto [name, version] = Utils::SplitModelNameAndVersion(id);
-
-      ModelInfo info;
-      info.model_id = id;
-      info.name = name;
-      info.alias = name;
-      info.uri = "local://" + name;
-      info.version = version;
-      info.string_properties[FOUNDRY_LOCAL_MODEL_PROP_MODEL_PROVIDER_STR] = "Local";
-      info.string_properties[FOUNDRY_LOCAL_MODEL_PROP_MODEL_TYPE_STR] = "ONNX";
-
-      result.push_back(std::move(info));
     }
   }
 

--- a/sdk_v2/cpp/src/catalog/catalog_client.h
+++ b/sdk_v2/cpp/src/catalog/catalog_client.h
@@ -49,8 +49,7 @@ class ICatalogClient {
   }
 };
 
-/// Production helper that combines a catalog fetch with locally cached model
-/// resolution and BYO synthesis.
+/// Fetch the current catalog and resolve cached model IDs that are no longer in the latest response.
 std::vector<ModelInfo> FetchAllModelInfosWithCachedModels(
     ICatalogClient& client,
     const std::vector<std::string>& cached_model_ids,

--- a/sdk_v2/cpp/test/CMakeLists.txt
+++ b/sdk_v2/cpp/test/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(foundry_local_tests
     internal_api/region_fallback_test.cc
     internal_api/sse_stream_body_test.cc
     internal_api/azure_catalog_test.cc
+    internal_api/azure_model_catalog_test.cc
     internal_api/telemetry_test.cc
     internal_api/tensor_test.cc
     internal_api/chat/search_options_test.cc

--- a/sdk_v2/cpp/test/internal_api/azure_catalog_test.cc
+++ b/sdk_v2/cpp/test/internal_api/azure_catalog_test.cc
@@ -588,7 +588,7 @@ TEST(AzureCatalogClientTest, WithCachedModels_UnresolvedId_TriggersSecondFetch) 
   EXPECT_TRUE(found_old);
 }
 
-TEST(AzureCatalogClientTest, WithCachedModels_FullyUnresolved_CreatesBYOEntry) {
+TEST(AzureCatalogClientTest, WithCachedModels_FullyUnresolved_DefersBYOEntryToCatalogMerge) {
   CpuOnlyEpDetector ep;
   StderrLogger logger;
   int http_call_count = 0;
@@ -609,22 +609,8 @@ TEST(AzureCatalogClientTest, WithCachedModels_FullyUnresolved_CreatesBYOEntry) {
   auto result = FetchAllModelInfosWithCachedModels(client, {"custom-model:0"}, logger);
 
   EXPECT_EQ(http_call_count, 2);
-
-  // Find the BYO entry.
-  const ModelInfo* byo = nullptr;
-  for (const auto& info : result) {
-    if (info.model_id == "custom-model:0") {
-      byo = &info;
-    }
-  }
-
-  ASSERT_NE(byo, nullptr);
-  EXPECT_EQ(byo->name, "custom-model");
-  EXPECT_EQ(byo->alias, "custom-model");
-  EXPECT_EQ(byo->uri, "local://custom-model");
-  EXPECT_EQ(byo->version, 0);
-  EXPECT_EQ(byo->string_properties.at(FOUNDRY_LOCAL_MODEL_PROP_MODEL_PROVIDER_STR), "Local");
-  EXPECT_EQ(byo->string_properties.at(FOUNDRY_LOCAL_MODEL_PROP_MODEL_TYPE_STR), "ONNX");
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].model_id, "phi-4-mini:3");
 }
 
 // ========================================================================

--- a/sdk_v2/cpp/test/internal_api/azure_model_catalog_test.cc
+++ b/sdk_v2/cpp/test/internal_api/azure_model_catalog_test.cc
@@ -1,0 +1,344 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "catalog/azure_model_catalog.h"
+#include "catalog/catalog_cache.h"
+#include "catalog/catalog_client.h"
+#include "internal_api/test_helpers.h"
+#include "model.h"
+#include "model_info.h"
+#include "utils/temp_path.h"
+
+#include <foundry_local/foundry_local_c.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+using namespace fl;
+
+namespace {
+
+namespace fs = std::filesystem;
+
+struct CatalogBehavior {
+  bool fail_fetch_all = false;
+  std::vector<ModelInfo> all_models;
+  std::vector<ModelInfo> models_by_id;
+  int fetch_all_calls = 0;
+  int fetch_by_id_calls = 0;
+  std::vector<std::string> last_requested_ids;
+};
+
+class FakeCatalogClient final : public ICatalogClient {
+ public:
+  explicit FakeCatalogClient(std::shared_ptr<CatalogBehavior> behavior) : behavior_(std::move(behavior)) {}
+
+  std::vector<ModelInfo> FetchAllModelInfos() override {
+    ++behavior_->fetch_all_calls;
+    if (behavior_->fail_fetch_all) {
+      throw std::runtime_error("configured catalog failure");
+    }
+
+    return behavior_->all_models;
+  }
+
+  std::vector<ModelInfo> FetchModelsByIds(const std::vector<std::string>& model_ids) override {
+    ++behavior_->fetch_by_id_calls;
+    behavior_->last_requested_ids = model_ids;
+
+    const std::unordered_set<std::string> requested_ids(model_ids.begin(), model_ids.end());
+    std::vector<ModelInfo> result;
+    for (const auto& info : behavior_->models_by_id) {
+      if (requested_ids.contains(info.model_id)) {
+        result.push_back(info);
+      }
+    }
+
+    return result;
+  }
+
+ private:
+  std::shared_ptr<CatalogBehavior> behavior_;
+};
+
+class TestAzureModelCatalog final : public AzureModelCatalog {
+ public:
+  using ClientFactory =
+      std::function<std::unique_ptr<ICatalogClient>(const std::string& url, const std::string& filter)>;
+
+  TestAzureModelCatalog(std::vector<std::pair<std::string, std::optional<std::string>>> catalog_urls,
+                        std::string cache_dir,
+                        ModelFactory model_factory,
+                        const IEpDetector& ep_detector,
+                        ILogger& logger,
+                        bool cache_only,
+                        ClientFactory client_factory)
+      : AzureModelCatalog(std::move(catalog_urls), std::move(cache_dir), std::move(model_factory), ep_detector, logger,
+                          cache_only),
+        client_factory_(std::move(client_factory)) {}
+
+ protected:
+  std::unique_ptr<ICatalogClient> CreateCatalogClient(const std::string& url,
+                                                      const std::string& filter) const override {
+    return client_factory_(url, filter);
+  }
+
+ private:
+  ClientFactory client_factory_;
+};
+
+ModelInfo MakeModelInfo(const std::string& model_id,
+                        const std::string& name,
+                        int version,
+                        const std::string& alias,
+                        const std::string& provider) {
+  ModelInfo info;
+  info.model_id = model_id;
+  info.name = name;
+  info.version = version;
+  info.alias = alias;
+  info.uri = "https://example.test/" + model_id;
+  info.string_properties[FOUNDRY_LOCAL_MODEL_PROP_MODEL_PROVIDER_STR] = provider;
+  info.string_properties[FOUNDRY_LOCAL_MODEL_PROP_MODEL_TYPE_STR] = "ONNX";
+  return info;
+}
+
+Model* FindVariant(const std::vector<Model*>& models, const std::string& model_id) {
+  for (auto* model : models) {
+    for (auto* variant : model->Variants()) {
+      if (variant->Info().model_id == model_id) {
+        return variant;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+}  // namespace
+
+class AzureModelCatalogTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<CatalogBehavior> AddBehavior(const std::string& url, bool fail_fetch_all = false) {
+    auto behavior = std::make_shared<CatalogBehavior>();
+    behavior->fail_fetch_all = fail_fetch_all;
+    behaviors_[url] = behavior;
+    return behavior;
+  }
+
+  fs::path AddLocalModel(const std::string& model_id, const std::string& directory_name) {
+    auto model_directory = cache_directory_.path() / "Microsoft" / directory_name;
+    fs::create_directories(model_directory);
+
+    {
+      std::ofstream genai_config(model_directory / "genai_config.json");
+      genai_config << "{}";
+    }
+
+    {
+      std::ofstream inference_model(model_directory / "inference_model.json");
+      inference_model << nlohmann::json({{"Name", model_id}}).dump();
+    }
+
+    return model_directory;
+  }
+
+  void WriteSnapshot(const std::vector<ModelInfo>& model_infos) {
+    nlohmann::json models = nlohmann::json::array();
+    for (const auto& info : model_infos) {
+      models.push_back(ModelInfoToJson(info));
+    }
+
+    const nlohmann::json snapshot = {
+        {"version", 1},
+        {"savedAtUnix", 0},
+        {"models", std::move(models)},
+    };
+
+    std::ofstream file(cache_directory_.path() / "foundry.modelinfo.json");
+    ASSERT_TRUE(file.is_open());
+    file << snapshot.dump(2);
+  }
+
+  std::unique_ptr<AzureModelCatalog> CreateCatalog(
+      std::vector<std::pair<std::string, std::optional<std::string>>> catalog_urls,
+      bool cache_only = false) {
+    auto model_factory = [this](ModelInfo info, std::string local_path) {
+      return Model::FromModelInfo(std::move(info), std::move(local_path), services_.download_manager,
+                                  services_.model_load_manager);
+    };
+    auto client_factory = [this](const std::string& url, const std::string&) {
+      ++factory_calls_;
+      auto behavior = behaviors_.find(url);
+      if (behavior == behaviors_.end()) {
+        throw std::runtime_error("missing fake behavior for " + url);
+      }
+
+      return std::make_unique<FakeCatalogClient>(behavior->second);
+    };
+
+    return std::make_unique<TestAzureModelCatalog>(std::move(catalog_urls), cache_directory_.string(),
+                                                   std::move(model_factory), services_.ep_detector, services_.logger,
+                                                   cache_only, std::move(client_factory));
+  }
+
+  fl::test::TempPath cache_directory_ = fl::test::TempPath::CreateTempDir("fl_azure_model_catalog_");
+  fl::test::FakeServiceBindings services_;
+  std::unordered_map<std::string, std::shared_ptr<CatalogBehavior>> behaviors_;
+  int factory_calls_ = 0;
+};
+
+TEST_F(AzureModelCatalogTest, AllUrlsFailUsesSnapshotMetadataAndScannedPathsWithoutRewritingSnapshot) {
+  const auto gpu_info =
+      MakeModelInfo("snapshot-gpu:2", "snapshot-gpu", 2, "snapshot-alias", "SnapshotProvider");
+  const auto cpu_info =
+      MakeModelInfo("snapshot-cpu:2", "snapshot-cpu", 2, "snapshot-alias", "SnapshotProvider");
+  WriteSnapshot({gpu_info, cpu_info});
+  const auto gpu_path = AddLocalModel("snapshot-gpu:2", "snapshot-gpu");
+  const auto cpu_path = AddLocalModel("snapshot-cpu:2", "snapshot-cpu");
+  const auto byom_path = AddLocalModel("offline-byom:4", "offline-byom");
+
+  AddBehavior("https://catalog-one.test", true);
+  AddBehavior("https://catalog-two.test", true);
+  auto catalog = CreateCatalog({
+      {"https://catalog-one.test", std::nullopt},
+      {"https://catalog-two.test", std::nullopt},
+  });
+
+  const auto cached_models = catalog->GetCachedModels();
+
+  ASSERT_EQ(cached_models.size(), 3u);
+  auto* gpu_model = FindVariant(cached_models, "snapshot-gpu:2");
+  ASSERT_NE(gpu_model, nullptr);
+  EXPECT_EQ(gpu_model->Info().alias, "snapshot-alias");
+  const auto* provider = gpu_model->Info().GetPropertyStr(FOUNDRY_LOCAL_MODEL_PROP_MODEL_PROVIDER_STR);
+  ASSERT_NE(provider, nullptr);
+  EXPECT_EQ(*provider, "SnapshotProvider");
+  EXPECT_EQ(gpu_model->LocalPath(), gpu_path.string());
+
+  auto* cpu_model = FindVariant(cached_models, "snapshot-cpu:2");
+  ASSERT_NE(cpu_model, nullptr);
+  EXPECT_EQ(cpu_model->Info().alias, "snapshot-alias");
+  EXPECT_EQ(cpu_model->LocalPath(), cpu_path.string());
+
+  auto* byom_model = FindVariant(cached_models, "offline-byom:4");
+  ASSERT_NE(byom_model, nullptr);
+  EXPECT_EQ(byom_model->LocalPath(), byom_path.string());
+
+  CatalogCache persisted_cache(cache_directory_.string(), services_.logger);
+  persisted_cache.Load();
+  const auto persisted_models = persisted_cache.GetCachedModels();
+  ASSERT_TRUE(persisted_models.has_value());
+  ASSERT_EQ(persisted_models->size(), 2u);
+  EXPECT_EQ((*persisted_models)[0].model_id, "snapshot-gpu:2");
+  EXPECT_EQ((*persisted_models)[1].model_id, "snapshot-cpu:2");
+  EXPECT_EQ(factory_calls_, 2);
+}
+
+TEST_F(AzureModelCatalogTest, AllUrlsFailWithoutSnapshotSurfacesScannedModelAsByom) {
+  const auto local_path = AddLocalModel("custom-model:0", "custom-model");
+  AddBehavior("https://catalog-one.test", true);
+  AddBehavior("https://catalog-two.test", true);
+  auto catalog = CreateCatalog({
+      {"https://catalog-one.test", std::nullopt},
+      {"https://catalog-two.test", std::nullopt},
+  });
+
+  const auto cached_models = catalog->GetCachedModels();
+
+  ASSERT_EQ(cached_models.size(), 1u);
+  auto* byom_model = FindVariant(cached_models, "custom-model:0");
+  ASSERT_NE(byom_model, nullptr);
+  EXPECT_EQ(byom_model->Info().name, "custom-model");
+  EXPECT_EQ(byom_model->Info().alias, "custom-model");
+  EXPECT_EQ(byom_model->Info().version, 0);
+  EXPECT_EQ(byom_model->Info().uri, "local://custom-model");
+  const auto* provider = byom_model->Info().GetPropertyStr(FOUNDRY_LOCAL_MODEL_PROP_MODEL_PROVIDER_STR);
+  const auto* model_type = byom_model->Info().GetPropertyStr(FOUNDRY_LOCAL_MODEL_PROP_MODEL_TYPE_STR);
+  ASSERT_NE(provider, nullptr);
+  ASSERT_NE(model_type, nullptr);
+  EXPECT_EQ(*provider, "Local");
+  EXPECT_EQ(*model_type, "ONNX");
+  EXPECT_EQ(byom_model->LocalPath(), local_path.string());
+  EXPECT_FALSE(fs::exists(cache_directory_.path() / "foundry.modelinfo.json"));
+}
+
+TEST_F(AzureModelCatalogTest, EmptySuccessfulUrlPreventsSnapshotFallbackWhenAnotherUrlFails) {
+  WriteSnapshot({MakeModelInfo("snapshot-only:1", "snapshot-only", 1, "snapshot-only", "SnapshotProvider")});
+  AddBehavior("https://failed-catalog.test", true);
+  const auto successful_behavior = AddBehavior("https://empty-catalog.test");
+  auto catalog = CreateCatalog({
+      {"https://failed-catalog.test", std::nullopt},
+      {"https://empty-catalog.test", std::nullopt},
+  });
+
+  const auto models = catalog->ListModels();
+
+  EXPECT_TRUE(models.empty());
+  EXPECT_EQ(successful_behavior->fetch_all_calls, 1);
+  EXPECT_EQ(factory_calls_, 2);
+}
+
+TEST_F(AzureModelCatalogTest, CacheOnlyUsesSnapshotAndScannedByomWithoutCreatingLiveClient) {
+  WriteSnapshot({MakeModelInfo("snapshot-model:3", "snapshot-model", 3, "snapshot-alias", "SnapshotProvider")});
+  AddLocalModel("snapshot-model:3", "snapshot-model");
+  AddLocalModel("cache-only-byom:5", "cache-only-byom");
+  auto catalog = CreateCatalog({{"https://must-not-be-called.test", std::nullopt}}, true);
+
+  const auto cached_models = catalog->GetCachedModels();
+
+  ASSERT_EQ(cached_models.size(), 2u);
+  EXPECT_NE(FindVariant(cached_models, "snapshot-model:3"), nullptr);
+  EXPECT_NE(FindVariant(cached_models, "cache-only-byom:5"), nullptr);
+  EXPECT_EQ(factory_calls_, 0);
+}
+
+TEST_F(AzureModelCatalogTest, LiveAggregationDeduplicatesAndSavesResolvedAndByomMetadata) {
+  AddLocalModel("old-model:1", "old-model");
+  AddLocalModel("custom-model:0", "custom-model");
+
+  const auto latest_info = MakeModelInfo("latest-model:2", "latest-model", 2, "latest-model", "LiveProvider");
+  const auto old_info = MakeModelInfo("old-model:1", "old-model", 1, "old-model", "ResolvedProvider");
+
+  const auto first_behavior = AddBehavior("https://catalog-one.test");
+  first_behavior->all_models = {latest_info};
+  first_behavior->models_by_id = {old_info};
+  const auto second_behavior = AddBehavior("https://catalog-two.test");
+  second_behavior->all_models = {latest_info};
+
+  auto catalog = CreateCatalog({
+      {"https://catalog-one.test", std::nullopt},
+      {"https://catalog-two.test", std::nullopt},
+  });
+
+  const auto models = catalog->ListModels();
+
+  ASSERT_EQ(models.size(), 3u);
+  EXPECT_EQ(first_behavior->fetch_by_id_calls, 1);
+  EXPECT_EQ(second_behavior->fetch_by_id_calls, 1);
+
+  CatalogCache persisted_cache(cache_directory_.string(), services_.logger);
+  persisted_cache.Load();
+  const auto persisted_models = persisted_cache.GetCachedModels();
+  ASSERT_TRUE(persisted_models.has_value());
+  ASSERT_EQ(persisted_models->size(), 3u);
+
+  std::unordered_set<std::string> persisted_ids;
+  for (const auto& info : *persisted_models) {
+    persisted_ids.insert(info.model_id);
+  }
+
+  EXPECT_EQ(persisted_ids,
+            (std::unordered_set<std::string>{"latest-model:2", "old-model:1", "custom-model:0"}));
+}

--- a/sdk_v2/cpp/test/internal_api/base_model_catalog_test.cc
+++ b/sdk_v2/cpp/test/internal_api/base_model_catalog_test.cc
@@ -304,6 +304,28 @@ TEST_F(BaseModelCatalogTest, GroupedModel_PrefersCachedVariant) {
   EXPECT_EQ(m->Info().model_id, "phi-3:2");
 }
 
+TEST_F(BaseModelCatalogTest, GetCachedModelsReturnsEveryCachedLeafInCatalogVariantOrder) {
+  TestCatalog catalog(logger_);
+  catalog.AddModel(MakeModel("alpha:1", "alpha", 1, "alpha", "/cache/alpha-1"));
+  catalog.AddModel(MakeModel("alpha:3", "alpha", 3, "alpha"));
+  catalog.AddModel(MakeModel("alpha:2", "alpha", 2, "alpha", "/cache/alpha-2"));
+  catalog.AddModel(MakeModel("beta:1", "beta", 1, "beta", "/cache/beta-1"));
+
+  auto cached = catalog.GetCachedModels();
+
+  ASSERT_EQ(cached.size(), 3u);
+  EXPECT_EQ(cached[0]->Info().model_id, "alpha:2");
+  EXPECT_EQ(cached[1]->Info().model_id, "alpha:1");
+  EXPECT_EQ(cached[2]->Info().model_id, "beta:1");
+
+  for (auto* variant : cached) {
+    EXPECT_FALSE(variant->IsContainer());
+    EXPECT_TRUE(variant->IsCached());
+    EXPECT_EQ(variant->Variants().size(), 1u);
+    EXPECT_EQ(variant, catalog.GetModelVariant(variant->Info().model_id));
+  }
+}
+
 TEST_F(BaseModelCatalogTest, GetModelVariant_ById_ReturnsVariantNotContainer) {
   TestCatalog catalog(logger_);
   catalog.AddModel(MakeModel("phi-3-mini:1", "phi-3-mini", 1, "phi-3"));

--- a/sdk_v2/cpp/test/sdk_api/cache_only_test.cc
+++ b/sdk_v2/cpp/test/sdk_api/cache_only_test.cc
@@ -6,8 +6,6 @@
 // the previous one must be destroyed before creating a new one.
 //
 
-#include "utils/safe_getenv.h"
-
 #include <foundry_local/foundry_local_cpp.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
@@ -82,6 +80,15 @@ class CacheOnlyTest : public ::testing::Test {
     config.SetModelCacheDir(test_dir_)
         .SetExternalServiceUrl("http://127.0.0.1:12345");
     return config;
+  }
+
+  std::string CreateLocalModel(const std::string& model_id, const std::string& directory_name) {
+    auto model_directory = fs::path(test_dir_) / "Microsoft" / directory_name;
+    fs::create_directories(model_directory);
+    WriteFile((model_directory / "genai_config.json").string(), "{}");
+    WriteFile((model_directory / "inference_model.json").string(),
+              nlohmann::json({{"Name", model_id}}).dump());
+    return model_directory.string();
   }
 
   std::string test_dir_;
@@ -250,65 +257,36 @@ TEST_F(CacheOnlyTest, MissingCacheFileReturnsEmptyModelList) {
   }
 }
 
-// Cache-only mode must still scan the cache directory for locally-present models so callers see
-// accurate IsCached() / GetPath() state. Without this, every model surfaces as not-cached and
-// Model::Download triggers a redundant download even when the bits are already on disk.
-//
-// This test runs against the shared test model cache (the same one used by sdk_integration_tests).
-// It is skipped when the cache or its catalog file is unavailable — there is no fake-model fixture
-// here because we want to exercise the real on-disk layout (genai_config.json + inference_model.json
-// pairing, variant subdirectories, etc.) that production callers rely on.
-TEST(CacheOnlyLocalScan, LocalModelsAreReportedAsCached) {
-  std::string cache_dir = fl::test::SafeGetEnv("FOUNDRY_TEST_DATA_DIR ");
-  if (cache_dir.empty() || !fs::exists(cache_dir)) {
-    GTEST_SKIP() << "FOUNDRY_TEST_DATA_DIR not set or path does not exist; "
-                 << "skipping local-scan test against the shared test model cache.";
+TEST_F(CacheOnlyTest, SnapshotAndByomModelsUseScannedLocalPaths) {
+  WriteTwoModelCacheFile();
+  const auto snapshot_model_path =
+      CreateLocalModel("phi-4-mini-instruct-generic-cpu:2", "phi-snapshot-model");
+  const auto byom_model_path = CreateLocalModel("contoso-custom-model:7", "contoso-byom-model");
+
+  {
+    foundry_local::Manager manager(MakeCacheOnlyConfig());
+    auto& catalog = manager.GetCatalog();
+    auto models = catalog.GetModels();
+    auto cached_models = catalog.GetCachedModels();
+
+    ASSERT_EQ(models.size(), 3u);
+    ASSERT_EQ(cached_models.size(), 2u);
+
+    auto snapshot_model = catalog.GetModelVariant("phi-4-mini-instruct-generic-cpu:2");
+    ASSERT_NE(snapshot_model, nullptr);
+    EXPECT_TRUE(snapshot_model->IsCached());
+    EXPECT_EQ(std::string(snapshot_model->GetPath()), snapshot_model_path);
+    EXPECT_EQ(snapshot_model->GetInfo().Publisher().value_or(""), "Microsoft");
+
+    auto byom_model = catalog.GetModelVariant("contoso-custom-model:7");
+    ASSERT_NE(byom_model, nullptr);
+    EXPECT_TRUE(byom_model->IsCached());
+    EXPECT_EQ(std::string(byom_model->GetPath()), byom_model_path);
+    EXPECT_EQ(byom_model->GetInfo().Name(), "contoso-custom-model");
+    EXPECT_EQ(byom_model->GetInfo().Alias(), "contoso-custom-model");
+    EXPECT_EQ(byom_model->GetInfo().Version(), 7);
+    EXPECT_EQ(byom_model->GetInfo().Uri(), "local://contoso-custom-model");
+    EXPECT_EQ(byom_model->GetInfo().ModelProvider().value_or(""), "Local");
+    EXPECT_EQ(byom_model->GetInfo().ModelType().value_or(""), "ONNX");
   }
-
-  fs::path cache_file = fs::path(cache_dir) / "foundry.modelinfo.json";
-  if (!fs::exists(cache_file)) {
-    GTEST_SKIP() << "Shared test model cache has no foundry.modelinfo.json at " << cache_file.string()
-                 << "; cache-only mode has nothing to enumerate. Run the non-cache-only tests once "
-                 << "to populate the catalog cache, then re-run.";
-  }
-
-  foundry_local::Configuration config("cache_only_local_scan_test");
-  config.SetModelCacheDir(cache_dir)
-      .SetExternalServiceUrl("http://127.0.0.1:12345");
-
-  foundry_local::Manager manager(std::move(config));
-  auto& catalog = manager.GetCatalog();
-  auto model_list = catalog.GetModels();
-  const auto& models = model_list;
-
-  ASSERT_FALSE(models.empty()) << "Expected the cache file to contain at least one model entry.";
-
-  // At least one model in the shared cache should be locally present. Anything less means either
-  // the scan regressed or the shared cache is empty — both are problems worth surfacing here rather
-  // than silently downloading on the next sample run.
-  std::size_t cached_count = 0;
-  std::size_t with_path_count = 0;
-
-  for (const auto& model : models) {
-    if (model->IsCached()) {
-      ++cached_count;
-
-      std::string path(model->GetPath());
-      EXPECT_FALSE(path.empty())
-          << "Model " << model->GetInfo().Id() << " reports cached but has empty GetPath().";
-      EXPECT_TRUE(fs::exists(path))
-          << "Model " << model->GetInfo().Id() << " reports cached but path does not exist: " << path;
-
-      if (!path.empty() && fs::exists(path)) {
-        ++with_path_count;
-      }
-    }
-  }
-
-  EXPECT_GT(cached_count, 0u)
-      << "No model in cache-only mode reported IsCached()=true against " << cache_dir
-      << ". Either the shared cache is empty or the cache-only branch is no longer running "
-      << "ScanLocalModels.";
-  EXPECT_EQ(cached_count, with_path_count)
-      << "Some models reported cached but failed the path-exists check above.";
 }

--- a/sdk_v2/cpp/test/sdk_api/catalog_test.cc
+++ b/sdk_v2/cpp/test/sdk_api/catalog_test.cc
@@ -119,6 +119,10 @@ TEST_F(ModelFixture, CatalogGetCachedModelsIncludesDownloadedModel) {
   EXPECT_TRUE(cached_model->IsCached());
   EXPECT_EQ(cached_model->GetInfo().Id(), model_id());
 
+  foundry_local::ModelList variants = cached_model->GetVariants();
+  ASSERT_EQ(variants.size(), 1u) << "GetCachedModels should return leaf variants rather than alias containers";
+  EXPECT_EQ(variants.front()->GetInfo().Id(), model_id());
+
   std::string local_path(cached_model->GetPath());
   EXPECT_FALSE(local_path.empty());
   EXPECT_TRUE(fs::exists(local_path)) << "Expected cached model path to exist: " << local_path;

--- a/sdk_v2/cs/src/ICatalog.cs
+++ b/sdk_v2/cs/src/ICatalog.cs
@@ -43,7 +43,7 @@ public interface ICatalog
     /// Get a list of currently downloaded models from the model cache.
     /// </summary>
     /// <param name="ct">Optional CancellationToken.</param>
-    /// <returns>List of IModel instances.</returns>
+    /// <returns>One leaf IModel instance per cached model variant.</returns>
     Task<List<IModel>> GetCachedModelsAsync(CancellationToken? ct = null);
 
     /// <summary>

--- a/sdk_v2/cs/src/ICatalog.cs
+++ b/sdk_v2/cs/src/ICatalog.cs
@@ -43,7 +43,7 @@ public interface ICatalog
     /// Get a list of currently downloaded models from the model cache.
     /// </summary>
     /// <param name="ct">Optional CancellationToken.</param>
-    /// <returns>One leaf IModel instance per cached model variant.</returns>
+    /// <returns>One IModel instance per cached model variant.</returns>
     Task<List<IModel>> GetCachedModelsAsync(CancellationToken? ct = null);
 
     /// <summary>

--- a/sdk_v2/js/src/catalog.ts
+++ b/sdk_v2/js/src/catalog.ts
@@ -32,7 +32,7 @@ export class Catalog {
     return wrapAll(this.#native.getModels());
   }
 
-  /** Models currently present in the local cache. */
+  /** Every leaf model variant currently present in the local cache. */
   async getCachedModels(): Promise<IModel[]> {
     return wrapAll(this.#native.getCachedModels());
   }

--- a/sdk_v2/js/src/catalog.ts
+++ b/sdk_v2/js/src/catalog.ts
@@ -32,7 +32,7 @@ export class Catalog {
     return wrapAll(this.#native.getModels());
   }
 
-  /** Every leaf model variant currently present in the local cache. */
+  /** Every individual model variant currently present in the local cache. */
   async getCachedModels(): Promise<IModel[]> {
     return wrapAll(this.#native.getCachedModels());
   }

--- a/sdk_v2/python/src/foundry_local_sdk/catalog.py
+++ b/sdk_v2/python/src/foundry_local_sdk/catalog.py
@@ -129,7 +129,7 @@ class Catalog:
         """Get a list of currently downloaded models from the model cache.
 
         Returns:
-            List of ``IModel`` instances (leaf variants cached locally).
+            One ``IModel`` instance per cached model variant.
         """
         from foundry_local_sdk._native.api import api, ffi
 


### PR DESCRIPTION
This PR makes cached-model discovery resilient to catalog outages and returns every cached model variant instead of one selected model per alias.

- Falls back to `foundry.modelinfo.json` when all live catalog URLs fail.
- Treats valid disk models missing from metadata as BYOM models.
- Returns cached leaf variants in alias order and per-alias best-first order.


### Issues addressed

1. **Offline catalog returned no cached models**
   - Before: if every live catalog request failed, catalog population returned an empty list even when models and `foundry.modelinfo.json` were present locally.
   - Now: when all live catalog URLs fail, the local snapshot supplies model metadata.

2. **Locally valid models missing from metadata were omitted**
   - Before: a downloaded model could be invisible when neither the live response nor snapshot contained its ID.
   - Now: valid models found by the disk scan are included with BYOM metadata.

3. **Only one cached variant per alias was returned**
   - Before: `GetCachedModels()` returned the alias container, which exposed only its selected CPU/GPU/NPU variant.
   - Now: it returns every cached leaf variant under the alias and skips only uncached variants.

4. **Cache-only mode did not reconcile snapshot metadata with disk state**
   - Before: snapshot entries were created without scanned local paths, and disk-only models were not represented.
   - Now: cache-only mode still performs no live requests, but attaches scanned paths and adds unmatched models as BYOM entries.

5. **Multiple catalog URLs could produce duplicate model IDs**
   - Before: each URL independently resolved local IDs and could synthesize duplicate entries.
   - Now: successful live results are aggregated, deduplicated by model ID, and merged with local models once.

6. **Cached-model results could hide the canonical variant objects**
   - Before: callers received alias containers rather than the leaf returned by `GetModelVariant(model_id)`.
   - Now: both APIs return the same catalog-owned leaf pointer, keeping download, load, removal, and path state consistent.

### Code flow

```text
GetCachedModels()
       |
       v
Scan local model cache
       |
       +--> model IDs + local paths
       |
       v
Is catalog cache-only?
       |
   +---+---+
   |       |
  Yes      No
   |       |
   |       v
   |   Query configured live catalog URL(s)
   |       |
   |   +---+------------------+
   |   |                      |
   |   | Any URL succeeded    | All URLs failed
   |   v                      v
   | Aggregate + deduplicate  Load foundry.modelinfo.json
   | live metadata            (missing/invalid = empty)
   |   |                      |
   +---+----------------------+
       |
       v
Merge selected metadata with disk scan
       |
       +--> attach local paths by model ID
       +--> synthesize BYOM metadata for unmatched disk models
       |
       v
Save snapshot only when metadata came from live catalog
       |
       v
Group models by alias
       |
       v
Flatten and return every cached leaf variant
```