### PR TITLE
Follow up: isolate per-operation cancellation state

### DIFF
--- a/sdk_v2/cpp/CMakeLists.txt
+++ b/sdk_v2/cpp/CMakeLists.txt
@@ -216,6 +216,12 @@ set(FOUNDRY_LOCAL_SOURCES
     src/inferencing/session/session_manager.cc
     src/inferencing/session/oga_generator_cancellable.cc
     src/inferencing/session/live_session_registry.cc
+    src/inferencing/session/session_runtime.cc
+    src/inferencing/session/operation_state.cc
+    src/inferencing/session/cancel_slot.cc
+    src/inferencing/session/request_control.cc
+    src/inferencing/session/request_snapshot.cc
+    src/inferencing/session/operation.cc
     src/inferencing/generative/chat/chat_session.cc
     src/inferencing/generative/chat/chat_template.cc
     src/configuration.cc

--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_generator.h
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_generator.h
@@ -39,9 +39,10 @@ class AudioGenerator : public ICancellable {
   /// Default implementation loops GenerateNextToken/Decode.
   virtual std::string GenerateAll();
 
-  /// Request cancellation of generation. Thread-safe — can be called from another thread.
+  /// Request cancellation of generation. Thread-safe — can be called from another thread, and noexcept:
+  /// it is invoked from teardown and watchdog paths that cannot handle a failure.
   /// After cancellation, IsDone() should return true on the next check.
-  void Cancel() override = 0;
+  bool Cancel() noexcept override = 0;
 
  protected:
   AudioGenerator() = default;

--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
@@ -119,48 +119,45 @@ bool IsLanguageToken(const std::string& token) {
   return end >= start && token[start] == '<' && token[end] == '>';
 }
 
+void SealAndPublishAudioResponse(const OperationContext& operation, Response& pending_response,
+                                 Response& response) {
+  if (!operation.TrySeal()) {
+    pending_response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
+  }
+
+  response.Swap(pending_response);
+}
+
 }  // namespace
 
 
-AudioSession::AudioSession(const fl::Model& catalog_model, GenAIModelInstance& model,
-                           ILogger& logger, ITelemetry& telemetry)
-    : Session(catalog_model, logger, telemetry), logger_(logger), model_(model) {
-  logger_.Log(LogLevel::Debug, fmt::format("Creating AudioSession for model: {}", model.ModelId()));
-  // Last so a throw above does not leak a refcount; nothing below can throw.
-  model_.AcquireSession();
+AudioRuntime::AudioRuntime(const fl::Model& catalog_model, ModelSessionLease lease, ILogger& logger,
+                           ITelemetry& telemetry)
+    : SessionRuntime(catalog_model, logger, telemetry, std::move(lease)), logger_(logger) {
+  logger_.Log(LogLevel::Debug, fmt::format("Creating AudioSession for model: {}", Model().ModelId()));
 }
 
-AudioSession::~AudioSession() {
-  if (owns_session_) {
-    model_.ReleaseSession();
-  }
+AudioRuntime::~AudioRuntime() noexcept {
+  // Nothing to wait for and no refcount to hand back: reaching this destructor already means no operation or
+  // callback references this runtime, and the base releases the model lease after every derived member dies.
 }
 
-AudioSession::AudioSession(AudioSession&& other) noexcept
-    : Session(std::move(other)),
-      logger_(other.logger_),
-      model_(other.model_),
-      owns_session_(other.owns_session_),
-      session_options_(std::move(other.session_options_)) {
-  other.owns_session_ = false;
-}
-
-SessionType AudioSession::Type() const {
+SessionType AudioRuntime::Type() const {
   return SessionType::kAudio;
 }
 
-void AudioSession::SetSessionOptionsImpl(const KeyValuePairs& options) {
+void AudioRuntime::SetSessionOptionsImpl(const KeyValuePairs& options) {
   session_options_ = SearchOptions::FromParameters(options);
 }
 
-void AudioSession::ProcessRequestImpl(const Request& request, Response& response) {
+void AudioRuntime::ProcessRequestImpl(const OperationContext& operation, const Request& request, Response& response) {
   // OpenAI audio transcription JSON pass-through: a TEXT item tagged OPENAI_JSON.
   for (const auto* item : request.items) {
     if (item->type == FOUNDRY_LOCAL_ITEM_TEXT) {
       const auto& text_item = static_cast<const TextItem&>(*item);
 
       if (text_item.text_type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON) {
-        ProcessAudioTranscriptionJson(text_item.text, request, response);
+        ProcessAudioTranscriptionJson(operation, text_item.text, response);
         return;
       }
     }
@@ -191,7 +188,7 @@ void AudioSession::ProcessRequestImpl(const Request& request, Response& response
     }
 
     auto& queue = static_cast<ItemQueue&>(*request.items[1]);
-    ProcessStreamingAudio(audio_item, queue, request, response);
+    ProcessStreamingAudio(operation, audio_item, queue, request, response);
     return;
   }
 
@@ -237,25 +234,34 @@ void AudioSession::ProcessRequestImpl(const Request& request, Response& response
   // `file:///C:/My%20Audio.wav` work the same as a plain path.
   std::string audio_path = PathFromFileUri(audio_item.uri);
 
+  if (operation.ShouldStop()) {
+    return;
+  }
+
   auto generator = OnnxAudioGenerator::Create(audio_path, temperature, Model(), language);
   int prompt_tokens = generator->PromptTokenCount();
 
   // Token-by-token generation with optional streaming.
-  // Check request.canceled each iteration — a streaming callback returning
-  // non-zero sets this flag asynchronously via CallbackHandler.
+  // Poll the operation each iteration — a streaming callback returning non-zero stops that exact operation
+  // asynchronously via CallbackHandler.
   std::vector<std::string> token_texts;
   token_texts.reserve(kInitialTokenCapacity);
-  auto streaming_callback = CreateCallbackHandler(request);
+  auto streaming_callback = CreateCallbackHandler(operation);
   std::vector<std::unique_ptr<SpeechSegmentItem>> segments;
   segments.reserve(kInitialTokenCapacity);
 
   // Publish the generator so Session::Cancel() and the deadline watchdog can interrupt
   // an in-flight compute, not just the loop between tokens.
   {
-    ActiveGenerator active(*this, *generator);
+    ActiveGenerator active(operation, *generator);
 
-    while (!generator->IsDone() && !request.ShouldStop()) {
+    while (!operation.ShouldStop() && !generator->IsDone()) {
       generator->GenerateNextToken();
+
+      if (operation.ShouldStop()) {
+        break;
+      }
+
       std::string token = generator->Decode();
 
       if (!token.empty()) {
@@ -267,43 +273,40 @@ void AudioSession::ProcessRequestImpl(const Request& request, Response& response
 
         token_texts.push_back(std::move(token));
       }
-
-      if (request.canceled) {
-        generator->Cancel();
-      }
     }
   }
 
-  int total_tokens = generator->TokenCount();
-  int completion_tokens = total_tokens - prompt_tokens;
-
+  // Final engine reads before the seal: they are part of what the commit records.
+  const int total_tokens = generator->TokenCount();
+  const int completion_tokens = total_tokens - prompt_tokens;
   std::string text = JoinTokens(token_texts);
 
-  response.items.push_back(BuildSpeechResult(std::move(text), std::move(segments)));
-
-  // Set finish reason
-  if (request.canceled) {
-    response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
-  } else {
-    response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
-  }
-
-  // Set token usage
-  response.usage.prompt_tokens = prompt_tokens;
-  response.usage.completion_tokens = completion_tokens;
-  response.usage.total_tokens = total_tokens;
+  Response pending_response;
+  pending_response.items.push_back(BuildSpeechResult(std::move(text), std::move(segments)));
+  pending_response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+  pending_response.usage.prompt_tokens = prompt_tokens;
+  pending_response.usage.completion_tokens = completion_tokens;
+  pending_response.usage.total_tokens = total_tokens;
 
   logger_.Log(LogLevel::Verbose,
               fmt::format("Completion stats: Total Tokens: {}, Prompt Tokens: {}, Completion Tokens: {}",
                           total_tokens, prompt_tokens, completion_tokens));
+
+  // The generator guard has ended and the accumulators are final; let every already-pushed callback item be
+  // delivered so a callback stop is visible to the seal rather than landing after the commit.
+  if (streaming_callback) {
+    streaming_callback->Quiesce();
+  }
+
+  SealAndPublishAudioResponse(operation, pending_response, response);
 }
 
 // ---------------------------------------------------------------------------
 // Streaming audio path
 // ---------------------------------------------------------------------------
 
-void AudioSession::ProcessStreamingAudio(const AudioItem& format_item, ItemQueue& queue,
-                                         const Request& request, Response& response) {
+void AudioRuntime::ProcessStreamingAudio(const OperationContext& operation, const AudioItem& format_item,
+                                         ItemQueue& queue, const Request& request, Response& response) {
   // 1. Validate format
   if (format_item.format != "pcm") {
     FL_LOG_AND_THROW(logger_, FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
@@ -324,6 +327,10 @@ void AudioSession::ProcessStreamingAudio(const AudioItem& format_item, ItemQueue
 
   logger_.Log(LogLevel::Debug, "Starting streaming audio transcription");
 
+  if (operation.ShouldStop()) {
+    return;
+  }
+
   // 2. Create ORT GenAI streaming pipeline
   auto& oga_model = Model().GetOgaModel();
   auto processor = OgaStreamingProcessor::Create(oga_model);
@@ -338,15 +345,20 @@ void AudioSession::ProcessStreamingAudio(const AudioItem& format_item, ItemQueue
     gen_params->SetSearchOption("temperature", *options.temperature);
   }
 
+  if (operation.ShouldStop()) {
+    return;
+  }
+
   auto generator = OgaGenerator::Create(oga_model, *gen_params);
   auto tokenizer_stream = OgaTokenizerStream::Create(Model().Tokenizer().Oga());
 
-  // Publish the raw generator so Session::Cancel() and the deadline watchdog can interrupt
-  // an in-flight encoder/decoder pass. Spans steps 3-5 below, which all drive this generator.
+  // Publish the raw generator so a session cancel and the deadline watchdog can interrupt an in-flight
+  // encoder/decoder pass. Spans steps 3-5 below, which all drive this generator, and is released explicitly
+  // before the commit so the seal cannot race a cancellation still being delivered to it.
   OgaGeneratorCancellable cancellable(*generator);
-  ActiveGenerator active(*this, cancellable);
+  auto generator_guard = std::make_unique<ActiveGenerator>(operation, cancellable);
 
-  auto streaming_callback = CreateCallbackHandler(request);
+  auto streaming_callback = CreateCallbackHandler(operation);
   std::vector<std::string> token_texts;
   token_texts.reserve(kInitialTokenCapacity);
   std::vector<std::unique_ptr<SpeechSegmentItem>> segments;
@@ -359,12 +371,12 @@ void AudioSession::ProcessStreamingAudio(const AudioItem& format_item, ItemQueue
   if (format_item.data && format_item.data_size > 0) {
     auto float_samples = ConvertS16LEToFloat(
         static_cast<const uint8_t*>(format_item.data), format_item.data_size);
-    ProcessChunk(*processor, *generator, *tokenizer_stream,
-                 float_samples, token_texts, segments, streaming_callback, request, completion_tokens);
+    ProcessChunk(operation, *processor, *generator, *tokenizer_stream,
+                 float_samples, token_texts, segments, streaming_callback, completion_tokens);
   }
 
   // 4. Read from queue until finished or cancelled
-  while (!request.ShouldStop()) {
+  while (!operation.ShouldStop()) {
     auto item = queue.WaitAndPop(std::chrono::milliseconds(100));
 
     if (!item) {
@@ -384,78 +396,102 @@ void AudioSession::ProcessStreamingAudio(const AudioItem& format_item, ItemQueue
     auto float_samples = ConvertS16LEToFloat(
         static_cast<const uint8_t*>(bytes.data), bytes.data_size);
 
-    ProcessChunk(*processor, *generator, *tokenizer_stream,
-                 float_samples, token_texts, segments, streaming_callback, request, completion_tokens);
+    ProcessChunk(operation, *processor, *generator, *tokenizer_stream,
+                 float_samples, token_texts, segments, streaming_callback, completion_tokens);
   }
 
   // 5. Flush remaining buffered audio
-  if (!request.canceled) {
+  if (!operation.ShouldStop()) {
     auto flush_tensors = processor->Flush();
 
-    if (flush_tensors) {
-      generator->SetInputs(*flush_tensors);
-      DecodeTokens(*generator, *tokenizer_stream, token_texts, segments, streaming_callback, request,
+    if (flush_tensors && TrySetGeneratorInputs(*generator, *flush_tensors, operation)) {
+      DecodeTokens(operation, *generator, *tokenizer_stream, token_texts, segments, streaming_callback,
                    completion_tokens);
     }
   }
 
-  // 6. Produce response — SpeechResultItem carrying all per-token segments.
+  // 6. Produce response — SpeechResultItem carrying all per-token segments. Built as a local first: the
+  //    response is only touched once the outcome has been sealed.
   std::string full_text = JoinTokens(token_texts);
   const size_t full_text_size = full_text.size();
-  response.items.push_back(BuildSpeechResult(std::move(full_text), std::move(segments)));
 
-  if (request.canceled) {
-    response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
-  } else {
-    response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+  // End the generator publication before committing, so no cancellation can still be in flight against it.
+  generator_guard.reset();
+
+  Response pending_response;
+  pending_response.items.push_back(BuildSpeechResult(std::move(full_text), std::move(segments)));
+  pending_response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+  pending_response.usage.prompt_tokens = 0;
+  pending_response.usage.completion_tokens = completion_tokens;
+  pending_response.usage.total_tokens = completion_tokens;
+
+  logger_.Log(LogLevel::Debug,
+              fmt::format("Streaming audio transcription complete, text length: {}", full_text_size));
+
+  if (streaming_callback) {
+    streaming_callback->Quiesce();
   }
 
-  response.usage.prompt_tokens = 0;
-  response.usage.completion_tokens = completion_tokens;
-  response.usage.total_tokens = completion_tokens;
-
-  logger_.Log(LogLevel::Debug, fmt::format("Streaming audio transcription complete, text length: {}",
-                                           response.items.empty() ? 0 : full_text_size));
+  SealAndPublishAudioResponse(operation, pending_response, response);
 }
 
-void AudioSession::ProcessChunk(OgaStreamingProcessor& processor, OgaGenerator& generator,
+void AudioRuntime::ProcessChunk(const OperationContext& operation, OgaStreamingProcessor& processor,
+                                OgaGenerator& generator,
                                 OgaTokenizerStream& tokenizer_stream,
                                 const std::vector<float>& samples,
                                 std::vector<std::string>& token_texts,
                                 std::vector<std::unique_ptr<SpeechSegmentItem>>& segments,
                                 const std::unique_ptr<CallbackHandler>& callback,
-                                const Request& request,
                                 int& completion_tokens) {
+  if (operation.ShouldStop()) {
+    return;
+  }
+
   auto tensors = processor.Process(samples.data(), samples.size());
 
   if (tensors) {
-    generator.SetInputs(*tensors);
-    DecodeTokens(generator, tokenizer_stream, token_texts, segments, callback, request, completion_tokens);
+    if (!TrySetGeneratorInputs(generator, *tensors, operation)) {
+      return;
+    }
+
+    DecodeTokens(operation, generator, tokenizer_stream, token_texts, segments, callback, completion_tokens);
   }
 }
 
-void AudioSession::DecodeTokens(OgaGenerator& generator, OgaTokenizerStream& tokenizer_stream,
+void AudioRuntime::DecodeTokens(const OperationContext& operation, OgaGenerator& generator,
+                                OgaTokenizerStream& tokenizer_stream,
                                 std::vector<std::string>& token_texts,
                                 std::vector<std::unique_ptr<SpeechSegmentItem>>& segments,
                                 const std::unique_ptr<CallbackHandler>& callback,
-                                const Request& request,
                                 int& completion_tokens) {
-  while (!generator.IsDone() && !generator.IsSessionTerminated() && !request.ShouldStop()) {
-    if (!TryGenerateNextToken(generator, request)) {
+  while (!operation.ShouldStop() && !IsGeneratorDoneCancellationSafe(generator, operation)) {
+    if (!TryGenerateNextToken(generator, operation)) {
       break;
     }
 
-    auto next_tokens = generator.GetNextTokens();
+    const auto next_tokens = TryGetNextTokens(generator, operation);
 
-    if (next_tokens.empty()) {
+    if (!next_tokens) {
+      break;
+    }
+
+    if (next_tokens->empty()) {
       continue;
     }
 
-    int32_t token_id = next_tokens[0];
-    const char* token_text = tokenizer_stream.Decode(token_id);
+    int32_t token_id = (*next_tokens)[0];
+    const auto decoded = TryDecodeToken(tokenizer_stream, token_id, operation);
+    if (!decoded) {
+      break;
+    }
+
+    const char* token_text = *decoded;
 
     if (token_text && token_text[0] != '\0') {
-      ++completion_tokens;
+      if (!TryIncrementTokenCount(completion_tokens, operation)) {
+        break;
+      }
+
       segments.push_back(MakeNoneSegment(token_text));
 
       if (callback) {
@@ -467,8 +503,8 @@ void AudioSession::DecodeTokens(OgaGenerator& generator, OgaTokenizerStream& tok
   }
 }
 
-void AudioSession::ProcessAudioTranscriptionJson(const std::string& request_json,
-                                                 const Request& original_request,
+void AudioRuntime::ProcessAudioTranscriptionJson(const OperationContext& operation,
+                                                 const std::string& request_json,
                                                  Response& response) {
   // Parse the OpenAI audio transcription request
   auto req_json = nlohmann::json::parse(request_json);
@@ -482,13 +518,14 @@ void AudioSession::ProcessAudioTranscriptionJson(const std::string& request_json
   // Validate file exists
   namespace fs = std::filesystem;
   if (!fs::exists(req.filename)) {
-    FL_LOG_AND_THROW(logger_, FOUNDRY_LOCAL_ERROR_INVALID_USAGE, fmt::format("Audio file not found: '{}'", req.filename));
+    FL_LOG_AND_THROW(logger_, FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
+                     fmt::format("Audio file not found: '{}'", req.filename));
   }
 
   // Nemotron speech models are RNNT-based and do not use the Whisper-oriented OnnxAudioGenerator path below.
   // Route file transcription through StreamingProcessor so nemotron_speech models can decode correctly.
   if (IsNemotronSpeechModel()) {
-    ProcessNemotronFileTranscription(req, original_request, response);
+    ProcessNemotronFileTranscription(operation, req, response);
     return;
   }
 
@@ -508,10 +545,14 @@ void AudioSession::ProcessAudioTranscriptionJson(const std::string& request_json
   }
 
   // Create the audio generator
+  if (operation.ShouldStop()) {
+    return;
+  }
+
   auto generator = OnnxAudioGenerator::Create(req.filename, temperature, Model(), language);
   int prompt_tokens = generator->PromptTokenCount();
 
-  auto streaming_callback = CreateCallbackHandler(original_request);
+  auto streaming_callback = CreateCallbackHandler(operation);
   bool is_streaming = (streaming_callback != nullptr);
   std::string response_id = ResponseConverter::GenerateId("audio");
 
@@ -520,10 +561,15 @@ void AudioSession::ProcessAudioTranscriptionJson(const std::string& request_json
   {
     // Publish the generator so Session::Cancel() and the deadline watchdog can interrupt
     // an in-flight compute, not just the loop between tokens.
-    ActiveGenerator active(*this, *generator);
+    ActiveGenerator active(operation, *generator);
 
-    while (!generator->IsDone() && !original_request.ShouldStop()) {
+    while (!operation.ShouldStop() && !generator->IsDone()) {
       generator->GenerateNextToken();
+
+      if (operation.ShouldStop()) {
+        break;
+      }
+
       std::string token = generator->Decode();
 
       if (!token.empty()) {
@@ -539,46 +585,44 @@ void AudioSession::ProcessAudioTranscriptionJson(const std::string& request_json
         }
       }
 
-      if (original_request.canceled) {
-        generator->Cancel();
-      }
     }
   }
 
-  int total_tokens = generator->TokenCount();
-  int completion_tokens = total_tokens - prompt_tokens;
+  // Final engine reads before the seal.
+  const int total_tokens = generator->TokenCount();
+  const int completion_tokens = total_tokens - prompt_tokens;
 
-  // Set finish reason
-  if (original_request.canceled) {
-    response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
-  } else {
-    response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
-  }
+  Response pending_response;
+  pending_response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+  pending_response.usage.prompt_tokens = prompt_tokens;
+  pending_response.usage.completion_tokens = completion_tokens;
+  pending_response.usage.total_tokens = total_tokens;
 
-  // Set token usage
-  response.usage.prompt_tokens = prompt_tokens;
-  response.usage.completion_tokens = completion_tokens;
-  response.usage.total_tokens = total_tokens;
-
-  // Build AudioTranscriptionResponse and wrap as an OPENAI_JSON-tagged TextItem.
+  // Build AudioTranscriptionResponse and serialize it before the completion outcome is sealed.
   AudioTranscriptionResponse output;
   output.id = response_id;
   output.text = std::move(text);
-  response.items.push_back(std::make_unique<TextItem>(nlohmann::json(output).dump(),
-                                                      FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+  pending_response.items.push_back(std::make_unique<TextItem>(nlohmann::json(output).dump(),
+                                                             FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
 
   logger_.Log(LogLevel::Verbose,
               fmt::format("Audio transcription stats: Total Tokens: {}, Prompt Tokens: {}, Completion Tokens: {}",
                           total_tokens, prompt_tokens, completion_tokens));
+
+  if (is_streaming) {
+    streaming_callback->Quiesce();
+  }
+
+  SealAndPublishAudioResponse(operation, pending_response, response);
 }
 
 
-bool AudioSession::IsNemotronSpeechModel() const {
+bool AudioRuntime::IsNemotronSpeechModel() const {
   const auto& cfg = Model().GetGenAIConfig();
   return cfg.model.has_value() && cfg.model->type == "nemotron_speech";
 }
 
-void AudioSession::TryNemotronLanguageId(OgaGenerator& generator, const std::string& language) const {
+void AudioRuntime::TryNemotronLanguageId(OgaGenerator& generator, const std::string& language) const {
   if (language.empty()) {
     return;
   }
@@ -598,29 +642,41 @@ void AudioSession::TryNemotronLanguageId(OgaGenerator& generator, const std::str
   }
 }
 
-void AudioSession::DecodeNemotronTokens(OgaGenerator& generator, OgaTokenizerStream& tokenizer_stream, std::string& text,
+void AudioRuntime::DecodeNemotronTokens(const OperationContext& operation, OgaGenerator& generator,
+                                        OgaTokenizerStream& tokenizer_stream, std::string& text,
                                         const std::unique_ptr<CallbackHandler>& streaming_callback,
-                                        const std::string& response_id, const Request& original_request,
-                                        int& completion_tokens) const {
+                                        const std::string& response_id, int& completion_tokens) const {
   const bool is_streaming = (streaming_callback != nullptr);
 
-  while (!generator.IsDone() && !generator.IsSessionTerminated() && !original_request.ShouldStop()) {
-    if (!TryGenerateNextToken(generator, original_request)) {
+  while (!operation.ShouldStop() && !IsGeneratorDoneCancellationSafe(generator, operation)) {
+    if (!TryGenerateNextToken(generator, operation)) {
       break;
     }
 
-    auto next_tokens = generator.GetNextTokens();
-    if (next_tokens.empty()) {
+    const auto next_tokens = TryGetNextTokens(generator, operation);
+    if (!next_tokens) {
+      break;
+    }
+
+    if (next_tokens->empty()) {
       continue;
     }
 
-    ++completion_tokens;
-    const char* decoded = tokenizer_stream.Decode(next_tokens[0]);
-    if (!decoded || decoded[0] == '\0') {
+    if (!TryIncrementTokenCount(completion_tokens, operation)) {
+      break;
+    }
+
+    const auto decoded = TryDecodeToken(tokenizer_stream, (*next_tokens)[0], operation);
+    if (!decoded) {
+      break;
+    }
+
+    const char* token_text = *decoded;
+    if (!token_text || token_text[0] == '\0') {
       continue;
     }
 
-    std::string token(decoded);
+    std::string token(token_text);
     if (IsLanguageToken(token)) {
       continue;
     }
@@ -637,25 +693,29 @@ void AudioSession::DecodeNemotronTokens(OgaGenerator& generator, OgaTokenizerStr
   }
 }
 
-void AudioSession::RunNemotronDecodePass(std::unique_ptr<OgaNamedTensors> tensors, OgaGenerator& generator,
+void AudioRuntime::RunNemotronDecodePass(const OperationContext& operation,
+                                         std::unique_ptr<OgaNamedTensors> tensors, OgaGenerator& generator,
                                          OgaTokenizerStream& tokenizer_stream, std::string& text,
                                          const std::unique_ptr<CallbackHandler>& streaming_callback,
-                                         const std::string& response_id, const Request& original_request,
-                                         int& completion_tokens) const {
-  if (!tensors || original_request.ShouldStop()) {
+                                         const std::string& response_id, int& completion_tokens) const {
+  if (!tensors || operation.ShouldStop()) {
     return;
   }
 
-  generator.SetInputs(*tensors);
-  DecodeNemotronTokens(generator, tokenizer_stream, text, streaming_callback, response_id, original_request,
+  if (!TrySetGeneratorInputs(generator, *tensors, operation)) {
+    return;
+  }
+
+  DecodeNemotronTokens(operation, generator, tokenizer_stream, text, streaming_callback, response_id,
                        completion_tokens);
 }
 
-void AudioSession::ProcessNemotronFileTranscription(const AudioTranscriptionRequest& req,
-                                                    const Request& original_request,
+void AudioRuntime::ProcessNemotronFileTranscription(const OperationContext& operation,
+                                                    const AudioTranscriptionRequest& req,
                                                     Response& response) {
-  if (original_request.canceled) {
-    response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
+  if (operation.ShouldStop()) {
+    Response stopped_response;
+    response.Swap(stopped_response);
     return;
   }
 
@@ -680,47 +740,69 @@ void AudioSession::ProcessNemotronFileTranscription(const AudioTranscriptionRequ
   if (temperature.has_value()) {
     generator_params->SetSearchOption("temperature", *temperature);
   }
+
+  if (operation.ShouldStop()) {
+    return;
+  }
+
   auto generator = OgaGenerator::Create(oga_model, *generator_params);
-  TryNemotronLanguageId(*generator, language);
+  if (!operation.ShouldStop()) {
+    TryNemotronLanguageId(*generator, language);
+  }
 
-  // Publish the raw generator so cancellation/deadline can interrupt an in-flight
-  // encoder or decode pass rather than only stopping between chunks.
-  OgaGeneratorCancellable cancellable(*generator);
-  ActiveGenerator active(*this, cancellable);
-
-  auto streaming_callback = CreateCallbackHandler(original_request);
-  std::string response_id = ResponseConverter::GenerateId("audio");
+  auto streaming_callback = CreateCallbackHandler(operation);
+  const std::string response_id = ResponseConverter::GenerateId("audio");
 
   std::string text;
   text.reserve(512);
   int completion_tokens = 0;
 
-  constexpr size_t kNemotronSamplesPerChunk = 1600;  // 100ms at 16kHz
-  for (size_t offset = 0; offset < samples.size() && !original_request.ShouldStop();
-       offset += kNemotronSamplesPerChunk) {
-    size_t count = std::min(kNemotronSamplesPerChunk, samples.size() - offset);
-    RunNemotronDecodePass(processor->Process(samples.data() + offset, count), *generator, *tokenizer_stream, text,
-                          streaming_callback, response_id, original_request, completion_tokens);
-  }
-  if (!original_request.canceled) {
-    RunNemotronDecodePass(processor->Flush(), *generator, *tokenizer_stream, text, streaming_callback, response_id,
-                          original_request, completion_tokens);
+  {
+    // Publish the raw generator so cancellation/deadline can interrupt an in-flight encoder or decode pass
+    // rather than only stopping between chunks. Scoped so the publication has ended before the seal below.
+    OgaGeneratorCancellable cancellable(*generator);
+    ActiveGenerator active(operation, cancellable);
+
+    constexpr size_t kNemotronSamplesPerChunk = 1600;  // 100ms at 16kHz
+    for (size_t offset = 0; offset < samples.size() && !operation.ShouldStop();
+         offset += kNemotronSamplesPerChunk) {
+      const size_t count = std::min(kNemotronSamplesPerChunk, samples.size() - offset);
+      if (operation.ShouldStop()) {
+        break;
+      }
+
+      auto tensors = processor->Process(samples.data() + offset, count);
+      RunNemotronDecodePass(operation, std::move(tensors), *generator, *tokenizer_stream, text,
+                            streaming_callback, response_id, completion_tokens);
+    }
+
+    if (!operation.ShouldStop()) {
+      RunNemotronDecodePass(operation, processor->Flush(), *generator, *tokenizer_stream, text, streaming_callback,
+                            response_id, completion_tokens);
+    }
   }
 
-  response.finish_reason = original_request.canceled ? FOUNDRY_LOCAL_FINISH_NONE : FOUNDRY_LOCAL_FINISH_STOP;
-  // Nemotron file-transcription path feeds audio tensors directly and does not expose prompt token accounting.
-  response.usage.prompt_tokens = 0;
-  response.usage.completion_tokens = completion_tokens;
-  response.usage.total_tokens = completion_tokens;
+  Response pending_response;
+  pending_response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+  // Nemotron file transcription feeds audio tensors directly and exposes no prompt-token accounting.
+  pending_response.usage.prompt_tokens = 0;
+  pending_response.usage.completion_tokens = completion_tokens;
+  pending_response.usage.total_tokens = completion_tokens;
 
   AudioTranscriptionResponse output;
   output.id = response_id;
   output.text = std::move(text);
-  response.items.push_back(std::make_unique<TextItem>(nlohmann::json(output).dump(),
-                                                      FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+  pending_response.items.push_back(std::make_unique<TextItem>(nlohmann::json(output).dump(),
+                                                             FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+
+  if (streaming_callback) {
+    streaming_callback->Quiesce();
+  }
+
+  SealAndPublishAudioResponse(operation, pending_response, response);
 }
 
-std::vector<float> AudioSession::LoadPcmWavAsFloatSamples(const std::string& audio_file_path) {
+std::vector<float> AudioRuntime::LoadPcmWavAsFloatSamples(const std::string& audio_file_path) {
   std::ifstream in(audio_file_path, std::ios::binary);
   if (!in) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE,

--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.h
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.h
@@ -3,11 +3,14 @@
 #pragma once
 
 #include "inferencing/generative/chat/search_options.h"
+#include "inferencing/model_session_lease.h"
 #include "inferencing/session/session.h"
+#include "inferencing/session/session_runtime.h"
 #include "logger.h"
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 // Forward declarations — avoid pulling ort_genai.h into the header
@@ -25,7 +28,7 @@ struct AudioItem;
 struct ItemQueue;
 struct SpeechSegmentItem;
 
-/// Audio transcription session.
+/// Executable body of an audio transcription session.
 /// Stateless — each request processes one audio file independently (no history).
 /// Input: a Request with an AUDIO item (file path in uri) and optional parameters
 ///        (language, temperature) in request.options.
@@ -35,51 +38,50 @@ struct SpeechSegmentItem;
 /// Output: a SpeechResultItem with the full transcribed text and per-segment detail, plus token usage stats.
 ///         When OPENAI_JSON input is used, output is an OPENAI_JSON-tagged TextItem with the
 ///         AudioTranscriptionResponse payload.
-class AudioSession : public Session {
+///
+/// Every path builds a complete pending response before OperationContext::TrySeal(). A successful seal
+/// publishes it by noexcept swap; a failed seal publishes the same generated-so-far response with FINISH_NONE
+/// for legacy callers, while explicit operations erase it centrally.
+class AudioRuntime : public SessionRuntime {
  public:
-  AudioSession(const fl::Model& catalog_model, GenAIModelInstance& model, ILogger& logger, ITelemetry& telemetry);
-  ~AudioSession();
-
-  // Movable: transfers session refcount ownership to the moved-to instance.
-  AudioSession(AudioSession&& other) noexcept;
-  AudioSession& operator=(AudioSession&&) = delete;
+  AudioRuntime(const fl::Model& catalog_model, ModelSessionLease lease, ILogger& logger, ITelemetry& telemetry);
+  ~AudioRuntime() noexcept override;
 
   SessionType Type() const override;
 
  private:
-   friend class AudioSessionTestAccessor;
+  friend class AudioSession;
+  friend class AudioSessionTestAccessor;
 
-   void SetSessionOptionsImpl(const KeyValuePairs& options) override;
-  void ProcessRequestImpl(const Request& request, Response& response) override;
+  void SetSessionOptionsImpl(const KeyValuePairs& options) override;
+  void ProcessRequestImpl(const OperationContext& operation, const Request& request, Response& response) override;
 
   /// Process a request whose first item is a TEXT item tagged OPENAI_JSON containing an
   /// OpenAI AudioTranscriptionRequest payload.
-  void ProcessAudioTranscriptionJson(const std::string& request_json, const Request& original_request,
+  void ProcessAudioTranscriptionJson(const OperationContext& operation, const std::string& request_json,
                                      Response& response);
 
   bool IsNemotronSpeechModel() const;
 
-  void ProcessNemotronFileTranscription(const AudioTranscriptionRequest& req, 
-                                        const Request& original_request,
+  void ProcessNemotronFileTranscription(const OperationContext& operation, const AudioTranscriptionRequest& req,
                                         Response& response);
 
-  void RunNemotronDecodePass(std::unique_ptr<OgaNamedTensors> tensors, OgaGenerator& generator,
-                             OgaTokenizerStream& tokenizer_stream, std::string& text,
+  void RunNemotronDecodePass(const OperationContext& operation, std::unique_ptr<OgaNamedTensors> tensors,
+                             OgaGenerator& generator, OgaTokenizerStream& tokenizer_stream, std::string& text,
                              const std::unique_ptr<CallbackHandler>& streaming_callback,
-                             const std::string& response_id, const Request& original_request,
-                             int& completion_tokens) const;
+                             const std::string& response_id, int& completion_tokens) const;
 
-  void DecodeNemotronTokens(OgaGenerator& generator, OgaTokenizerStream& tokenizer_stream, std::string& text,
+  void DecodeNemotronTokens(const OperationContext& operation, OgaGenerator& generator,
+                            OgaTokenizerStream& tokenizer_stream, std::string& text,
                             const std::unique_ptr<CallbackHandler>& streaming_callback,
-                            const std::string& response_id, const Request& original_request,
-                            int& completion_tokens) const;
+                            const std::string& response_id, int& completion_tokens) const;
 
   void TryNemotronLanguageId(OgaGenerator& generator, const std::string& language) const;
 
   static std::vector<float> LoadPcmWavAsFloatSamples(const std::string& audio_file_path);
 
   /// Process a streaming audio request: an AudioItem (format descriptor) + an ItemQueue (PCM chunks).
-  void ProcessStreamingAudio(const AudioItem& format_item, ItemQueue& queue,
+  void ProcessStreamingAudio(const OperationContext& operation, const AudioItem& format_item, ItemQueue& queue,
                              const Request& request, Response& response);
 
   /// Feed float32 PCM samples to the StreamingProcessor. If a full encoder chunk is ready,
@@ -87,32 +89,51 @@ class AudioSession : public Session {
   /// IMPORTANT: DecodeTokens must drain to IsDone() before the next SetInputs() call.
   /// `segments` accumulates a SpeechSegmentItem per decoded token; the same per-token
   /// segments are also what gets pushed to the streaming callback.
-  void ProcessChunk(OgaStreamingProcessor& processor, OgaGenerator& generator,
+  void ProcessChunk(const OperationContext& operation, OgaStreamingProcessor& processor, OgaGenerator& generator,
                     OgaTokenizerStream& tokenizer_stream, const std::vector<float>& samples,
                     std::vector<std::string>& token_texts,
                     std::vector<std::unique_ptr<SpeechSegmentItem>>& segments,
                     const std::unique_ptr<CallbackHandler>& callback,
-                    const Request& request,
                     int& completion_tokens);
 
   /// Decode all available tokens from the generator. This MUST run to completion
   /// (IsDone() == true) before the next SetInputs() call.
-  void DecodeTokens(OgaGenerator& generator, OgaTokenizerStream& tokenizer_stream,
+  void DecodeTokens(const OperationContext& operation, OgaGenerator& generator,
+                    OgaTokenizerStream& tokenizer_stream,
                     std::vector<std::string>& token_texts,
                     std::vector<std::unique_ptr<SpeechSegmentItem>>& segments,
                     const std::unique_ptr<CallbackHandler>& callback,
-                    const Request& request,
                     int& completion_tokens);
 
-  GenAIModelInstance& Model() { return model_; }
-  const GenAIModelInstance& Model() const { return model_; }
-
   ILogger& logger_;
-  GenAIModelInstance& model_;
-  // Tracks who is responsible for calling model_.ReleaseSession(). Set to false on the
-  // moved-from instance so the refcount transfers cleanly across moves.
-  bool owns_session_ = true;
   SearchOptions session_options_;
+};
+
+/// Audio transcription session.
+///
+/// Stateless facade over a shared AudioRuntime — see Session. Movable (it moves a shared_ptr) and destroyed
+/// without waiting; the runtime holds the ModelSessionLease that keeps the model loaded.
+class AudioSession : public Session {
+ public:
+  /// Compatibility construction against an already-pinned model. The caller must exclude a concurrent
+  /// unload until construction returns; production paths should pass a manager-acquired ModelSessionLease.
+  AudioSession(const fl::Model& catalog_model, GenAIModelInstance& model, ILogger& logger, ITelemetry& telemetry)
+      : AudioSession(catalog_model, ModelSessionLease::Adopt(model), logger, telemetry) {}
+
+  /// Construction from a lease acquired atomically against unload (Session::Create).
+  AudioSession(const fl::Model& catalog_model, ModelSessionLease lease, ILogger& logger, ITelemetry& telemetry)
+      : Session(MakeSessionRuntime<AudioRuntime>(catalog_model, std::move(lease), logger, telemetry)) {}
+
+  AudioSession(AudioSession&&) noexcept = default;
+  AudioSession& operator=(AudioSession&&) = delete;
+
+ private:
+  friend class AudioSessionTestAccessor;
+
+  /// Test seam: the WAV decoder is a pure function of its input and is covered directly.
+  static std::vector<float> LoadPcmWavAsFloatSamples(const std::string& audio_file_path) {
+    return AudioRuntime::LoadPcmWavAsFloatSamples(audio_file_path);
+  }
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/audio/onnx_audio_generator.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/onnx_audio_generator.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #include "inferencing/generative/audio/onnx_audio_generator.h"
 #include "exception.h"
+#include "inferencing/session/oga_generator_cancellable.h"
 
 #include <ort_genai.h>
 #include <unordered_set>
@@ -51,75 +52,79 @@ OnnxAudioGenerator::OnnxAudioGenerator(std::unique_ptr<OgaAudios> audios,
       gen_params_(std::move(gen_params)),
       generator_(std::move(generator)),
       stream_(std::move(stream)),
-      prompt_token_count_(prompt_token_count) {}
+      prompt_token_count_(prompt_token_count),
+      token_count_(prompt_token_count) {}
 
 // ---------------------------------------------------------------------------
 // AudioGenerator interface
 // ---------------------------------------------------------------------------
 
 bool OnnxAudioGenerator::IsDone() const {
-  if (cancelled_) {
+  if (cancelled_.load(std::memory_order_acquire)) {
     return true;
   }
 
   // OgaGenerator::IsDone() is non-const in the ORT GenAI API, so we need const_cast.
   // This is safe because IsDone only reads state.
   auto* gen = const_cast<OgaGenerator*>(generator_.get());
-  return gen->IsDone() || gen->IsSessionTerminated();
+  return IsGeneratorDoneCancellationSafe(*gen, engine_termination_delivered_);
 }
 
 void OnnxAudioGenerator::GenerateNextToken() {
-  if (cancelled_) {
+  if (cancelled_.load(std::memory_order_acquire)) {
     return;
   }
 
   try {
-    generator_->GenerateNextToken();
-  } catch (const std::runtime_error& e) {
-    // If cancelled while generating, the OGA engine throws when the session is terminated.
-    // This is expected — not an error.
-    if (cancelled_) {
+    if (!TryGenerateNextToken(*generator_, engine_termination_delivered_)) {
       return;
     }
-
+  } catch (const std::runtime_error& e) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, std::string("audio token generation failed: ") + e.what());
   }
+
+  token_count_.fetch_add(1, std::memory_order_relaxed);
 }
 
 std::string OnnxAudioGenerator::Decode() {
-  if (cancelled_) {
+  if (cancelled_.load(std::memory_order_acquire)) {
     return "";
   }
 
-  auto next_tokens = generator_->GetNextTokens();
+  const auto next_tokens = TryGetNextTokens(*generator_, engine_termination_delivered_);
 
-  if (next_tokens.empty()) {
+  if (!next_tokens || next_tokens->empty()) {
     return "";
   }
 
-  int32_t token_id = next_tokens[0];
+  int32_t token_id = (*next_tokens)[0];
   const char* token_text = stream_->Decode(token_id);
 
   return token_text ? std::string(token_text) : "";
 }
 
 int OnnxAudioGenerator::TokenCount() const {
-  return static_cast<int>(generator_->GetSequenceCount(0));
+  return token_count_.load(std::memory_order_relaxed);
 }
 
 int OnnxAudioGenerator::PromptTokenCount() const {
   return prompt_token_count_;
 }
 
-void OnnxAudioGenerator::Cancel() {
-  cancelled_ = true;
+bool OnnxAudioGenerator::Cancel() noexcept {
+  cancelled_.store(true, std::memory_order_release);
 
   // Use the ORT GenAI engine-level termination to interrupt mid-compute
-  // (e.g. during a long prefill), not just between token boundaries.
+  // (e.g. during a long prefill), not just between token boundaries. Record successful delivery only once the
+  // call returns. A throwing call can still leave the pinned OGA session terminated; IsSessionTerminated is
+  // kept as a separate source of exact evidence.
   try {
     generator_->SetRuntimeOption("terminate_session", "1");
-  } catch (const std::exception&) {
+    engine_termination_delivered_.store(true, std::memory_order_release);
+    return true;
+  } catch (...) {
     // SetRuntimeOption may not be supported by all ORT GenAI builds.
+    return false;
   }
 }
 

--- a/sdk_v2/cpp/src/inferencing/generative/audio/onnx_audio_generator.h
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/onnx_audio_generator.h
@@ -36,7 +36,7 @@ class OnnxAudioGenerator : public AudioGenerator {
   std::string Decode() override;
   int TokenCount() const override;
   int PromptTokenCount() const override;
-  void Cancel() override;
+  bool Cancel() noexcept override;
 
   /// Factory: create a fully configured generator for audio transcription from a file.
   ///
@@ -66,7 +66,15 @@ class OnnxAudioGenerator : public AudioGenerator {
   std::unique_ptr<OgaGenerator> generator_;
   std::unique_ptr<OgaTokenizerStream> stream_;
   int prompt_token_count_ = 0;
+  /// Numeric accounting only; generator publication and operation sealing provide lifecycle synchronization.
+  std::atomic<int> token_count_{0};
+  /// Local cancellation intent; not by itself evidence that the OGA session terminated.
   std::atomic<bool> cancelled_{false};
+
+  /// Set only after SetRuntimeOption("terminate_session", ...) actually *succeeds* in Cancel(). Distinct from
+  /// cancelled_: a throwing call may still have terminated the pinned OGA session, while a later unrelated
+  /// runtime_error must not be suppressed without either this bit or IsSessionTerminated().
+  std::atomic<bool> engine_termination_delivered_{false};
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/chat/chat_generator.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/chat_generator.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #pragma once
 
@@ -38,9 +38,10 @@ class ChatGenerator : public ICancellable {
   /// Default implementation loops GenerateNextToken/Decode.
   virtual std::string GenerateAll();
 
-  /// Request cancellation of generation. Thread-safe — can be called from another thread.
+  /// Request cancellation of generation. Thread-safe — can be called from another thread, and noexcept:
+  /// it is invoked from teardown and watchdog paths that cannot handle a failure.
   /// After cancellation, IsDone() should return true on the next check.
-  void Cancel() override = 0;
+  bool Cancel() noexcept override = 0;
 
  protected:
   ChatGenerator() = default;

--- a/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.cc
@@ -49,52 +49,49 @@ void ApplyToolChoiceToContext(std::optional<flToolChoice> tool_choice, ToolCallC
 
 }  // namespace
 
-ChatSession::ChatSession(const fl::Model& catalog_model, GenAIModelInstance& model, ILogger& logger, ITelemetry& telemetry)
-    : Session(catalog_model, logger, telemetry), logger_(logger), model_(model) {
-  logger_.Log(LogLevel::Debug, fmt::format("Creating ChatSession for model: {}", model.ModelId()));
-  // Last so a throw above does not leak a refcount; nothing below can throw.
-  model_.AcquireSession();
+ChatRuntime::ChatRuntime(const fl::Model& catalog_model, ModelSessionLease lease, ILogger& logger,
+                         ITelemetry& telemetry)
+    : SessionRuntime(catalog_model, logger, telemetry, std::move(lease)), logger_(logger) {
+  logger_.Log(LogLevel::Debug, fmt::format("Creating ChatSession for model: {}", Model().ModelId()));
 }
 
-ChatSession::~ChatSession() {
-  if (owns_session_) {
-    model_.ReleaseSession();
-  }
+ChatRuntime::~ChatRuntime() noexcept {
+  // Nothing to wait for and nothing to release by hand. Reaching this destructor already means no operation
+  // or callback holds a reference to this runtime, and the model lease on the base is released only after
+  // cached_generator_ and the rest of the derived state below have been destroyed.
 }
 
-ChatSession::ChatSession(ChatSession&& other) noexcept
-    : Session(std::move(other)),
-      logger_(other.logger_),
-      model_(other.model_),
-      owns_session_(other.owns_session_),
-      history_(std::move(other.history_)),
-      turns_(std::move(other.turns_)),
-      session_options_(std::move(other.session_options_)),
-      cached_generator_(std::move(other.cached_generator_)) {
-  other.owns_session_ = false;
-}
-
-SessionType ChatSession::Type() const {
+SessionType ChatRuntime::Type() const {
   return SessionType::kChat;
 }
 
-void ChatSession::SetSessionOptionsImpl(const KeyValuePairs& options) {
+void ChatRuntime::SetSessionOptionsImpl(const KeyValuePairs& options) {
   session_options_ = SearchOptions::FromParameters(options);
 }
 
-void ChatSession::OnRequestFinished(const Request& request) noexcept {
-  if (!request.timed_out.load(std::memory_order_relaxed)) {
+void ChatRuntime::OnRequestFinished(const OperationContext& operation, const Request& /*request*/) noexcept {
+  // Discard the cached generator (and its tool context) whenever this run left it in a state that cannot be
+  // safely continued:
+  //   - a delivered engine cancel (session cancel, operation cancel, timeout, or a streaming callback asking
+  //     to stop) permanently terminates the OGA session, and
+  //   - a fault means ProcessRequestImpl threw *after* mutating the generator (e.g. AppendMessages ran but the
+  //     turn never committed), so its KV cache no longer matches committed history.
+  // Safe here because the watchdog is already joined, so no deadline callback can still hold the generator. A
+  // stop latched after the generator guard ended delivers no engine cancel and does not fault; that generator
+  // stays usable and the seal-failure path rewinds it instead.
+  if (!operation.EngineCancelDelivered() && !operation.IsFaulted()) {
     return;
   }
 
-  // The watchdog cancelled the OGA session to enforce the deadline, which permanently terminates the generator: it can
-  // never be rewound or reused. Dropping it here is safe because Session::ProcessRequest has joined the watchdog, so
-  // its deadline cancellation callback can no longer be holding the generator.
+  ResetGeneratorCache();
+}
+
+void ChatRuntime::ResetGeneratorCache() noexcept {
   cached_generator_.reset();
   cached_tool_ctx_ = {};
 }
 
-void ChatSession::UpdateToolContextForTurn(const Request& request, ToolCallContext& tool_ctx) const {
+void ChatRuntime::UpdateToolContextForTurn(const Request& request, ToolCallContext& tool_ctx) const {
   auto get_param = [&](const char* key) -> std::string {
     auto it = request.options.find(key);
     if (it != request.options.end()) {
@@ -116,7 +113,7 @@ void ChatSession::UpdateToolContextForTurn(const Request& request, ToolCallConte
   tool_ctx.guidance_data = get_param("guidance_data");
 }
 
-ToolCallContext ChatSession::BuildToolCallContext(const Request& request) const {
+ToolCallContext ChatRuntime::BuildToolCallContext(const Request& request) const {
   ToolCallContext tool_ctx;
 
   auto get_param = [&](const char* key) -> std::string {
@@ -131,7 +128,7 @@ ToolCallContext ChatSession::BuildToolCallContext(const Request& request) const 
   tool_ctx.tool_call_end = get_param(FOUNDRY_LOCAL_MODEL_PROP_TOOL_CALL_END_STR);
 
   // Fall back to model info properties if not specified in the request
-  const auto& info = CatalogModel().Info();
+  const auto& info = CatalogModelInfo();
 
   // Check if the model supports tool calling
   const auto* tool_calling_val = info.GetPropertyInt(FOUNDRY_LOCAL_MODEL_PROP_SUPPORTS_TOOL_CALLING_INT);
@@ -305,7 +302,7 @@ static std::vector<TextSegment> SplitReasoningContent(const std::string& text,
   return segments;
 }
 
-void ChatSession::ProcessGeneratedOutput(std::string text, const ToolCallContext& tool_ctx,
+void ChatRuntime::ProcessGeneratedOutput(std::string text, const ToolCallContext& tool_ctx,
                                          const SearchOptions& effective_options, bool canceled,
                                          Response& response, int prompt_tokens, int total_tokens,
                                          std::vector<ParsedToolCall> pre_parsed_calls) {
@@ -389,7 +386,7 @@ void ChatSession::ProcessGeneratedOutput(std::string text, const ToolCallContext
                           total_tokens, prompt_tokens, completion_tokens));
 }
 
-void ChatSession::ProcessRequestImpl(const Request& request, Response& response) {
+void ChatRuntime::ProcessRequestImpl(const OperationContext& operation, const Request& request, Response& response) {
   // OpenAI chat completions JSON pass-through: a TEXT item tagged OPENAI_JSON. Routes to a separate handler that
   // never uses the cached generator or history (the JSON payload is self-contained).
   for (const auto* item : request.items) {
@@ -397,7 +394,7 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
       const auto& text_item = static_cast<const fl::TextItem&>(*item);
 
       if (text_item.text_type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON) {
-        ProcessChatCompletionsJson(text_item.text, request, response);
+        ProcessChatCompletionsJson(operation, text_item.text, request, response);
         return;
       }
     }
@@ -424,6 +421,10 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
   if (new_messages.empty()) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
              "At least one MESSAGE item with non-empty content is required in the request");
+  }
+
+  if (operation.ShouldStop()) {
+    return;
   }
 
   // Vision input detection.
@@ -458,7 +459,7 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
   SearchOptions effective_options = SearchOptions::FromParameters(effective_kvp);
 
   int prompt_tokens = 0;
-  int pre_turn_token_count = 0;
+  std::optional<RewindBoundary> rewind_boundary;
 
   if (cached_generator_) {
     // Check if guidance requirements changed since the generator was created. Guidance (LARK grammar) is baked into
@@ -472,12 +473,29 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
 
     if (prev_needs_guidance != curr_needs_guidance) {
       // Guidance requirements changed — invalidate. The branch below will rebuild from full history.
-      cached_generator_.reset();
-      cached_tool_ctx_ = {};
+      ResetGeneratorCache();
     } else {
       // Continuous decoding: append only the new messages to the existing generator.
-      pre_turn_token_count = cached_generator_->TokenCount();
-      prompt_tokens = cached_generator_->AppendMessages(new_messages, Model(), cached_tool_ctx_.tools_json);
+      {
+        ActiveGenerator active(operation, *cached_generator_);
+        if (operation.ShouldStop()) {
+          return;
+        }
+
+        const RewindBoundary candidate_boundary{
+            .generator_generation = generator_generation_,
+            .token_count = cached_generator_->TokenCount(),
+        };
+        prompt_tokens = cached_generator_->AppendMessages(new_messages, Model(), cached_tool_ctx_.tools_json);
+        rewind_boundary = candidate_boundary;
+      }
+
+      if (operation.ShouldStop()) {
+        // The append registration already delivered (or attempted) cancellation. Do not publish the same
+        // generator a second time for this stopped operation, and never retain an append the turn did not commit.
+        ResetGeneratorCache();
+        return;
+      }
 
       // Refresh per-turn fields (tool_choice, guidance) while keeping session-level definitions stable.
       UpdateToolContextForTurn(request, cached_tool_ctx_);
@@ -494,10 +512,14 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
     all_messages.insert(all_messages.end(), history_.begin(), history_.end());
     all_messages.insert(all_messages.end(), new_messages.begin(), new_messages.end());
 
+    if (operation.ShouldStop()) {
+      return;
+    }
+
     std::unique_ptr<OnnxChatGenerator> generator;
     if (vision_turn) {
       // Vision is single-shot: the generator is dropped after the turn (see
-      // CommitTurn cleanup below) because AppendMessages can't extend a
+      // the post-seal cleanup below) because AppendMessages can't extend a
       // sequence whose state includes image-derived tokens. Sizing the KV
       // cache to the model's full context window would needlessly allocate
       // gigabytes (262k tokens × 28 layers × 8 heads × 128 dims for
@@ -508,30 +530,41 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
       generator = OnnxChatGenerator::Create(all_messages, effective_options, Model(), tool_ctx,
                                             /*use_full_context*/ true);
     }
+
+    if (operation.ShouldStop()) {
+      return;
+    }
+
     prompt_tokens = generator->PromptTokenCount();
 
     cached_generator_ = std::move(generator);
     cached_tool_ctx_ = std::move(tool_ctx);
+
+    // A brand-new generator is a new generation. Turns produced by it record this value so a later rewind or
+    // undo can tell it apart from any generator built afterwards.
+    ++generator_generation_;
   }
 
   int max_output = effective_options.max_output_tokens.value_or(0);
 
   // Generate token-by-token with optional streaming.
-  // Check request.canceled each iteration — a streaming callback returning
-  // non-zero sets this flag asynchronously via CallbackHandler.
+  // Poll the operation each iteration — a streaming callback returning non-zero stops that exact operation
+  // asynchronously via CallbackHandler.
   std::string text;
-  auto streaming_callback = CreateCallbackHandler(request);
+  auto streaming_callback = CreateCallbackHandler(operation);
   int output_tokens = 0;
 
   // Splitter: only active for reasoning models. For non-reasoning models start_marker is empty and the splitter
   // degrades to a passthrough (every token becomes one DEFAULT segment), so the streaming path stays uniform.
-  ReasoningStreamSplitter splitter(
-      cached_tool_ctx_.supports_reasoning ? (cached_tool_ctx_.reasoning_start.empty() ? std::string("<think>")
-                                                                                      : cached_tool_ctx_.reasoning_start)
-                                          : std::string(),
-      cached_tool_ctx_.supports_reasoning ? (cached_tool_ctx_.reasoning_end.empty() ? std::string("</think>")
-                                                                                    : cached_tool_ctx_.reasoning_end)
-                                          : std::string());
+  const auto reasoning_start =
+      cached_tool_ctx_.supports_reasoning
+          ? (cached_tool_ctx_.reasoning_start.empty() ? std::string("<think>") : cached_tool_ctx_.reasoning_start)
+          : std::string();
+  const auto reasoning_end =
+      cached_tool_ctx_.supports_reasoning
+          ? (cached_tool_ctx_.reasoning_end.empty() ? std::string("</think>") : cached_tool_ctx_.reasoning_end)
+          : std::string();
+  ReasoningStreamSplitter splitter(reasoning_start, reasoning_end);
 
   // Accumulator: separates visible text from tool-call blocks in the DEFAULT-segment stream. For models without
   // tool-call markers configured, both marker strings are empty and the accumulator degrades to passthrough.
@@ -591,10 +624,15 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
   // it mid-compute, not just between tokens. Scoped to the generation loop: the cached
   // generator may be reset below, and it must not stay published past this point.
   {
-    ActiveGenerator active(*this, *cached_generator_);
+    ActiveGenerator active(operation, *cached_generator_);
 
-    while (!cached_generator_->IsDone() && !request.ShouldStop()) {
+    while (!operation.ShouldStop() && !cached_generator_->IsDone()) {
       cached_generator_->GenerateNextToken();
+
+      if (operation.ShouldStop()) {
+        break;
+      }
+
       std::string token = cached_generator_->Decode();
       ++output_tokens;
 
@@ -616,61 +654,103 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
   emit_segments(splitter.Flush());
   flush_accumulator();
 
-  int total_tokens = cached_generator_->TokenCount();
+  // Final engine read *before* the seal: total_tokens is part of what the commit records, so it has to be
+  // taken while the generator is still guaranteed usable.
+  const int total_tokens = cached_generator_->TokenCount();
 
-  if (request.canceled) {
-    // Rewind the generator to undo this turn's input. The generator remains valid
-    // for the next attempt — the caller can re-send the same input.
-    //
-    // A timed-out turn is the exception: its generator is already terminated, so it is neither rewound nor reused.
-    // OnRequestFinished() discards it once the watchdog can no longer race that teardown.
-    if (!request.timed_out.load(std::memory_order_relaxed)) {
-      cached_generator_->RewindTo(pre_turn_token_count);
+  // Build the entire turn candidate off to the side, *before* the seal: the response items, the history
+  // additions and the turn record are all prepared here so that once the seal succeeds the commit is nothing
+  // but noexcept moves. Any throw during this preparation (tool-call parsing, allocation) faults the
+  // operation — Run marks it faulted and OnRequestFinished discards the mutated generator — instead of
+  // tearing a half-committed turn.
+  Response pending_response;
+  ProcessGeneratedOutput(std::move(text), cached_tool_ctx_, effective_options, /*canceled=*/false,
+                         pending_response, prompt_tokens, total_tokens, std::move(streamed_tool_calls));
+
+  const size_t pending_history_start = history_.size();
+  const size_t pending_input_count = new_messages.size();
+
+  std::vector<MessageItem> pending_history = history_;
+  pending_history.reserve(history_.size() + new_messages.size() + 1);
+  for (auto& msg : new_messages) {
+    pending_history.push_back(std::move(msg));
+  }
+
+  // Assistant reply: the first assistant MESSAGE item the output produced, copied before the seal where a
+  // throw is still recoverable.
+  for (const auto& item : pending_response.items) {
+    if (item->type == FOUNDRY_LOCAL_ITEM_MESSAGE) {
+      const auto& msg = static_cast<const MessageItem&>(*item);
+      if (msg.role == FOUNDRY_LOCAL_ROLE_ASSISTANT && !msg.content.empty()) {
+        pending_history.push_back(msg);
+        break;
+      }
     }
   }
 
-  ProcessGeneratedOutput(std::move(text), cached_tool_ctx_, effective_options, request.canceled,
-                         response, prompt_tokens, total_tokens, std::move(streamed_tool_calls));
+  std::vector<TurnRecord> pending_turns = turns_;
+  pending_turns.push_back(TurnRecord{
+      .history_start = pending_history_start,
+      .input_count = pending_input_count,
+      .rewind_boundary = rewind_boundary,
+  });
 
-  // Commit input messages + assistant reply to history only on success (not cancelled)
-  if (!request.canceled) {
-    // LARK grammar (tool-call-only mode) is a single-shot finite parse. If generation was truncated while grammar was
-    // active, the parser is in an unrecoverable state. Additionally, a completed grammar signals EOS — IsDone() would
-    // return true on the next turn. Invalidate after any grammar-guided generation so the next turn rebuilds.
-    //
-    // Reasoning models (qwen3, etc.) also need invalidation: continuous decoding leaves prior <think> tokens in the KV
-    // cache and the model fails to close subsequent reasoning blocks. The chat template strips prior </think> content
-    // when re-applied to history, so a rebuild restores correct behavior. This matches C#, which always applies the
-    // full template per turn.
-    bool grammar_was_active = cached_tool_ctx_.tool_output && !cached_tool_ctx_.text_output;
-    bool reasoning_was_active = cached_tool_ctx_.supports_reasoning;
+  // Whether continuous decoding must be abandoned after this turn: LARK grammar (tool-call-only mode) is a
+  // single-shot parse that also signals EOS; reasoning leaves prior <think> tokens in the KV cache that break
+  // the next turn's reasoning; a vision sequence cannot be extended by AppendMessages. Decided before the
+  // seal, applied as a noexcept reset after it. The chat template strips prior reasoning when re-applied to
+  // history, so a rebuild is correct and matches C#, which always re-applies the full template per turn.
+  const bool invalidate_generator = (cached_tool_ctx_.tool_output && !cached_tool_ctx_.text_output) ||
+                                    cached_tool_ctx_.supports_reasoning || vision_turn;
 
-    if (grammar_was_active || reasoning_was_active) {
-      cached_generator_.reset();
-      cached_tool_ctx_ = {};
+  // Quiesce (not Drain) the callback: wait until every pushed item has been delivered and no callback
+  // invocation is in flight, so a slow callback's stop decision is visible to the seal below instead of
+  // landing after this turn has already been committed. The handler is still usable afterwards and its
+  // destructor performs the real drain+join.
+  if (streaming_callback) {
+    streaming_callback->Quiesce();
+  }
+
+  // Single commit point for this path. The generator guard has ended, the engine reads are done and every
+  // callback decision has landed, so this is the exact moment the outcome can be closed to cancellation.
+  if (!operation.TrySeal()) {
+    // Only a boundary captured from a successful append to this exact cached generator can be rewound. Even a
+    // failed terminate_session signal may already have poisoned pinned OGA state, so delivery success is not
+    // the reuse criterion: this exact generator must never have been cancellation-attempted. A stop after slot
+    // withdrawal never calls Cancel(), leaves this marker false and remains rewindable.
+    if (cached_generator_ && rewind_boundary.has_value() &&
+        rewind_boundary->generator_generation == generator_generation_ &&
+        !cached_generator_->WasCancellationAttempted()) {
+      cached_generator_->RewindTo(rewind_boundary->token_count);
+    } else {
+      ResetGeneratorCache();
     }
 
-    CommitTurn(std::move(new_messages), response, pre_turn_token_count, total_tokens);
+    // Legacy ProcessRequest preserves generated-so-far output and usage on cancellation. Explicit operations
+    // erase this centrally in Operation::Process.
+    pending_response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
+    response.Swap(pending_response);
+    return;
+  }
 
-    // After a vision turn, drop the cached generator so any text follow-up
-    // rebuilds from history. AppendMessages cannot extend a vision-decoded
-    // sequence; trying to do so would silently feed text into a state that
-    // includes image-derived tokens.
-    if (vision_turn) {
-      cached_generator_.reset();
-      cached_tool_ctx_ = {};
-    }
+  // Seal won: publish only through noexcept ownership swaps.
+  response.Swap(pending_response);
+  history_.swap(pending_history);
+  turns_.swap(pending_turns);
+
+  if (invalidate_generator) {
+    ResetGeneratorCache();
   }
 }
 
-void ChatSession::ProcessChatCompletionsJson(const std::string& request_json, const Request& original_request,
-                                             Response& response) {
+void ChatRuntime::ProcessChatCompletionsJson(const OperationContext& operation, const std::string& request_json,
+                                             const Request& original_request, Response& response) {
   // Parse the OpenAI chat completions request
   auto req_json = nlohmann::json::parse(request_json);
   auto req = req_json.get<ChatCompletionRequest>();
 
   // Apply catalog defaults passed via request options
-  chat_completions::ApplyCatalogDefaults(req, CatalogModel().Info().model_settings);
+  chat_completions::ApplyCatalogDefaults(req, CatalogModelInfo().model_settings);
 
   std::string model_name = req.model;
   std::string completion_id = chat_completions::GenerateCompletionId();
@@ -726,10 +806,19 @@ void ChatSession::ProcessChatCompletionsJson(const std::string& request_json, co
   }
 
   // Create generator
+  if (operation.ShouldStop()) {
+    return;
+  }
+
   auto generator = OnnxChatGenerator::Create(messages, options, Model(), tool_ctx);
+
+  if (operation.ShouldStop()) {
+    return;
+  }
+
   int prompt_tokens = generator->PromptTokenCount();
 
-  auto streaming_callback = CreateCallbackHandler(original_request);
+  auto streaming_callback = CreateCallbackHandler(operation);
   bool is_streaming = (streaming_callback != nullptr);
 
   // Emit initial streaming chunk
@@ -822,10 +911,15 @@ void ChatSession::ProcessChatCompletionsJson(const std::string& request_json, co
   {
     // Publish the generator so Session::Cancel() and the deadline watchdog can interrupt
     // an in-flight compute, not just the loop between tokens.
-    ActiveGenerator active(*this, *generator);
+    ActiveGenerator active(operation, *generator);
 
-    while (!generator->IsDone() && !original_request.ShouldStop()) {
+    while (!operation.ShouldStop() && !generator->IsDone()) {
       generator->GenerateNextToken();
+
+      if (operation.ShouldStop()) {
+        break;
+      }
+
       std::string token = generator->Decode();
 
       if (!token.empty()) {
@@ -844,67 +938,87 @@ void ChatSession::ProcessChatCompletionsJson(const std::string& request_json, co
     emit_ready_calls(out.ready_calls);
   }
 
-  int total_tokens = generator->TokenCount();
+  // Final engine read before the seal — the response's usage block depends on it.
+  const int total_tokens = generator->TokenCount();
 
-  // Process the generated output into response items (MessageItem, ToolCallItem, etc.)
-  // This also updates finish_reason, and usage on the response. Streamed-parsed tool calls are reused so call_ids
-  // stay stable across stream deltas and the final ChatCompletionResponse.
-  ProcessGeneratedOutput(std::move(text), tool_ctx, options, original_request.canceled,
-                         response, prompt_tokens, total_tokens, std::move(streamed_tool_calls));
+  // Build the candidate entirely off to the side. Nothing reaches the caller-owned response until the
+  // operation seals, but constructing the final streaming envelope before that seal lets its callback's stop
+  // decision participate in the same completion race as every earlier chunk.
+  Response completed_response;
+  ProcessGeneratedOutput(std::move(text), tool_ctx, options, /*canceled=*/false,
+                         completed_response, prompt_tokens, total_tokens, std::move(streamed_tool_calls));
 
-  // Emit final streaming chunk with finish_reason
+  completed_response.metadata["completion_id"] = completion_id;
+  completed_response.metadata["created"] = std::to_string(created);
+  completed_response.metadata["model"] = model_name;
+
+  // Build both serialized outcomes before the seal. Mutating only the outer finish reason after serialization
+  // would let a cancelled legacy result carry a natural "stop"/"length" inside its JSON payload.
+  auto completed_chat_response =
+      chat_completions::BuildResponse(completed_response, completion_id, created, model_name);
+
+  const auto completed_finish_reason = completed_response.finish_reason;
+  completed_response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
+  auto cancelled_chat_response =
+      chat_completions::BuildResponse(completed_response, completion_id, created, model_name);
+  completed_response.finish_reason = completed_finish_reason;
+
+  Response cancelled_response;
+  cancelled_response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
+  cancelled_response.usage = completed_response.usage;
+  cancelled_response.metadata = completed_response.metadata;
+  cancelled_response.items.push_back(std::make_unique<TextItem>(nlohmann::json(cancelled_chat_response).dump(),
+                                                                FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+
+  completed_response.items.clear();
+  completed_response.items.push_back(std::make_unique<TextItem>(nlohmann::json(completed_chat_response).dump(),
+                                                                FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+
+  std::unique_ptr<Item> completed_final_item;
+  std::unique_ptr<Item> cancelled_final_item;
   if (is_streaming) {
-    auto final_json = chat_completions::FormatFinalStreamingChunk(response.finish_reason, completion_id, created,
-                                                                  model_name);
-    streaming_callback->PushItem(std::make_unique<TextItem>(std::move(final_json),
-                                                            FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+    auto completed_final_json =
+        chat_completions::FormatFinalStreamingChunk(completed_response.finish_reason, completion_id, created,
+                                                    model_name);
+    completed_final_item = std::make_unique<TextItem>(std::move(completed_final_json),
+                                                      FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON);
+
+    auto cancelled_final_json =
+        chat_completions::FormatFinalStreamingChunk(FOUNDRY_LOCAL_FINISH_NONE, completion_id, created, model_name);
+    cancelled_final_item = std::make_unique<TextItem>(std::move(cancelled_final_json),
+                                                      FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON);
+
+    // Every content-bearing callback decision must land before the outcome is sealed. The terminal envelope
+    // carries no new generated content, so its callback runs after the decision and cannot reopen it.
+    streaming_callback->Quiesce();
   }
 
-  // Store completion envelope metadata so callers can access without parsing JSON
-  response.metadata["completion_id"] = completion_id;
-  response.metadata["created"] = std::to_string(created);
-  response.metadata["model"] = model_name;
+  // Single decision point for both the returned JSON and the terminal SSE envelope.
+  const bool sealed = operation.TrySeal();
 
-  // Build the ChatCompletionResponse and replace response items with a single OPENAI_JSON-tagged TextItem.
-  auto chat_response = chat_completions::BuildResponse(response, completion_id, created, model_name);
-  response.items.clear();
-  response.items.push_back(std::make_unique<TextItem>(nlohmann::json(chat_response).dump(),
-                                                      FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+  if (is_streaming) {
+    auto& final_item = sealed ? completed_final_item : cancelled_final_item;
+    streaming_callback->PushFinalItem(std::move(final_item));
+    streaming_callback->Quiesce();
+  }
+
+  if (!sealed) {
+    response.Swap(cancelled_response);
+    return;
+  }
+
+  response.Swap(completed_response);
 }
 
-const std::vector<MessageItem>& ChatSession::GetHistory() const {
+const std::vector<MessageItem>& ChatRuntime::GetHistory() const {
   return history_;
 }
 
-void ChatSession::CommitTurn(std::vector<MessageItem>&& new_messages, const Response& response,
-                             int pre_turn_token_count, int post_turn_token_count) {
-  size_t history_start = history_.size();
-  size_t input_count = new_messages.size();
-
-  // Commit input messages to history
-  for (auto& msg : new_messages) {
-    history_.push_back(std::move(msg));
-  }
-
-  // Commit assistant reply from the response (first MESSAGE item with role=assistant)
-  for (const auto& item : response.items) {
-    if (item->type == FOUNDRY_LOCAL_ITEM_MESSAGE) {
-      const auto& msg = static_cast<const MessageItem&>(*item);
-      if (msg.role == FOUNDRY_LOCAL_ROLE_ASSISTANT && !msg.content.empty()) {
-        history_.push_back(msg);
-        break;
-      }
-    }
-  }
-
-  turns_.push_back({history_start, input_count, pre_turn_token_count, post_turn_token_count});
-}
-
-size_t ChatSession::TurnCount() const {
+size_t ChatRuntime::TurnCount() const {
   return turns_.size();
 }
 
-void ChatSession::UndoTurns(size_t count) {
+void ChatRuntime::UndoTurns(size_t count) {
   if (count == 0) {
     return;
   }
@@ -915,27 +1029,33 @@ void ChatSession::UndoTurns(size_t count) {
                  std::to_string(turns_.size()) + " turns exist");
   }
 
-  // Find the target turn — the one we're rewinding to the start of
-  auto& target = turns_[turns_.size() - count];
+  // Copy the target before truncation invalidates its record.
+  const TurnRecord target = turns_[turns_.size() - count];
+  const size_t retained_turns = turns_.size() - count;
 
-  // Truncate history back to where the target turn started
-  history_.resize(target.history_start);
+  // A token count is meaningful only as part of an exact boundary from a continuous append on this generator.
+  const bool can_rewind = cached_generator_ && target.rewind_boundary.has_value() &&
+                          target.rewind_boundary->generator_generation == generator_generation_;
 
-  // Rewind the generator
-  if (cached_generator_) {
-    if (count == turns_.size()) {
-      // Undoing all turns — destroy the generator entirely
-      cached_generator_.reset();
-      cached_tool_ctx_ = {};
-    } else {
-      cached_generator_->RewindTo(target.pre_turn_token_count);
+  if (!can_rewind) {
+    ResetGeneratorCache();
+  } else {
+    try {
+      cached_generator_->RewindTo(target.rewind_boundary->token_count);
+    } catch (...) {
+      // Rewind is a cache optimization, not part of the logical undo contract. A faulting cache is discarded;
+      // the history transaction below still completes and the next turn rebuilds from retained history.
+      ResetGeneratorCache();
     }
   }
 
-  turns_.resize(turns_.size() - count);
+  // Every potentially throwing operation is complete. Shrinking these vectors performs no allocation, so the
+  // history and turn metadata commit together and cannot expose a partial logical undo.
+  history_.resize(target.history_start);
+  turns_.resize(retained_turns);
 }
 
-size_t ChatSession::MessageCount() const {
+size_t ChatRuntime::MessageCount() const {
   return history_.size();
 }
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.h
@@ -1,16 +1,21 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #pragma once
 
 #include "inferencing/generative/chat/search_options.h"
 #include "inferencing/generative/toolcalling/tool_call_context.h"
 #include "inferencing/generative/toolcalling/tool_call_utils.h"
+#include "inferencing/model_session_lease.h"
 #include "inferencing/session/session.h"
+#include "inferencing/session/session_runtime.h"
 #include "items/message_item.h"
 #include "logger.h"
 
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace fl {
@@ -18,33 +23,39 @@ namespace fl {
 class GenAIModelInstance;
 class OnnxChatGenerator;
 
-/// A chat session that maintains conversation history across turns.
-/// Designed for multi-turn conversations where message history accumulates
-/// and is sent with each generation request (for use with the OpenAI
-/// Responses API pattern).
+/// Executable body of a chat session: conversation history, cached generator and tool context.
 ///
-/// Generator caching: after the first non-JSON request, the ORT GenAI generator is cached.
-/// Subsequent turns append only new messages to the cached generator, reusing the KV cache.
-/// OpenAI chat completions JSON requests (TextItem with text_type == OPENAI_JSON) always create a fresh
-/// generator and never use the cache.
-class ChatSession : public Session {
+/// Designed for multi-turn conversations where message history accumulates and is sent with each generation
+/// request (for use with the OpenAI Responses API pattern).
+///
+/// Generator caching: after the first non-JSON request, the ORT GenAI generator is cached. Subsequent turns
+/// append only new messages to the cached generator, reusing the KV cache. OpenAI chat completions JSON
+/// requests (TextItem with text_type == OPENAI_JSON) always create a fresh generator and never use the cache.
+///
+/// Commit discipline: history is committed only after OperationContext::TrySeal() succeeds — i.e. after the
+/// generator guard has ended, final engine reads have happened and the streaming callback has quiesced. A
+/// failed seal leaves logical history unchanged but exposes generated-so-far output with FINISH_NONE to the
+/// legacy ProcessRequest path; explicit operations clear that response centrally.
+class ChatRuntime : public SessionRuntime {
  public:
+  /// Exact state before a turn was appended to an already-existing cached generator. Absence means the turn
+  /// started from a fresh generator and therefore has no valid rewind target.
+  struct RewindBoundary {
+    uint64_t generator_generation;
+    int token_count;
+  };
+
   /// Tracks the token-level and history-level boundaries of a single conversation turn.
   /// Used for generator rewind and history rollback on error or undo.
   struct TurnRecord {
-    size_t history_start;       // index in history_ where this turn's input messages begin
-    size_t input_count;         // number of input messages (user + tool results) in this turn
-    int pre_turn_token_count;   // generator sequence length before this turn's input was appended
-    int post_turn_token_count;  // generator sequence length after generation completed
+    size_t history_start;                        // index in history_ where this turn's input messages begin
+    size_t input_count;                          // number of input messages (user + tool results) in this turn
+    std::optional<RewindBoundary> rewind_boundary;
     // The assistant reply is at history_[history_start + input_count]
   };
 
-  ChatSession(const fl::Model& catalog_model, GenAIModelInstance& model, ILogger& logger, ITelemetry& telemetry);
-  ~ChatSession();
-
-  // Movable: transfers session refcount ownership to the moved-to instance.
-  ChatSession(ChatSession&& other) noexcept;
-  ChatSession& operator=(ChatSession&&) = delete;
+  ChatRuntime(const fl::Model& catalog_model, ModelSessionLease lease, ILogger& logger, ITelemetry& telemetry);
+  ~ChatRuntime() noexcept override;
 
   SessionType Type() const override;
 
@@ -57,14 +68,12 @@ class ChatSession : public Session {
   /// Get the number of completed turns.
   size_t TurnCount() const override;
 
-  /// Undo the last `count` completed turns: rewinds the cached generator and removes
-  /// each turn's input messages and assistant reply from history.
-  /// If all turns are undone, the cached generator is destroyed.
+  /// Undo the last `count` completed turns: rewinds the cached generator and removes each turn's input
+  /// messages and assistant reply from history. If all turns are undone, the cached generator is destroyed.
   ///
-  /// Vision turns: image input is only allowed on the first turn of a
-  /// session. UndoTurns rolls back history but does not undo this
-  /// constraint — once a session has started, no later turn may include
-  /// images. Start a new ChatSession to send images.
+  /// Vision turns: image input is only allowed on the first turn of a session. UndoTurns rolls back history
+  /// but does not undo this constraint — once a session has started, no later turn may include images. Start
+  /// a new chat session to send images.
   ///
   /// @param count  Number of turns to undo. Must be <= TurnCount().
   void UndoTurns(size_t count) override;
@@ -74,11 +83,16 @@ class ChatSession : public Session {
   void SetSessionOptionsImpl(const KeyValuePairs& options) override;
 
   /// Process a request: extracts MESSAGE items and parameters from the generic request,
-  /// generates a response, and on success commits messages to conversation history.
-  void ProcessRequestImpl(const Request& request, Response& response) override;
+  /// generates a response, and on a successful seal commits messages to conversation history.
+  void ProcessRequestImpl(const OperationContext& operation, const Request& request, Response& response) override;
 
-  /// Discard generator state invalidated by a timeout after the watchdog can no longer access it.
-  void OnRequestFinished(const Request& request) noexcept override;
+  /// Discard generator state after an exact engine cancellation delivery or a fault, once the watchdog can no
+  /// longer reach it. A stop after generator withdrawal is handled by the exact rewind-boundary path instead.
+  void OnRequestFinished(const OperationContext& operation, const Request& request) noexcept override;
+
+  /// Drop the generator and the tool state baked into it. Generator destruction and ToolCallContext moves are
+  /// noexcept, so this is safe on both sides of the completion seal.
+  void ResetGeneratorCache() noexcept;
 
   /// Build tool calling context from request parameters and session tool definitions.
   ToolCallContext BuildToolCallContext(const Request& request) const;
@@ -101,21 +115,10 @@ class ChatSession : public Session {
   /// request. Parses the JSON, converts to internal items, runs generation, and produces an OPENAI_JSON-tagged
   /// TextItem response with the OpenAI ChatCompletionResponse.
   /// Does not use or update history_ or the cached generator.
-  void ProcessChatCompletionsJson(const std::string& request_json, const Request& original_request,
-                                  Response& response);
-
-  /// Commit input messages and assistant reply to history after a successful turn.
-  void CommitTurn(std::vector<MessageItem>&& new_messages, const Response& response,
-                  int pre_turn_token_count, int post_turn_token_count);
-
-  GenAIModelInstance& Model() { return model_; }
-  const GenAIModelInstance& Model() const { return model_; }
+  void ProcessChatCompletionsJson(const OperationContext& operation, const std::string& request_json,
+                                  const Request& original_request, Response& response);
 
   ILogger& logger_;
-  GenAIModelInstance& model_;
-  // Tracks who is responsible for calling model_.ReleaseSession(). Set to false on the
-  // moved-from instance so the refcount transfers cleanly across moves.
-  bool owns_session_ = true;
   std::vector<MessageItem> history_;
   std::vector<TurnRecord> turns_;
   SearchOptions session_options_;
@@ -124,9 +127,41 @@ class ChatSession : public Session {
   // Null until first non-JSON ProcessRequestImpl call.
   std::unique_ptr<OnnxChatGenerator> cached_generator_;
 
+  // Monotonic identity for cached_generator_, bumped every time a *new* generator is built. A rewind boundary
+  // stores the generation it belongs to, so rollback can reject a token count from any rebuilt generator.
+  uint64_t generator_generation_ = 0;
+
   // Tool context used when creating the cached generator.
   // Reused for subsequent turns to maintain tool definition consistency.
   ToolCallContext cached_tool_ctx_;
+};
+
+/// A chat session that maintains conversation history across turns.
+///
+/// Stateless facade over a shared ChatRuntime — see Session. Movable (it moves a shared_ptr), destroyed
+/// without waiting, and it owns no model reference of its own: the runtime holds the ModelSessionLease.
+class ChatSession : public Session {
+ public:
+  /// Compatibility construction against an already-pinned model. The caller must exclude a concurrent
+  /// unload until construction returns; production paths should pass a manager-acquired ModelSessionLease.
+  ChatSession(const fl::Model& catalog_model, GenAIModelInstance& model, ILogger& logger, ITelemetry& telemetry)
+      : ChatSession(catalog_model, ModelSessionLease::Adopt(model), logger, telemetry) {}
+
+  /// Construction from a lease acquired atomically against unload (Session::Create).
+  ChatSession(const fl::Model& catalog_model, ModelSessionLease lease, ILogger& logger, ITelemetry& telemetry)
+      : Session(MakeSessionRuntime<ChatRuntime>(catalog_model, std::move(lease), logger, telemetry)) {}
+
+  ChatSession(ChatSession&&) noexcept = default;
+  ChatSession& operator=(ChatSession&&) = delete;
+
+  /// Get the full conversation history.
+  const std::vector<MessageItem>& GetHistory() const { return Typed().GetHistory(); }
+
+  /// Get the number of messages in the history.
+  size_t MessageCount() const { return Typed().MessageCount(); }
+
+ private:
+  ChatRuntime& Typed() const { return static_cast<ChatRuntime&>(RuntimeRef()); }
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
@@ -6,6 +6,7 @@
 #include "items/message_item.h"
 #include "items/text_item.h"
 #include "inferencing/generative/toolcalling/grammar.h"
+#include "inferencing/session/oga_generator_cancellable.h"
 #include "utils.h"
 
 #include <nlohmann/json.hpp>
@@ -34,55 +35,54 @@ OnnxChatGenerator::OnnxChatGenerator(std::unique_ptr<OgaGeneratorParams> gen_par
       stream_with_special_(std::move(stream_with_special)),
       named_tensors_(std::move(named_tensors)),
       model_(model),
-      prompt_token_count_(prompt_token_count) {}
+      prompt_token_count_(prompt_token_count),
+      token_count_(prompt_token_count) {}
 
 // ---------------------------------------------------------------------------
 // ChatGenerator interface
 // ---------------------------------------------------------------------------
 
 bool OnnxChatGenerator::IsDone() const {
-  if (cancelled_) {
+  if (cancelled_.load(std::memory_order_acquire)) {
     return true;
   }
 
   // OgaGenerator::IsDone() is non-const in the ORT GenAI API, so we need const_cast.
   // This is safe because IsDone only reads state.
   auto* gen = const_cast<OgaGenerator*>(generator_.get());
-  return gen->IsDone() || gen->IsSessionTerminated();
+  return IsGeneratorDoneCancellationSafe(*gen, engine_termination_delivered_);
 }
 
 void OnnxChatGenerator::GenerateNextToken() {
-  if (cancelled_) {
+  if (cancelled_.load(std::memory_order_acquire)) {
     return;
   }
 
   try {
-    generator_->GenerateNextToken();
-  } catch (const std::runtime_error& e) {
-    // If cancelled while generating, the OGA engine throws when the session is terminated.
-    // This is expected — not an error.
-    if (cancelled_) {
+    if (!TryGenerateNextToken(*generator_, engine_termination_delivered_)) {
       return;
     }
-
+  } catch (const std::runtime_error& e) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, std::string("token generation failed: ") + e.what());
   }
+
+  token_count_.fetch_add(1, std::memory_order_relaxed);
 }
 
 std::string OnnxChatGenerator::Decode() {
-  if (cancelled_) {
+  if (cancelled_.load(std::memory_order_acquire)) {
     return "";
   }
 
   // Get the most recently generated token ID.
   // GetNextTokens returns the batch of next tokens; we use index 0 (batch size = 1).
-  auto next_tokens = generator_->GetNextTokens();
+  const auto next_tokens = TryGetNextTokens(*generator_, engine_termination_delivered_);
 
-  if (next_tokens.empty()) {
+  if (!next_tokens || next_tokens->empty()) {
     return "";
   }
 
-  int32_t token_id = next_tokens[0];
+  int32_t token_id = (*next_tokens)[0];
 
   // Decode through the normal tokenizer stream
   const char* token_text = stream_->Decode(token_id);
@@ -112,22 +112,27 @@ std::string OnnxChatGenerator::Decode() {
 }
 
 int OnnxChatGenerator::TokenCount() const {
-  return static_cast<int>(generator_->GetSequenceCount(0));
+  return token_count_.load(std::memory_order_relaxed);
 }
 
 int OnnxChatGenerator::PromptTokenCount() const {
   return prompt_token_count_;
 }
 
-void OnnxChatGenerator::Cancel() {
-  cancelled_ = true;
+bool OnnxChatGenerator::Cancel() noexcept {
+  cancelled_.store(true, std::memory_order_release);
 
   // Use the ORT GenAI engine-level termination to interrupt mid-compute
-  // (e.g. during a long prefill), not just between token boundaries.
+  // (e.g. during a long prefill), not just between token boundaries. Record successful delivery only once the
+  // call returns. A throwing call can still leave the pinned OGA session terminated; IsSessionTerminated is
+  // kept as a separate source of exact evidence.
   try {
     generator_->SetRuntimeOption("terminate_session", "1");
+    engine_termination_delivered_.store(true, std::memory_order_release);
+    return true;
   } catch (...) {
     // SetRuntimeOption may not be supported by all ORT GenAI builds
+    return false;
   }
 }
 
@@ -143,7 +148,8 @@ int OnnxChatGenerator::AppendMessages(const std::vector<MessageItem>& new_messag
   }
 
   // Build prompt from only the new messages. ApplyChatTemplate with add_generation_prompt=true
-  // produces the correct continuation tokens (e.g. <|im_end|>\n<|im_start|>user\n...<|im_end|>\n<|im_start|>assistant\n)
+  // produces the correct continuation tokens
+  // (e.g. <|im_end|>\n<|im_start|>user\n...<|im_end|>\n<|im_start|>assistant\n).
   std::string prompt = BuildChatPrompt(new_messages, model, tools_json);
   auto sequences = EncodePrompt(prompt, model);
   int new_token_count = static_cast<int>(sequences->SequenceCount(0));
@@ -154,6 +160,7 @@ int OnnxChatGenerator::AppendMessages(const std::vector<MessageItem>& new_messag
     FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, std::string("failed to append token sequences: ") + e.what());
   }
 
+  token_count_.fetch_add(new_token_count, std::memory_order_relaxed);
   return new_token_count;
 }
 
@@ -163,6 +170,8 @@ void OnnxChatGenerator::RewindTo(int token_count) {
   } catch (const std::runtime_error& e) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, std::string("failed to rewind generator: ") + e.what());
   }
+
+  token_count_.store(token_count, std::memory_order_relaxed);
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #pragma once
 
@@ -39,7 +39,14 @@ class OnnxChatGenerator : public ChatGenerator {
   std::string Decode() override;
   int TokenCount() const override;
   int PromptTokenCount() const override;
-  void Cancel() override;
+  bool Cancel() noexcept override;
+
+  /// True once cancellation was attempted against this generator, regardless of whether SetRuntimeOption
+  /// reported successful delivery. A failed signal can still poison a pinned OGA session, so such a generator
+  /// must never be rewound or reused.
+  [[nodiscard]] bool WasCancellationAttempted() const noexcept {
+    return cancelled_.load(std::memory_order_acquire);
+  }
 
   /// Encode new messages and append their tokens to the generator's sequence.
   /// Used for continuous decoding — only the new turn's messages are encoded and appended.
@@ -134,7 +141,16 @@ class OnnxChatGenerator : public ChatGenerator {
   std::unique_ptr<OgaNamedTensors> named_tensors_;
   GenAIModelInstance& model_;  // non-owning reference — model outlives generator
   int prompt_token_count_ = 0;
+  /// Numeric accounting only; generator publication and operation sealing provide lifecycle synchronization.
+  std::atomic<int> token_count_{0};
+  /// Monotonic cancellation-attempt marker for this generator. It also stops local token/decode work promptly,
+  /// but is not by itself evidence that the OGA session terminated.
   std::atomic<bool> cancelled_{false};
+
+  /// Set only after SetRuntimeOption("terminate_session", ...) actually *succeeds* in Cancel(). Distinct from
+  /// cancelled_: a throwing call may still have terminated the pinned OGA session, while a later unrelated
+  /// runtime_error must not be suppressed without either this bit or IsSessionTerminated().
+  std::atomic<bool> engine_termination_delivered_{false};
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/embeddings/embeddings_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/embeddings/embeddings_session.cc
@@ -22,25 +22,40 @@
 
 namespace fl {
 
-EmbeddingsSession::EmbeddingsSession(const fl::Model& catalog_model, GenAIModelInstance& model,
-                                     ILogger& logger, ITelemetry& telemetry)
-    : Session(catalog_model, logger, telemetry, /*allow_concurrent_requests=*/true),
-      logger_(logger),
-      model_(model) {
-  logger_.Log(LogLevel::Debug, fmt::format("Creating EmbeddingsSession for model: {}", model.ModelId()));
-  // Last so a throw above does not leak a refcount; nothing below can throw.
-  model_.AcquireSession();
+namespace {
+
+void SealAndPublishEmbeddingsResponse(const OperationContext& operation, Response& pending_response,
+                                      Response& response) {
+  if (!operation.TrySeal()) {
+    Response stopped_response;
+    response.Swap(stopped_response);
+    return;
+  }
+
+  response.Swap(pending_response);
 }
 
-EmbeddingsSession::~EmbeddingsSession() {
-  model_.ReleaseSession();
+}  // namespace
+
+EmbeddingsRuntime::EmbeddingsRuntime(const fl::Model& catalog_model, ModelSessionLease lease, ILogger& logger,
+                                     ITelemetry& telemetry)
+    : SessionRuntime(catalog_model, logger, telemetry, std::move(lease), /*allow_concurrent_requests=*/true),
+      logger_(logger) {
+  logger_.Log(LogLevel::Debug, fmt::format("Creating EmbeddingsSession for model: {}", Model().ModelId()));
 }
 
-SessionType EmbeddingsSession::Type() const {
+EmbeddingsRuntime::~EmbeddingsRuntime() noexcept {
+  // Embeddings run concurrently, so several operations can share this runtime. There is nothing to wait for
+  // here: every one of them holds a strong reference, so this destructor only runs once they are all gone,
+  // and the base releases the model lease afterwards.
+}
+
+SessionType EmbeddingsRuntime::Type() const {
   return SessionType::kEmbeddings;
 }
 
-void EmbeddingsSession::ProcessRequestImpl(const Request& request, Response& response) {
+void EmbeddingsRuntime::ProcessRequestImpl(const OperationContext& operation, const Request& request,
+                                          Response& response) {
   // OpenAI embeddings JSON pass-through: a TEXT item tagged OPENAI_JSON. Routes to a
   // separate handler that produces an OPENAI_JSON response, parity with chat and audio.
   for (const auto* item : request.items) {
@@ -48,7 +63,7 @@ void EmbeddingsSession::ProcessRequestImpl(const Request& request, Response& res
       const auto& text_item = static_cast<const TextItem&>(*item);
 
       if (text_item.text_type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON) {
-        ProcessEmbeddingsJson(text_item.text, request, response);
+        ProcessEmbeddingsJson(operation, text_item.text, response);
         return;
       }
     }
@@ -68,22 +83,21 @@ void EmbeddingsSession::ProcessRequestImpl(const Request& request, Response& res
     inputs.push_back(static_cast<const TextItem&>(*item).text);
   }
 
+  // A validation-only success still commits an outcome, so it seals like any other path.
   if (inputs.empty()) {
-    response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+    Response pending_response;
+    pending_response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+    SealAndPublishEmbeddingsResponse(operation, pending_response, response);
     return;
   }
 
-  // Single batched forward pass for all inputs.
-  auto embeddings = GenerateEmbeddingsBatch(inputs, request);
+  // Single batched forward pass for all inputs. Every ActiveGenerator guard is scoped inside
+  // GenerateSingleEmbedding, so no generator is published by the time this returns.
+  auto embeddings = GenerateEmbeddingsBatch(operation, inputs);
 
-  // A cancelled or timed-out batch is incomplete — emit no partial items and let the
-  // caller see it stopped early, rather than silently returning fewer vectors than inputs.
-  if (request.canceled) {
-    response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
-    return;
-  }
+  Response pending_response;
 
-  // Wrap each embedding as a TensorItem in the response. The vector is heap-allocated
+  // Wrap each embedding as a TensorItem before sealing. The vector is heap-allocated
   // and ownership is transferred to the TensorItem deleter via deleter_user_data_, so
   // the buffer is freed correctly without raw new[]/delete[].
   for (auto& embedding : embeddings) {
@@ -96,14 +110,17 @@ void EmbeddingsSession::ProcessRequestImpl(const Request& request, Response& res
     tensor->deleter_ = [](const flTensorData*, void* ud) {
       delete static_cast<std::vector<float>*>(ud);
     };
-    response.items.push_back(std::move(tensor));
+    pending_response.items.push_back(std::move(tensor));
   }
 
-  response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+  pending_response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+
+  // A cancelled or timed-out batch is incomplete, so the publisher emits an empty response rather than a
+  // complete-looking short batch.
+  SealAndPublishEmbeddingsResponse(operation, pending_response, response);
 }
 
-void EmbeddingsSession::ProcessEmbeddingsJson(const std::string& request_json,
-                                              const Request& original_request,
+void EmbeddingsRuntime::ProcessEmbeddingsJson(const OperationContext& operation, const std::string& request_json,
                                               Response& response) {
   // Parse the OpenAI embeddings request. Let nlohmann::json::parse_error propagate —
   // matches AudioSession::ProcessAudioTranscriptionJson behavior.
@@ -125,14 +142,7 @@ void EmbeddingsSession::ProcessEmbeddingsJson(const std::string& request_json,
   // Reuse GenerateEmbeddingsBatch so the typed and JSON paths stay bit-for-bit equal
   // under future refactors (parity test relies on this).
   if (!inputs.empty()) {
-    auto embeddings = GenerateEmbeddingsBatch(inputs, original_request);
-
-    // Cancelled or timed out mid-batch: report the stop instead of returning a
-    // short data array that a client would read as a complete result.
-    if (original_request.canceled) {
-      response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
-      return;
-    }
+    auto embeddings = GenerateEmbeddingsBatch(operation, inputs);
 
     output.data.reserve(embeddings.size());
     for (size_t i = 0; i < embeddings.size(); ++i) {
@@ -151,13 +161,16 @@ void EmbeddingsSession::ProcessEmbeddingsJson(const std::string& request_json,
   // encoding_format = "base64" is parsed but intentionally not honored here, matching
   // the existing handler behavior. Follow-up task.
 
-  response.items.push_back(std::make_unique<TextItem>(nlohmann::json(output).dump(),
-                                                      FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
-  response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+  Response pending_response;
+  pending_response.items.push_back(std::make_unique<TextItem>(nlohmann::json(output).dump(),
+                                                              FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+  pending_response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+
+  SealAndPublishEmbeddingsResponse(operation, pending_response, response);
 }
 
-std::vector<std::vector<float>> EmbeddingsSession::GenerateEmbeddingsBatch(
-    const std::vector<std::string>& inputs, const Request& request) {
+std::vector<std::vector<float>> EmbeddingsRuntime::GenerateEmbeddingsBatch(
+    const OperationContext& operation, const std::vector<std::string>& inputs) {
   // Process each input independently (batch_size=1 per forward pass).
   //
   // Embedding models like Qwen3-Embedding use bidirectional attention —
@@ -174,11 +187,11 @@ std::vector<std::vector<float>> EmbeddingsSession::GenerateEmbeddingsBatch(
   for (const auto& input : inputs) {
     // Check between inputs: a large batch is otherwise uninterruptible, which is what
     // lets a runaway embeddings request pin the session refcount through shutdown.
-    if (request.ShouldStop()) {
+    if (operation.ShouldStop()) {
       break;
     }
 
-    results.push_back(GenerateSingleEmbedding(input, request));
+    results.push_back(GenerateSingleEmbedding(operation, input));
   }
 
   logger_.Log(LogLevel::Verbose,
@@ -187,14 +200,23 @@ std::vector<std::vector<float>> EmbeddingsSession::GenerateEmbeddingsBatch(
   return results;
 }
 
-std::vector<float> EmbeddingsSession::GenerateSingleEmbedding(const std::string& input, const Request& request) {
-  auto& oga_model = model_.GetOgaModel();
+std::vector<float> EmbeddingsRuntime::GenerateSingleEmbedding(const OperationContext& operation,
+                                                              const std::string& input) {
+  if (operation.ShouldStop()) {
+    return {};
+  }
+
+  auto& oga_model = Model().GetOgaModel();
 
   // 1. Tokenize and append EOS. Encode is serialized on the model's shared tokenizer.
-  const auto& eos_ids = model_.GetEosTokenIds();
-  auto sequences = model_.Tokenizer().Encode(input.c_str());
+  const auto& eos_ids = Model().GetEosTokenIds();
+  auto sequences = Model().Tokenizer().Encode(input.c_str());
   if (!eos_ids.empty()) {
     sequences->Append(eos_ids[0], 0);
+  }
+
+  if (operation.ShouldStop()) {
+    return {};
   }
 
   const size_t token_count = sequences->SequenceCount(0);
@@ -204,22 +226,32 @@ std::vector<float> EmbeddingsSession::GenerateSingleEmbedding(const std::string&
   gen_params->SetSearchOption("batch_size", 1.0);
   gen_params->SetSearchOption("max_length", static_cast<double>(token_count + 1));
 
-  auto generator = OgaGenerator::Create(oga_model, *gen_params);
-  generator->AppendTokenSequences(*sequences);
-
-  // Publish the generator so cancellation or an expired deadline interrupts this forward
-  // pass. A single long input can exceed the budget without ever reaching the loop check
-  // in GenerateEmbeddingsBatch.
-  OgaGeneratorCancellable cancellable(*generator);
-  ActiveGenerator active(*this, cancellable);
-
-  // 3. Single forward pass.
-  if (!TryGenerateNextToken(*generator, request)) {
+  if (operation.ShouldStop()) {
     return {};
   }
 
+  auto generator = OgaGenerator::Create(oga_model, *gen_params);
+
+  if (operation.ShouldStop()) {
+    return {};
+  }
+
+  generator->AppendTokenSequences(*sequences);
+
+  {
+    // Publish only for the interruptible forward pass. Withdrawing the slot drains any cancel lease, after
+    // which a later stop can still defeat the seal but cannot terminate the generator during output reads.
+    OgaGeneratorCancellable cancellable(*generator);
+    ActiveGenerator active(operation, cancellable);
+
+    // 3. Single forward pass.
+    if (!TryGenerateNextToken(*generator, operation)) {
+      return {};
+    }
+  }
+
   // The pass may have been terminated mid-compute, leaving hidden_states unusable.
-  if (request.ShouldStop()) {
+  if (operation.ShouldStop()) {
     return {};
   }
 
@@ -233,7 +265,7 @@ std::vector<float> EmbeddingsSession::GenerateSingleEmbedding(const std::string&
   }
 
   // 5. Determine hidden_size.
-  const auto& config = model_.GetGenAIConfig();
+  const auto& config = Model().GetGenAIConfig();
   int hidden_size = config.hidden_size.value_or(0);
   if (hidden_size <= 0) {
     int64_t denom = static_cast<int64_t>(token_count);

--- a/sdk_v2/cpp/src/inferencing/generative/embeddings/embeddings_session.h
+++ b/sdk_v2/cpp/src/inferencing/generative/embeddings/embeddings_session.h
@@ -2,61 +2,85 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "inferencing/model_session_lease.h"
 #include "inferencing/session/session.h"
+#include "inferencing/session/session_runtime.h"
 #include "logger.h"
+
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace fl {
 
 class GenAIModelInstance;
 
-/// Embedding session — stateless, concurrent-safe.
+/// Executable body of an embeddings session — stateless, concurrent-safe.
 /// Each ProcessRequestImpl call creates a fresh generator, runs one forward pass,
 /// extracts hidden_states, does last-token pooling + L2 normalization.
 ///
-/// Dual input contract (parity with ChatSession and AudioSession):
+/// Dual input contract (parity with ChatRuntime and AudioRuntime):
 /// - Typed path: a Request with one or more TEXT items. Response contains one TENSOR item
 ///   per input carrying the L2-normalized embedding vector.
 /// - OPENAI_JSON path: a Request with a single TEXT item tagged OPENAI_JSON containing an
 ///   OpenAI EmbeddingCreateRequest payload. Response is a single TEXT item tagged OPENAI_JSON
 ///   containing the EmbeddingCreateResponse.
-class EmbeddingsSession : public Session {
+///
+/// Both paths — including the validation-only empty-input case — build complete pending responses before
+/// OperationContext::TrySeal(). Success publishes by noexcept swap; cancellation publishes an empty
+/// FINISH_NONE response, never a partial batch.
+class EmbeddingsRuntime : public SessionRuntime {
  public:
-  EmbeddingsSession(const fl::Model& catalog_model, GenAIModelInstance& model,
-                    ILogger& logger, ITelemetry& telemetry);
-  ~EmbeddingsSession();
-
-  EmbeddingsSession(EmbeddingsSession&&) = delete;
-  EmbeddingsSession& operator=(EmbeddingsSession&&) = delete;
+  EmbeddingsRuntime(const fl::Model& catalog_model, ModelSessionLease lease, ILogger& logger,
+                    ITelemetry& telemetry);
+  ~EmbeddingsRuntime() noexcept override;
 
   SessionType Type() const override;
 
  protected:
-  void ProcessRequestImpl(const Request& request, Response& response) override;
+  void ProcessRequestImpl(const OperationContext& operation, const Request& request, Response& response) override;
 
  private:
   /// Generate L2-normalized embedding vectors for a list of inputs.
   /// Each input is processed independently (batch_size=1) to avoid
   /// padding artifacts with bidirectional-attention embedding models.
   ///
-  /// Stops early if `request` is cancelled or its deadline expires, so the returned
-  /// vector may be shorter than `inputs`. Callers must check the request state before
-  /// treating the result as complete.
-  std::vector<std::vector<float>> GenerateEmbeddingsBatch(const std::vector<std::string>& inputs,
-                                                          const Request& request);
+  /// Stops early if `operation` was stopped (cancel or deadline), so the returned vector may be shorter
+  /// than `inputs`. Callers must check operation.ShouldStop() before treating the result as complete.
+  std::vector<std::vector<float>> GenerateEmbeddingsBatch(const OperationContext& operation,
+                                                          const std::vector<std::string>& inputs);
 
   /// Generate a single L2-normalized embedding vector for one input string.
   /// Returns an empty vector if the forward pass was interrupted by cancellation or a timeout.
-  std::vector<float> GenerateSingleEmbedding(const std::string& input, const Request& request);
+  std::vector<float> GenerateSingleEmbedding(const OperationContext& operation, const std::string& input);
 
   /// Process a request whose first item is a TEXT item tagged OPENAI_JSON containing an
   /// OpenAI EmbeddingCreateRequest payload. Parses the JSON, runs generation via the
   /// shared GenerateEmbeddingsBatch path, and produces an OPENAI_JSON-tagged TextItem
   /// wrapping the EmbeddingCreateResponse.
-  void ProcessEmbeddingsJson(const std::string& request_json,
-                             const Request& original_request, Response& response);
+  void ProcessEmbeddingsJson(const OperationContext& operation, const std::string& request_json,
+                             Response& response);
 
   ILogger& logger_;
-  GenAIModelInstance& model_;
+};
+
+/// Embedding session facade — see Session. Concurrent by design: several operations may run against the
+/// same runtime at once, each with its own cancellation slots.
+class EmbeddingsSession : public Session {
+ public:
+  /// Compatibility construction against an already-pinned model. The caller must exclude a concurrent
+  /// unload until construction returns; production paths should pass a manager-acquired ModelSessionLease.
+  EmbeddingsSession(const fl::Model& catalog_model, GenAIModelInstance& model, ILogger& logger,
+                    ITelemetry& telemetry)
+      : EmbeddingsSession(catalog_model, ModelSessionLease::Adopt(model), logger, telemetry) {}
+
+  /// Construction from a lease acquired atomically against unload (Session::Create).
+  EmbeddingsSession(const fl::Model& catalog_model, ModelSessionLease lease, ILogger& logger,
+                    ITelemetry& telemetry)
+      : Session(MakeSessionRuntime<EmbeddingsRuntime>(catalog_model, std::move(lease), logger, telemetry)) {}
+
+  EmbeddingsSession(EmbeddingsSession&&) noexcept = default;
+  EmbeddingsSession& operator=(EmbeddingsSession&&) = delete;
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/genai_model_instance.h
+++ b/sdk_v2/cpp/src/inferencing/generative/genai_model_instance.h
@@ -9,6 +9,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -22,8 +23,13 @@ namespace fl {
 
 /// A model that has been loaded into the ORT GenAI runtime.
 /// Owns the OgaModel, OgaTokenizer, and optional OgaMultiModalProcessor.
-/// Non-copyable, non-movable. Owned by ModelLoadManager via std::unique_ptr.
-class GenAIModelInstance {
+/// Non-copyable, non-movable. Owned by ModelLoadManager via std::shared_ptr.
+///
+/// The instance doubles as the *shared lease entry*: it carries the live-session count together with the
+/// mutex and condition variable that signal its release. A ModelSessionLease holds a strong shared_ptr to
+/// it, so a lease that outlives the ModelLoadManager still releases correctly against storage it owns a
+/// reference to, with no manager back-pointer involved.
+class GenAIModelInstance : public std::enable_shared_from_this<GenAIModelInstance> {
  public:
   ~GenAIModelInstance();
   GenAIModelInstance(const GenAIModelInstance&) = delete;
@@ -39,7 +45,9 @@ class GenAIModelInstance {
 
   /// Access the underlying OGA objects (for future chat generation work).
   OgaModel& GetOgaModel();
-  OgaTokenizer& GetOgaTokenizerWithSpecial();  // For tool calling, we need a tokenizer that does not skip special tokens.
+
+  /// Tool calling needs a tokenizer that does not skip special tokens.
+  OgaTokenizer& GetOgaTokenizerWithSpecial();
 
   /// The model's tokenizer, shared across all concurrent sessions of this model. Encode operations are
   /// synchronized internally; callers use it without needing to know it is shared. See fl::Tokenizer.
@@ -54,12 +62,40 @@ class GenAIModelInstance {
   /// Get the last-activity timestamp.
   std::chrono::steady_clock::time_point LastActivity() const { return last_activity_; }
 
-  /// Live-session reference counting. Sessions call AcquireSession() on construction and
-  /// ReleaseSession() on destruction; ModelLoadManager::UnloadModel refuses to unload
-  /// while the count is > 0 to prevent use-after-free of the OGA objects.
-  void AcquireSession() { session_ref_count_.fetch_add(1, std::memory_order_acq_rel); }
-  void ReleaseSession() { session_ref_count_.fetch_sub(1, std::memory_order_acq_rel); }
-  int SessionRefCount() const { return session_ref_count_.load(std::memory_order_acquire); }
+  /// Live-session reference counting. Taken and released exclusively through ModelSessionLease;
+  /// ModelLoadManager::UnloadModel refuses to unload while the count is > 0 to prevent use-after-free of the
+  /// OGA objects.
+  ///
+  /// Guarded by this instance's own mutex rather than being a bare atomic, so a release can wake
+  /// WaitForNoSessions() with no lost-wakeup window and the shutdown drain can block on a condition variable
+  /// instead of polling. The mutex and CV live here, on the shared entry, precisely so a lease that outlives
+  /// the ModelLoadManager never has to reach back through a manager pointer.
+  void AcquireSession() {
+    std::lock_guard<std::mutex> lock(session_mu_);
+    ++session_ref_count_;
+  }
+
+  void ReleaseSession() {
+    {
+      std::lock_guard<std::mutex> lock(session_mu_);
+      if (session_ref_count_ > 0) {
+        --session_ref_count_;
+      }
+    }
+
+    session_idle_cv_.notify_all();
+  }
+
+  int SessionRefCount() const {
+    std::lock_guard<std::mutex> lock(session_mu_);
+    return session_ref_count_;
+  }
+
+  /// Block until no lease references this model, or `deadline` passes. Returns true if it drained.
+  bool WaitForNoSessions(std::chrono::steady_clock::time_point deadline) const {
+    std::unique_lock<std::mutex> lock(session_mu_);
+    return session_idle_cv_.wait_until(lock, deadline, [this] { return session_ref_count_ == 0; });
+  }
 
  private:
   friend class ModelLoadManager;
@@ -81,7 +117,9 @@ class GenAIModelInstance {
   std::vector<int32_t> eos_token_ids_;                 // cached; populated on first GetEosTokenIds() call
   std::once_flag eos_token_ids_init_flag_;
   std::chrono::steady_clock::time_point last_activity_;
-  mutable std::atomic<int> session_ref_count_{0};
+  mutable std::mutex session_mu_;
+  mutable std::condition_variable session_idle_cv_;
+  int session_ref_count_ = 0;
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/model_load_manager.cc
+++ b/sdk_v2/cpp/src/inferencing/model_load_manager.cc
@@ -11,7 +11,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fmt/format.h>
-#include <thread>
+#include <utility>
 
 namespace fl {
 
@@ -47,7 +47,76 @@ std::string_view RequiredEpForModelId(std::string_view model_id) {
   return {};
 }
 
+#ifdef _WIN32
+/// SetDllDirectoryW is process-global. Every ModelLoadManager instance shares this lock so EP preparation
+/// cannot redirect another concurrent OGA model construction. The manager map mutex is never held here.
+std::unique_lock<std::mutex> AcquireModelEpLifecycleLock() {
+  static std::mutex lifecycle_mutex;
+  return std::unique_lock<std::mutex>(lifecycle_mutex);
+}
+#else
+/// Model/EP construction does not mutate a process-global loader path on POSIX, so it remains parallel.
+struct ModelEpLifecycleLock {};
+
+ModelEpLifecycleLock AcquireModelEpLifecycleLock() {
+  return {};
+}
+#endif
+
 }  // namespace
+
+class ModelLoadManager::LoadCallGuard {
+ public:
+  LoadCallGuard(ModelLoadManager& manager, const std::string& id) : manager_(manager), id_(id) {
+    std::lock_guard<std::mutex> lock(manager_.mutex_);
+    if (!manager_.admission_closed_) {
+      ++manager_.active_load_ids_[id_];
+      ++manager_.active_load_calls_;
+      admitted_ = true;
+    }
+  }
+
+  ~LoadCallGuard() {
+    if (admitted_) {
+      manager_.ReleaseLoadCall(id_, reserved_);
+    }
+  }
+
+  LoadCallGuard(const LoadCallGuard&) = delete;
+  LoadCallGuard& operator=(const LoadCallGuard&) = delete;
+
+  bool IsAdmitted() const noexcept { return admitted_; }
+  void MarkReserved() noexcept { reserved_ = true; }
+
+ private:
+  ModelLoadManager& manager_;
+  const std::string& id_;
+  bool admitted_ = false;
+  bool reserved_ = false;
+};
+
+class ModelLoadManager::UnloadReservationGuard {
+ public:
+  UnloadReservationGuard() = default;
+
+  ~UnloadReservationGuard() {
+    if (manager_ != nullptr) {
+      manager_->ReleaseUnloadReservation(*id_);
+    }
+  }
+
+  UnloadReservationGuard(const UnloadReservationGuard&) = delete;
+  UnloadReservationGuard& operator=(const UnloadReservationGuard&) = delete;
+
+  void Engage(ModelLoadManager& manager, const std::string& id) noexcept {
+    manager_ = &manager;
+    id_ = &id;
+  }
+
+ private:
+  ModelLoadManager* manager_ = nullptr;
+  const std::string* id_ = nullptr;
+};
 
 // ---------------------------------------------------------------------------
 // Construction / Destruction
@@ -56,10 +125,71 @@ std::string_view RequiredEpForModelId(std::string_view model_id) {
 ModelLoadManager::ModelLoadManager(IEpDetector& ep_detector, ILogger& logger)
     : ep_detector_(ep_detector), logger_(logger) {}
 
-ModelLoadManager::~ModelLoadManager() {
-  // Destroy all loaded models under the lock.
-  std::lock_guard<std::mutex> lock(mutex_);
-  loaded_models_.clear();
+ModelLoadManager::~ModelLoadManager() noexcept {
+  // Load and unload-reservation guards reference this manager's mutex/CV/sets. Closing and draining first
+  // guarantees every guard has released those references before member destruction begins, including during
+  // partial Manager teardown.
+  CloseLoadAdmission();
+  DrainModelLifecycleWork();
+
+  // Detach the entries under the lock, destroy them outside it. Releasing OGA objects is slow and can call
+  // back into logging; it must never run with this manager's mutex held. Any entry still referenced by an
+  // outstanding ModelSessionLease simply survives here and dies with that lease.
+  std::map<std::string, std::shared_ptr<GenAIModelInstance>> detached;
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    detached.swap(loaded_models_);
+  }
+}
+
+void ModelLoadManager::ReleaseLoadCall(const std::string& id, bool reserved) noexcept {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (reserved) {
+      loading_ids_.erase(id);
+    }
+
+    if (auto it = active_load_ids_.find(id); it != active_load_ids_.end()) {
+      if (it->second > 1) {
+        --it->second;
+      } else {
+        active_load_ids_.erase(it);
+      }
+    }
+
+    if (active_load_calls_ > 0) {
+      --active_load_calls_;
+    }
+  }
+
+  load_cv_.notify_all();
+}
+
+void ModelLoadManager::ReleaseUnloadReservation(const std::string& id) noexcept {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    unloading_ids_.erase(id);
+  }
+
+  load_cv_.notify_all();
+}
+
+void ModelLoadManager::CloseLoadAdmission() {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    admission_closed_ = true;
+  }
+
+  // Wake same-ID waiters so they observe closure and release their admitted-call guards.
+  load_cv_.notify_all();
+}
+
+void ModelLoadManager::DrainModelLifecycleWork() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  load_cv_.wait(lock, [this] {
+    return active_load_calls_ == 0 && unloading_ids_.empty();
+  });
 }
 
 bool ModelLoadManager::HasEP(const std::string& ep_name) const {
@@ -80,21 +210,49 @@ bool ModelLoadManager::HasEP(const std::string& ep_name) const {
 ModelLoadManager::LoadResult ModelLoadManager::LoadModel(std::string_view model_path,
                                                          std::string_view model_id,
                                                          ExecutionProvider ep_override) {
-  if (shutdown_.load()) {
-    FL_LOG_AND_THROW(logger_, FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
-                     "cannot load model during shutdown");
-  }
-
   // Convert to std::string for map operations and string concatenation
   std::string path_str(model_path);
   std::string id_str(model_id);
-  std::lock_guard<std::mutex> lock(mutex_);
 
-  // Check if model is already loaded
-  auto it = loaded_models_.find(id_str);
-  if (it != loaded_models_.end()) {
-    return {LoadStatus::kModelAlreadyLoaded, it->second.get()};
+  LoadCallGuard load_call(*this, id_str);
+  if (!load_call.IsAdmitted()) {
+    FL_LOG_AND_THROW(logger_, FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "cannot load model during shutdown");
   }
+
+  // Phase 1 — reserve under the lock. Re-check shutdown and the loaded map on every wakeup: a concurrent load
+  // of the same ID either publishes it (we then return kModelAlreadyLoaded) or fails and releases its
+  // reservation (we then take the load over ourselves). No filesystem, config, EP or model-construction work
+  // happens here — the lock only bookkeeps the reservation.
+  GenAIModelInstance* existing_model = nullptr;
+  bool shutdown_rejected = false;
+
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    load_cv_.wait(lock, [&] {
+      return admission_closed_ || loaded_models_.contains(id_str) ||
+             (!loading_ids_.contains(id_str) && !unloading_ids_.contains(id_str));
+    });
+
+    if (admission_closed_) {
+      shutdown_rejected = true;
+    } else if (auto it = loaded_models_.find(id_str); it != loaded_models_.end()) {
+      existing_model = it->second.get();
+    } else {
+      loading_ids_.insert(id_str);
+      load_call.MarkReserved();
+    }
+  }
+
+  if (shutdown_rejected) {
+    FL_LOG_AND_THROW(logger_, FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "cannot load model during shutdown");
+  }
+
+  if (existing_model != nullptr) {
+    return {LoadStatus::kModelAlreadyLoaded, existing_model};
+  }
+
+  // Phase 2 — the heavy work, with no lock held.
 
   // Validate model directory exists
   if (!std::filesystem::exists(path_str) || !std::filesystem::is_directory(path_str)) {
@@ -146,23 +304,51 @@ ModelLoadManager::LoadResult ModelLoadManager::LoadModel(std::string_view model_
                      " which is not registered. Call DownloadAndRegisterEps() first.");
   }
 
-  if (!required_ep.empty() && !ep_detector_.PrepareForModelLoad(required_ep)) {
-    FL_LOG_AND_THROW(logger_, FOUNDRY_LOCAL_ERROR_INTERNAL,
-                     "failed to prepare ", required_ep, " for model loading");
+  std::shared_ptr<GenAIModelInstance> loaded;
+  {
+    // Windows EP bootstrappers redirect the process-global DLL search path. Serialize that preparation with
+    // every OGA model construction, including CPU/default construction that could otherwise observe another
+    // load's temporary path. This is deliberately outside mutex_; POSIX receives a no-op guard.
+    [[maybe_unused]] auto lifecycle_lock = AcquireModelEpLifecycleLock();
+
+    if (!required_ep.empty() && !ep_detector_.PrepareForModelLoad(required_ep)) {
+      FL_LOG_AND_THROW(logger_, FOUNDRY_LOCAL_ERROR_INTERNAL,
+                       "failed to prepare ", required_ep, " for model loading");
+    }
+
+    // std::make_shared cannot access the private constructor; using new directly is intentional.
+    loaded.reset(new GenAIModelInstance(id_str, path_str, std::move(genai_config), resolved_ep, logger_));
   }
 
-  // std::make_unique cannot access the private constructor; using new directly is intentional.
-  auto loaded = std::unique_ptr<GenAIModelInstance>(new GenAIModelInstance(id_str,
-                                                                           path_str,
-                                                                           std::move(genai_config),
-                                                                           resolved_ep,
-                                                                           logger_));
+  // Phase 3 — publish under the lock. Re-check shutdown: it may have begun while we were loading outside the
+  // lock, and a model must not be published into a shutting-down manager.
+  GenAIModelInstance* raw_ptr = nullptr;
+  LoadStatus publish_status = LoadStatus::kSuccess;
 
-  auto* raw_ptr = loaded.get();
-  loaded_models_[id_str] = std::move(loaded);
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!admission_closed_) {
+      // Keep the local strong reference until after unlock. Even if map insertion throws or unexpectedly finds
+      // an existing key, destruction of the newly built engine can therefore happen only outside mutex_.
+      const auto [it, inserted] = loaded_models_.emplace(id_str, loaded);
+      raw_ptr = it->second.get();
+      publish_status = inserted ? LoadStatus::kSuccess : LoadStatus::kModelAlreadyLoaded;
+    }
+  }
 
-  logger_.Log(LogLevel::Information, fmt::format("model loaded successfully: {}", id_str));
-  return {LoadStatus::kSuccess, raw_ptr};
+  // The map owns a reference on success; on rejection (or the defensive already-loaded case) this is the
+  // point where the newly built engine is torn down, with no manager lock held.
+  loaded.reset();
+
+  if (raw_ptr != nullptr) {
+    if (publish_status == LoadStatus::kSuccess) {
+      logger_.Log(LogLevel::Information, fmt::format("model loaded successfully: {}", id_str));
+    }
+
+    return {publish_status, raw_ptr};
+  }
+
+  FL_LOG_AND_THROW(logger_, FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "cannot load model during shutdown");
 }
 
 // ---------------------------------------------------------------------------
@@ -170,20 +356,54 @@ ModelLoadManager::LoadResult ModelLoadManager::LoadModel(std::string_view model_
 // ---------------------------------------------------------------------------
 
 bool ModelLoadManager::UnloadModel(std::string_view model_id) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  const std::string id_str(model_id);
 
-  std::string id_str(model_id);
-  auto it = loaded_models_.find(id_str);
-  if (it == loaded_models_.end()) {
+  enum class Decision {
+    kNotLoaded,
+    kInUse,
+    kDetached,
+  };
+
+  Decision decision = Decision::kNotLoaded;
+  int live_sessions = 0;
+
+  // Declared before detached so its destructor runs afterwards: the unload reservation stays engaged until
+  // physical engine teardown has completed outside mutex_.
+  UnloadReservationGuard unload_reservation;
+  std::shared_ptr<GenAIModelInstance> detached;
+
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    // Wait for the construction owner and every same-ID caller already admitted behind it. Once this predicate
+    // wins while holding mutex_, a later LoadModel either linearizes after this detach or completes before it.
+    load_cv_.wait(lock, [&] {
+      return !active_load_ids_.contains(id_str) && !unloading_ids_.contains(id_str);
+    });
+
+    auto it = loaded_models_.find(id_str);
+    if (it != loaded_models_.end()) {
+      // Manager mutex -> model session mutex is the one allowed nested order. Lease release takes only the
+      // model mutex, so there is no inverse path.
+      live_sessions = it->second->SessionRefCount();
+      if (live_sessions > 0) {
+        decision = Decision::kInUse;
+      } else {
+        unloading_ids_.insert(id_str);
+        unload_reservation.Engage(*this, id_str);
+        detached = std::move(it->second);
+        loaded_models_.erase(it);
+        decision = Decision::kDetached;
+      }
+    }
+  }
+
+  if (decision == Decision::kNotLoaded) {
     logger_.Log(LogLevel::Information, fmt::format("model was not loaded: {}", id_str));
     return false;
   }
 
-  // Refuse to unload while sessions hold the instance — the OGA objects must outlive
-  // every session that referenced them. Asking to unload an in-use model is a caller
-  // contract violation, not a recoverable state.
-  auto live_sessions = it->second->SessionRefCount();
-  if (live_sessions > 0) {
+  if (decision == Decision::kInUse) {
     FL_LOG_AND_THROW(logger_, FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
                      "cannot unload model '", id_str, "': ", live_sessions,
                      " session(s) still using it");
@@ -191,25 +411,26 @@ bool ModelLoadManager::UnloadModel(std::string_view model_id) {
 
   logger_.Log(LogLevel::Information, fmt::format("unloading model: {}", id_str));
 
-  // Erasing destroys the GenAIModelInstance, which destroys OGA objects in reverse order.
-  loaded_models_.erase(it);
+  // `detached` dies here: the GenAIModelInstance destructor releases OGA objects in reverse order, with no
+  // manager lock held.
   return true;
 }
 
-void ModelLoadManager::RejectNewLoads() {
-  shutdown_.store(true);
-}
-
 void ModelLoadManager::UnloadAll(std::chrono::milliseconds timeout) {
-  // Snapshot ids+pointers under the lock; the GenAIModelInstance pointers stay valid
-  // because (a) only this method or UnloadModel can erase entries, and (b) we serialize
-  // the per-id erase below.
-  std::vector<std::pair<std::string, GenAIModelInstance*>> snapshot;
+  // This method is safe as the first shutdown call: close admission and wait until every admitted loader or
+  // same-ID waiter has left before taking a model snapshot.
+  CloseLoadAdmission();
+  DrainModelLifecycleWork();
+
+  // Snapshot *strong* entry references, not raw pointers: each entry now stays alive for as long as this
+  // snapshot holds it, so waiting on its condition variable can never race the entry's destruction.
+  std::vector<std::pair<std::string, std::shared_ptr<GenAIModelInstance>>> snapshot;
+
   {
     std::lock_guard<std::mutex> lock(mutex_);
     snapshot.reserve(loaded_models_.size());
-    for (auto& [id, instance] : loaded_models_) {
-      snapshot.emplace_back(id, instance.get());
+    for (const auto& [id, instance] : loaded_models_) {
+      snapshot.emplace_back(id, instance);
     }
   }
 
@@ -217,40 +438,61 @@ void ModelLoadManager::UnloadAll(std::chrono::milliseconds timeout) {
     return;
   }
 
-  logger_.Log(LogLevel::Information,
-              fmt::format("Shutdown: unloading {} model(s)", snapshot.size()));
+  logger_.Log(LogLevel::Information, fmt::format("Shutdown: unloading {} model(s)", snapshot.size()));
 
-  using clock = std::chrono::steady_clock;
-  constexpr auto kPollInterval = std::chrono::milliseconds(50);
+  // One overall deadline shared across all models: shutdown stays bounded regardless of how many models are
+  // loaded, and a stuck caller on one model cannot extend total drain time linearly with model count.
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
 
-  // Overall deadline shared across all models — shutdown must be bounded regardless of
-  // how many models are loaded. A stuck caller on one model shouldn't extend total drain
-  // time linearly with model count.
-  auto deadline = clock::now() + timeout;
+  // Entries detached from the map here and destroyed at the end of the function, outside the manager lock.
+  std::vector<std::shared_ptr<GenAIModelInstance>> detached;
+  detached.reserve(snapshot.size());
+  std::vector<std::string> unloaded_ids;
+  unloaded_ids.reserve(snapshot.size());
 
   for (auto& [id, instance] : snapshot) {
-    while (instance->SessionRefCount() > 0 && clock::now() < deadline) {
-      std::this_thread::sleep_for(kPollInterval);
-    }
-
-    auto remaining = instance->SessionRefCount();
-    if (remaining > 0) {
+    // Blocks on the entry's own CV instead of polling; a lease release wakes it immediately.
+    if (!instance->WaitForNoSessions(deadline)) {
       logger_.Log(LogLevel::Warning,
-                  fmt::format("Shutdown: model '{}' still has {} session(s) after overall {}ms deadline; leaving loaded",
-                              id, remaining, timeout.count()));
+                  fmt::format("Shutdown: model '{}' still has {} session(s) after overall {}ms deadline; "
+                              "leaving loaded",
+                              id, instance->SessionRefCount(), timeout.count()));
       continue;
     }
 
-    try {
-      UnloadModel(id);
-    } catch (const std::exception& ex) {
-      // A new session attached between our refcount poll and the lock acquisition inside
-      // UnloadModel. Log and move on — IsShutdownRequested-gated callers shouldn't be
-      // creating new sessions, but we don't crash shutdown over it.
+    int rechecked_sessions = 0;
+    bool did_detach = false;
+
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      auto it = loaded_models_.find(id);
+
+      // Re-check identity and lease count atomically against AcquireLoadedModel. Manager mutex -> model session
+      // mutex is intentional and consistent with UnloadModel/AcquireLoadedModel.
+      if (it != loaded_models_.end() && it->second.get() == instance.get()) {
+        rechecked_sessions = it->second->SessionRefCount();
+        if (rechecked_sessions == 0) {
+          detached.push_back(std::move(it->second));
+          loaded_models_.erase(it);
+          did_detach = true;
+        }
+      }
+    }
+
+    if (did_detach) {
+      unloaded_ids.push_back(id);
+    } else if (rechecked_sessions > 0) {
       logger_.Log(LogLevel::Warning,
-                  fmt::format("Shutdown: failed to unload '{}': {}", id, ex.what()));
+                  fmt::format("Shutdown: model '{}' acquired {} session(s) during drain; leaving loaded",
+                              id, rechecked_sessions));
     }
   }
+
+  for (const auto& id : unloaded_ids) {
+    logger_.Log(LogLevel::Information, fmt::format("unloading model: {}", id));
+  }
+
+  // `detached` and `snapshot` die here — every GenAIModelInstance destructor runs with no manager lock held.
 }
 
 // ---------------------------------------------------------------------------
@@ -260,13 +502,34 @@ void ModelLoadManager::UnloadAll(std::chrono::milliseconds timeout) {
 GenAIModelInstance* ModelLoadManager::GetLoadedModel(std::string_view model_id) {
   std::lock_guard<std::mutex> lock(mutex_);
 
-  std::string id_str(model_id);
+  const std::string id_str(model_id);
   auto it = loaded_models_.find(id_str);
   if (it != loaded_models_.end()) {
     return it->second.get();
   }
 
   return nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// AcquireLoadedModel
+// ---------------------------------------------------------------------------
+
+std::optional<ModelSessionLease> ModelLoadManager::AcquireLoadedModel(std::string_view model_id) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Shutdown check, loaded check and lease increment are one critical section. UnloadModel takes the same
+  // mutex before it inspects the lease count, so the two can never interleave into "unloaded but leased".
+  if (admission_closed_) {
+    return std::nullopt;
+  }
+
+  auto it = loaded_models_.find(std::string(model_id));
+  if (it == loaded_models_.end()) {
+    return std::nullopt;
+  }
+
+  return ModelSessionLease(it->second);
 }
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/model_load_manager.h
+++ b/sdk_v2/cpp/src/inferencing/model_load_manager.h
@@ -4,14 +4,18 @@
 
 #include "inferencing/execution_provider.h"
 #include "inferencing/generative/genai_model_instance.h"
+#include "inferencing/model_session_lease.h"
 #include "logger.h"
 #include "ep_detection/ep_detector.h"
 
-#include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
+#include <set>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -19,13 +23,18 @@
 namespace fl {
 
 /// Manages the lifecycle of loaded ORT GenAI models.
-/// Thread-safe. Owns all GenAIModelInstance instances.
+/// Thread-safe. Owns all GenAIModelInstance entries through shared_ptr.
 ///
-/// Returned GenAIModelInstance pointers are non-owning and valid only while the
-/// model remains loaded. The caller must ensure the model is not unloaded (via
-/// UnloadModel) while the pointer is in use. In practice, the Manager serializes
-/// load/unload operations through the web service, so concurrent unload during
-/// active inference does not occur.
+/// Two ways to reach a loaded model, and only one of them is lifetime-safe:
+///
+///   - GetLoadedModel() returns a *non-owning* pointer valid only while the model stays loaded. It exists
+///     for callers that merely inspect the instance.
+///   - AcquireLoadedModel() returns a ModelSessionLease. The shutdown check, the loaded check and the lease
+///     increment all happen inside one critical section here, so a model cannot be unloaded between "it is
+///     loaded" and "I hold a reference to it". This is what every session runtime uses.
+///
+/// UnloadModel refuses while any lease is outstanding and always destroys the entry *outside* this manager's
+/// mutex, so releasing OGA objects never runs under a lock a concurrent loader could be waiting on.
 class ModelLoadManager {
  public:
   enum class LoadStatus {
@@ -40,7 +49,7 @@ class ModelLoadManager {
   };
 
   ModelLoadManager(IEpDetector& ep_detector, ILogger& logger);
-  ~ModelLoadManager();
+  ~ModelLoadManager() noexcept;
 
   ModelLoadManager(const ModelLoadManager&) = delete;
   ModelLoadManager& operator=(const ModelLoadManager&) = delete;
@@ -64,12 +73,24 @@ class ModelLoadManager {
   bool UnloadModel(std::string_view model_id);
 
   /// Get a loaded model by ID. Returns nullptr if not loaded.
-  /// The returned pointer is valid until UnloadModel is called for this model_id.
+  /// The returned pointer is valid until UnloadModel is called for this model_id. Prefer
+  /// AcquireLoadedModel() whenever the caller intends to *use* the model.
   GenAIModelInstance* GetLoadedModel(std::string_view model_id);
 
-  /// Reject all future LoadModel calls. Called by Manager::Shutdown().
-  /// Idempotent and thread-safe.
-  void RejectNewLoads();
+  /// Take a lease on a loaded model. Returns nullopt while shutting down or when the model is not loaded.
+  ///
+  /// The check and the increment are one critical section: an UnloadModel racing this call either observes
+  /// the lease (and refuses) or completes before the lease is taken (and this returns nullopt). The returned
+  /// lease keeps the entry alive on its own, so it stays valid even if this manager is destroyed.
+  [[nodiscard]] std::optional<ModelSessionLease> AcquireLoadedModel(std::string_view model_id);
+
+  /// Close load admission and wake same-ID waiters. Non-blocking apart from taking the bookkeeping mutex;
+  /// already-admitted model lifecycle work continues until DrainModelLifecycleWork().
+  void CloseLoadAdmission();
+
+  /// Wait until every LoadModel call admitted before closure and every already-detached model teardown has
+  /// returned. Call CloseLoadAdmission() first. Idempotent and thread-safe.
+  void DrainModelLifecycleWork();
 
   /// Unload every loaded model, waiting for live sessions to finish.
   /// Called by Manager::Shutdown after the session manager has cancelled HTTP-tracked
@@ -83,13 +104,37 @@ class ModelLoadManager {
   void UnloadAll(std::chrono::milliseconds timeout = std::chrono::seconds(10));
 
  private:
+  class LoadCallGuard;
+  class UnloadReservationGuard;
+
   bool HasEP(const std::string& ep_name) const;
+  void ReleaseLoadCall(const std::string& id, bool reserved) noexcept;
+  void ReleaseUnloadReservation(const std::string& id) noexcept;
 
   IEpDetector& ep_detector_;
   ILogger& logger_;
-  std::atomic<bool> shutdown_{false};
   mutable std::mutex mutex_;
-  std::map<std::string, std::unique_ptr<GenAIModelInstance>> loaded_models_;
+
+  /// Guarded admission state. active_load_calls_ includes reservation owners and same-ID waiters admitted
+  /// before closure, so manager destruction can wait until no LoadModel stack still references manager fields.
+  /// active_load_ids_ provides the corresponding per-ID drain used by UnloadModel.
+  bool admission_closed_ = false;
+  size_t active_load_calls_ = 0;
+  std::map<std::string, size_t> active_load_ids_;
+
+  /// IDs currently being loaded. A load reserves its ID under mutex_ before doing the heavy filesystem /
+  /// config / EP / model-construction work *outside* the lock, then publishes under mutex_. A concurrent
+  /// LoadModel for the same ID waits on load_cv_ until the reservation is released rather than duplicating the
+  /// work (or racing to insert two instances for the same ID).
+  std::set<std::string> loading_ids_;
+  /// IDs detached by UnloadModel whose engine teardown is still running outside mutex_. A same-ID reload
+  /// waits until teardown completes rather than constructing a replacement concurrently.
+  std::set<std::string> unloading_ids_;
+  std::condition_variable load_cv_;
+
+  /// Shared, stable entries. Held by shared_ptr so an outstanding ModelSessionLease keeps the OGA objects
+  /// alive independently of this map — and independently of this manager.
+  std::map<std::string, std::shared_ptr<GenAIModelInstance>> loaded_models_;
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/model_session_lease.h
+++ b/sdk_v2/cpp/src/inferencing/model_session_lease.h
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include "inferencing/generative/genai_model_instance.h"
+
+#include <memory>
+#include <utility>
+
+namespace fl {
+
+/// Move-only lease on a loaded model, held for the whole lifetime of a SessionRuntime.
+///
+/// Two lifetime properties matter and neither is negotiable:
+///
+///  1. The lease holds a *strong* reference to the shared model entry, so it can outlive the
+///     ModelLoadManager that handed it out without ever dereferencing a manager pointer. A lease carrying a
+///     raw manager back-pointer could not make that claim.
+///  2. The reference count, its mutex and the condition variable that signals release all live on the entry,
+///     so the unload drain waits on storage the waiter itself holds a reference to.
+///
+/// Acquisition through ModelLoadManager::AcquireLoadedModel() performs the shutdown check, the loaded check
+/// and the increment inside one manager critical section, closing the window where a model could be unloaded
+/// between "it is loaded" and "I hold a reference to it".
+class ModelSessionLease {
+ public:
+  ModelSessionLease() = default;
+
+  /// Take a lease on an already-pinned instance. This compatibility path is for synchronized internal/test
+  /// construction only: the caller must already exclude unload until this function has promoted the model's
+  /// shared owner. Production creation uses ModelLoadManager::AcquireLoadedModel(), whose loaded-state check
+  /// and lease increment are atomic against unload.
+  static ModelSessionLease Adopt(GenAIModelInstance& model) {
+    return ModelSessionLease(model.shared_from_this());
+  }
+
+  ~ModelSessionLease() noexcept {
+    Release();
+  }
+
+  ModelSessionLease(ModelSessionLease&& other) noexcept : entry_(std::move(other.entry_)) {
+    other.entry_.reset();
+  }
+
+  ModelSessionLease& operator=(ModelSessionLease&& other) noexcept {
+    if (this != &other) {
+      Release();
+      entry_ = std::move(other.entry_);
+      other.entry_.reset();
+    }
+
+    return *this;
+  }
+
+  ModelSessionLease(const ModelSessionLease&) = delete;
+  ModelSessionLease& operator=(const ModelSessionLease&) = delete;
+
+  /// True while this lease pins a model. A model-free runtime (unit tests) holds an empty lease.
+  explicit operator bool() const noexcept { return entry_ != nullptr; }
+
+  /// The leased model. Only valid while the lease is engaged.
+  GenAIModelInstance& Model() const { return *entry_; }
+
+ private:
+  friend class ModelLoadManager;
+
+  explicit ModelSessionLease(std::shared_ptr<GenAIModelInstance> entry) : entry_(std::move(entry)) {
+    if (entry_) {
+      entry_->AcquireSession();
+    }
+  }
+
+  void Release() noexcept {
+    if (entry_) {
+      // Touches only the entry's own mutex and CV — never the manager, which may already be gone.
+      entry_->ReleaseSession();
+      entry_.reset();
+    }
+  }
+
+  std::shared_ptr<GenAIModelInstance> entry_;
+};
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/callback_handler.h
+++ b/sdk_v2/cpp/src/inferencing/session/callback_handler.h
@@ -1,15 +1,18 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #pragma once
 
 #include <cassert>
+#include <condition_variable>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <thread>
 
 #include <fmt/format.h>
 #include <foundry_local/foundry_local_c.h>
 
+#include "inferencing/session/operation_context.h"
 #include "inferencing/session/request.h"
 #include "items/item_queue.h"
 #include "logger.h"
@@ -18,30 +21,42 @@ namespace fl {
 
 /// Per-request streaming callback handler.
 ///
-/// Created by Session::CreateCallbackHandler() at the start of ProcessRequestImpl
-/// and destroyed (via unique_ptr) when ProcessRequestImpl returns.
+/// Created by SessionRuntime::CreateCallbackHandler() at the start of ProcessRequestImpl and destroyed (via
+/// unique_ptr) when ProcessRequestImpl returns — which is strictly inside the lifetime of the
+/// OperationContext it binds, so the worker thread can never outlive the state it stops.
 ///
-/// Items are pushed to the ItemQueue on the caller's thread (preserving
-/// generation order). A single worker thread pops items and fires the
-/// user callback. This decouples token generation from callback speed
-/// while guaranteeing delivery order.
+/// Items are pushed to the ItemQueue on the caller's thread (preserving generation order). A single worker
+/// thread pops items and fires the user callback. This decouples token generation from callback speed while
+/// guaranteeing delivery order.
 ///
-/// The Request reference is bound at construction — no need to pass it per push.
-/// Destruction drains the queue and joins the worker thread (RAII).
+/// Cancellation: a callback returning non-zero (or throwing) stops **this exact operation** with
+/// StopReason::kCallbackStop. That reaches the engine like any other stop, but Session::ProcessRequest maps
+/// it to a normal completion with FOUNDRY_LOCAL_FINISH_NONE, preserving the established streaming/SSE
+/// semantics where a client hanging up is not an error.
+///
+/// Quiesce() is the seal's precondition: it waits until everything pushed so far has been delivered and no
+/// callback invocation is in flight, *without* finishing the queue or joining the worker, so the caller can
+/// still push a final chunk after the outcome is committed. Destruction drains the queue and joins (RAII).
 struct CallbackHandler {
   using CallbackFn = std::function<int(flStreamingCallbackData, void*)>;
 
-  CallbackHandler(const Request& request, CallbackFn callback_fn, ILogger& logger,
+  /// Production constructor: bound to the operation driving the run.
+  CallbackHandler(const OperationContext& operation, CallbackFn callback_fn, ILogger& logger,
                   void* user_data = nullptr)
-      : request_(request),
+      : operation_(&operation), fn_(std::move(callback_fn)), user_data_(user_data), logger_(logger) {
+    Start();
+  }
+
+  /// Request-only constructor for direct-Request coverage that has no operation (no runtime run). It
+  /// latches the Request's diagnostic flag instead of stopping an operation, and is never used in
+  /// production — every production handler is created through SessionRuntime::CreateCallbackHandler.
+  CallbackHandler(const Request& request, CallbackFn callback_fn, ILogger& logger, void* user_data = nullptr)
+      : request_control_(request.Control()),
         fn_(std::move(callback_fn)),
         user_data_(user_data),
-        logger_(logger),
-        queue_(std::make_unique<ItemQueue>()) {
-    assert(fn_ && "Streaming callback cannot be null");
-    data_.version = FOUNDRY_LOCAL_API_VERSION;
-    data_.item_queue = queue_->AsApiType();
-    worker_ = std::thread(&CallbackHandler::WorkerLoop, this);
+        logger_(logger) {
+    assert(request_control_ && "Request-only CallbackHandler requires a usable Request");
+    Start();
   }
 
   ~CallbackHandler() {
@@ -54,11 +69,37 @@ struct CallbackHandler {
   /// Push an item into the queue and wake the worker.
   /// Called from the generator thread — returns immediately.
   void PushItem(std::unique_ptr<Item> item) {
-    if (request_.canceled) {
+    if (Stopped()) {
       return;
     }
 
     queue_->Push(std::move(item));
+  }
+
+  /// Publish the already-prepared terminal envelope after the operation outcome is sealed.
+  ///
+  /// Unlike PushItem(), this deliberately bypasses the stop filter so a cancelled operation can still tell a
+  /// streaming consumer its truthful terminal finish reason. The item must be fully allocated before sealing.
+  /// Queue growth is the only remaining throwing step; terminal delivery is best-effort and cannot reopen a
+  /// sealed outcome, so allocation failure is contained here without logging or changing operation state.
+  void PushFinalItem(std::unique_ptr<Item> item) noexcept {
+    try {
+      queue_->Push(std::move(item));
+    } catch (...) {
+    }
+  }
+
+  /// Wait until every item pushed so far has been processed and no callback invocation is in flight.
+  ///
+  /// Deliberately does *not* mark the queue finished and does *not* join: the caller may still need to push
+  /// a final chunk once it has committed its outcome. The user callback is never invoked while the idle
+  /// mutex is held, so a callback that pushes or inspects state cannot deadlock against this wait.
+  ///
+  /// This is what makes a completion seal meaningful: after Quiesce() returns, no callback decision is
+  /// pending, so TrySeal() sees the final answer instead of racing a worker that is about to stop the run.
+  void Quiesce() {
+    std::unique_lock<std::mutex> lock(idle_mu_);
+    idle_cv_.wait(lock, [this] { return worker_done_ || (!in_callback_ && queue_->Size() == 0); });
   }
 
   /// Mark the queue as finished, wait for the worker to drain all
@@ -72,6 +113,64 @@ struct CallbackHandler {
   }
 
  private:
+  void Start() {
+    assert(fn_ && "Streaming callback cannot be null");
+    data_.version = FOUNDRY_LOCAL_API_VERSION;
+    data_.item_queue = queue_->AsApiType();
+    worker_ = std::thread(&CallbackHandler::WorkerLoop, this);
+  }
+
+  bool Stopped() const {
+    if (operation_ != nullptr) {
+      return operation_->ShouldStop();
+    }
+
+    // Only a moved-from Request lacks a control. The constructor asserts in debug builds; treating that
+    // invalid test-only shell as stopped keeps release builds from dereferencing null.
+    return !request_control_ ||
+           request_control_->Diagnostic(DiagnosticBit::kCancelled, std::memory_order_relaxed);
+  }
+
+  /// Ask the bound operation to stop because the consumer no longer wants the stream.
+  void RequestCallbackStop() {
+    if (operation_ != nullptr) {
+      operation_->RequestStop(StopReason::kCallbackStop);
+      return;
+    }
+
+    // Diagnostic-only fallback for the operation-less constructor. Uses the mirror write so it cannot
+    // recurse back through the cancel routing.
+    if (request_control_) {
+      request_control_->SetDiagnostic(DiagnosticBit::kCancelled, true, std::memory_order_relaxed);
+    }
+  }
+
+  void BeginCallback() {
+    std::lock_guard<std::mutex> lock(idle_mu_);
+    in_callback_ = true;
+  }
+
+  /// Publish "no callback in flight". Every caller latches the callback's stop decision *before* this, so a
+  /// Quiesce() that wakes here can never miss a stop the worker had already decided on.
+  void EndCallback() {
+    {
+      std::lock_guard<std::mutex> lock(idle_mu_);
+      in_callback_ = false;
+    }
+
+    idle_cv_.notify_all();
+  }
+
+  void MarkWorkerDone() {
+    {
+      std::lock_guard<std::mutex> lock(idle_mu_);
+      in_callback_ = false;
+      worker_done_ = true;
+    }
+
+    idle_cv_.notify_all();
+  }
+
   void WorkerLoop() {
     while (true) {
       queue_->WaitUntilNonEmptyOrFinished();
@@ -79,46 +178,64 @@ struct CallbackHandler {
       // Fire the callback for each available item.
       // The callback pops from the queue — that is the established contract.
       while (queue_->Size() > 0) {
+        BeginCallback();
+
         try {
           if (fn_(data_, user_data_) != 0) {
-            request_.canceled = true;
+            // Latch before publishing idle so Quiesce() cannot observe a quiet worker whose stop decision
+            // has not landed yet.
+            RequestCallbackStop();
           }
         } catch (const std::exception& e) {
-          logger_.Log(LogLevel::Warning,
-                      fmt::format("streaming callback threw an exception; cancelling request: {}",
-                                  e.what()));
           DisableAfterException();
+          MarkWorkerDone();
+          logger_.Log(LogLevel::Warning,
+                      fmt::format("streaming callback threw an exception; cancelling request: {}", e.what()));
           return;
         } catch (...) {
-          logger_.Log(LogLevel::Warning,
-                      "streaming callback threw a non-std exception; cancelling request");
           DisableAfterException();
+          MarkWorkerDone();
+          logger_.Log(LogLevel::Warning, "streaming callback threw a non-std exception; cancelling request");
           return;
         }
+
+        EndCallback();
       }
 
       // Exit once the queue is finished and fully drained.
       if (queue_->IsFinished()) {
+        MarkWorkerDone();
         return;
       }
     }
   }
 
-  /// Called from the worker thread after the user callback throws. Marks the request
-  /// cancelled (so PushItem becomes a no-op and the generator loop stops feeding work)
-  /// and drops any items still queued so the destructor can join cleanly.
+  /// Called from the worker thread after the user callback throws. Stops the operation (so PushItem becomes
+  /// a no-op and the generation loop stops feeding work) and drops any items still queued so the destructor
+  /// can join cleanly.
   void DisableAfterException() {
-    request_.canceled = true;
+    RequestCallbackStop();
+
     while (queue_->TryPop()) {
     }
   }
 
-  const Request& request_;
+  /// Production borrows the operation context, which outlives the drained worker. The request-only
+  /// compatibility path retains its stable control instead of borrowing Request storage.
+  const OperationContext* operation_ = nullptr;
+  std::shared_ptr<RequestControl> request_control_;
+
   CallbackFn fn_;
   void* user_data_;
   ILogger& logger_;
   flStreamingCallbackData data_{};
-  std::unique_ptr<ItemQueue> queue_;
+  std::unique_ptr<ItemQueue> queue_ = std::make_unique<ItemQueue>();
+
+  /// Idle accounting for Quiesce(). Never held while the user callback runs.
+  mutable std::mutex idle_mu_;
+  std::condition_variable idle_cv_;
+  bool in_callback_ = false;
+  bool worker_done_ = false;
 
   std::thread worker_;
 };

--- a/sdk_v2/cpp/src/inferencing/session/cancel_slot.cc
+++ b/sdk_v2/cpp/src/inferencing/session/cancel_slot.cc
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "inferencing/session/cancel_slot.h"
+
+#include <utility>
+
+namespace fl {
+
+// ===========================================================================
+// CancelLease
+// ===========================================================================
+
+CancelLease::CancelLease(std::shared_ptr<CancelSlot> slot, ICancellable* target) noexcept
+    : slot_(std::move(slot)), target_(target) {
+}
+
+CancelLease::~CancelLease() noexcept {
+  Release();
+}
+
+CancelLease::CancelLease(CancelLease&& other) noexcept
+    : slot_(std::move(other.slot_)), target_(std::exchange(other.target_, nullptr)) {
+}
+
+CancelLease& CancelLease::operator=(CancelLease&& other) noexcept {
+  if (this != &other) {
+    Release();
+    slot_ = std::move(other.slot_);
+    target_ = std::exchange(other.target_, nullptr);
+  }
+
+  return *this;
+}
+
+bool CancelLease::Cancel() const noexcept {
+  if (target_ != nullptr) {
+    // No slot lock, no operation lock, no session lock: this call reaches the inference engine.
+    return target_->Cancel();
+  }
+
+  return false;
+}
+
+void CancelLease::Release() noexcept {
+  if (target_ == nullptr) {
+    slot_.reset();
+    return;
+  }
+
+  target_ = nullptr;
+
+  // Keep the slot alive across the accounting: the waiter inside Withdraw() is woken while this reference
+  // still guarantees the slot's storage, and only then is the reference dropped.
+  const std::shared_ptr<CancelSlot> slot = std::move(slot_);
+  slot->ReleaseLease();
+}
+
+// ===========================================================================
+// CancelSlot
+// ===========================================================================
+
+std::shared_ptr<CancelSlot> CancelSlot::Create(ICancellable& target) {
+  return std::make_shared<CancelSlot>(PrivateTag{}, target);
+}
+
+CancelLease CancelSlot::Acquire() noexcept {
+  std::lock_guard<std::mutex> lock(mu_);
+  if (target_ == nullptr) {
+    return CancelLease{};
+  }
+
+  auto self = weak_from_this().lock();
+  if (!self) {
+    return CancelLease{};
+  }
+
+  ++active_leases_;
+  return CancelLease(std::move(self), target_);
+}
+
+void CancelSlot::Withdraw() noexcept {
+  std::unique_lock<std::mutex> lock(mu_);
+
+  // Null the target first, so every Acquire() from here on returns an empty lease. Only leases taken before
+  // this point can still be holding the generator, and those are exactly what the wait below drains.
+  target_ = nullptr;
+  idle_cv_.wait(lock, [this] { return active_leases_ == 0; });
+}
+
+size_t CancelSlot::OutstandingLeases() const {
+  std::lock_guard<std::mutex> lock(mu_);
+  return active_leases_;
+}
+
+void CancelSlot::ReleaseLease() noexcept {
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (active_leases_ > 0) {
+      --active_leases_;
+    }
+  }
+
+  idle_cv_.notify_all();
+}
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/cancel_slot.h
+++ b/sdk_v2/cpp/src/inferencing/session/cancel_slot.h
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include "inferencing/session/cancellable.h"
+
+#include <condition_variable>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+
+namespace fl {
+
+class CancelSlot;
+
+/// A short-lived, strong pin on a CancelSlot's target.
+///
+/// Holding a lease guarantees the target ICancellable is still alive and cannot be withdrawn: the slot's
+/// withdraw path nulls the target and then blocks until every outstanding lease has been released. The lease
+/// also keeps the slot itself alive, so a canceller never touches freed control storage even if the
+/// operation it belongs to finishes underneath it.
+///
+/// Cancel() is deliberately invoked *outside* every framework, operation, session and slot mutex: it reaches
+/// into the ORT GenAI engine (terminate_session), which must never run under a lock the inference thread can
+/// also be waiting on.
+class CancelLease {
+ public:
+  CancelLease() = default;
+  ~CancelLease() noexcept;
+
+  CancelLease(CancelLease&& other) noexcept;
+  CancelLease& operator=(CancelLease&& other) noexcept;
+
+  CancelLease(const CancelLease&) = delete;
+  CancelLease& operator=(const CancelLease&) = delete;
+
+  /// True when this lease actually pinned a live target.
+  explicit operator bool() const noexcept { return target_ != nullptr; }
+
+  /// Deliver the cancellation. Must be called with no mutex held. Returns true only when the live target
+  /// confirms that engine termination was delivered; returns false for an empty lease or a failed delivery.
+  [[nodiscard]] bool Cancel() const noexcept;
+
+ private:
+  friend class CancelSlot;
+
+  CancelLease(std::shared_ptr<CancelSlot> slot, ICancellable* target) noexcept;
+
+  void Release() noexcept;
+
+  std::shared_ptr<CancelSlot> slot_;
+  ICancellable* target_ = nullptr;
+};
+
+/// Lifetime-pinned publication point for one borrowed ICancellable.
+///
+/// One slot is created per generator publication (ActiveGenerator owns it). The generator is borrowed
+/// storage owned by the modality; the slot is the only thing that decides whether it may still be touched.
+///
+/// This exists to remove the previous "cancel under the registry lock" pattern, where delivering a stop
+/// invoked ICancellable::Cancel() while holding the operation's generator mutex. That made an engine call
+/// part of the framework's lock graph and forced unregistration to block on it. Here a registry lock is only
+/// ever held long enough to copy shared_ptrs; the Cancel() itself runs lock-free under a lease.
+class CancelSlot : public std::enable_shared_from_this<CancelSlot> {
+ private:
+  struct PrivateTag {
+    explicit PrivateTag() = default;
+  };
+
+ public:
+  /// Publish `target`. The caller must Withdraw() before `target` is destroyed.
+  static std::shared_ptr<CancelSlot> Create(ICancellable& target);
+
+  /// Only reachable through Create(): PrivateTag keeps this effectively private while letting make_shared
+  /// construct the object in one allocation.
+  CancelSlot(PrivateTag /*tag*/, ICancellable& target) noexcept : target_(&target) {}
+
+  CancelSlot(const CancelSlot&) = delete;
+  CancelSlot& operator=(const CancelSlot&) = delete;
+
+  /// Pin the current target, if any. Returns an empty lease once the slot has been withdrawn.
+  [[nodiscard]] CancelLease Acquire() noexcept;
+
+  /// Retire the slot: nulls the target so no later Acquire() can see it, then waits until every outstanding
+  /// lease has been released. After it returns, the target can be destroyed safely.
+  ///
+  /// Must never be called from a thread that currently holds a lease on this slot. The call paths are built
+  /// so that cannot happen (a canceller never withdraws, and the owning guard never holds a lease across its
+  /// own scope) rather than relying on a thread-id escape hatch.
+  void Withdraw() noexcept;
+
+  /// Diagnostic: number of leases currently outstanding.
+  size_t OutstandingLeases() const;
+
+ private:
+  friend class CancelLease;
+
+  void ReleaseLease() noexcept;
+
+  mutable std::mutex mu_;
+  std::condition_variable idle_cv_;
+  ICancellable* target_ = nullptr;
+  size_t active_leases_ = 0;
+};
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/cancellable.h
+++ b/sdk_v2/cpp/src/inferencing/session/cancellable.h
@@ -6,19 +6,25 @@ namespace fl {
 
 /// Anything that can be interrupted from a thread other than the one driving it.
 ///
-/// Implemented by the per-request generators (chat, audio). A generation loop only
-/// observes `Request::ShouldStop()` between tokens, which is not enough on its own:
-/// a long prefill or a single slow decode step can block inside the ORT GenAI engine
-/// for an unbounded time. Cancel() reaches into the engine (terminate_session) so an
-/// external canceller or an expired deadline interrupts mid-compute.
+/// Implemented by the per-request generators (chat, audio) and by the raw-OgaGenerator adapter. A generation
+/// loop only observes the operation's stop latch between tokens, which is not enough on its own: a long
+/// prefill or a single slow decode step can block inside the ORT GenAI engine for an unbounded time.
+/// Cancel() reaches into the engine (terminate_session) so an external canceller or an expired deadline
+/// interrupts mid-compute.
 ///
-/// Cancel() must be safe to call from any thread, at any point in the generator's
-/// lifetime, and must be idempotent.
+/// Cancel() must be safe to call from any thread, at any point in the generator's lifetime, and must be
+/// idempotent. It returns true only when engine-level terminate_session was delivered successfully.
+///
+/// It is `noexcept` because it is invoked from framework boundaries that cannot handle a failure: a session
+/// teardown loop cancelling every live operation, a watchdog thread whose exception would call
+/// std::terminate anyway, and a generator-slot lock that must not unwind mid-iteration. Implementations
+/// swallow engine-specific errors from terminate_session (not all ORT GenAI builds support it) rather than
+/// letting cancellation failure escape.
 class ICancellable {
  public:
   virtual ~ICancellable() = default;
 
-  virtual void Cancel() = 0;
+  virtual bool Cancel() noexcept = 0;
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/live_session_registry.cc
+++ b/sdk_v2/cpp/src/inferencing/session/live_session_registry.cc
@@ -2,28 +2,80 @@
 // Licensed under the MIT License.
 #include "inferencing/session/live_session_registry.h"
 
+#include "inferencing/session/session_runtime.h"
+
 namespace fl {
 
+void LiveSessionRegistry::AdmissionClosure::Release() noexcept {
+  if (registry_ == nullptr) {
+    return;
+  }
+
+  registry_->ReleaseAdmissionClosure();
+  registry_ = nullptr;
+}
+
 LiveSessionRegistry& LiveSessionRegistry::Instance() {
-  // Leaked intentionally: sessions may be destroyed during static destruction, and a
-  // destroyed registry would make Remove() a use-after-free.
+  // Leaked intentionally: sessions may be destroyed during static destruction, and a destroyed registry
+  // would make Remove() a use-after-free.
   static LiveSessionRegistry* instance = new LiveSessionRegistry();
   return *instance;
 }
 
-void LiveSessionRegistry::Add(Session& session) {
+void LiveSessionRegistry::Add(const std::shared_ptr<SessionRuntime>& runtime) {
   std::lock_guard<std::mutex> lock(mutex_);
-  sessions_.insert(&session);
+  runtimes_[runtime.get()] = runtime;
+
+  // Close the shutdown race: a session that registers while a shutdown holds admission closed must not slip
+  // past the cancellation snapshot. MarkTerminal only flips a flag and wakes the admission CV — no ORT and
+  // no logging under this lock.
+  if (closure_depth_ > 0) {
+    runtime->MarkTerminal();
+  }
 }
 
-void LiveSessionRegistry::Remove(Session& session) {
+void LiveSessionRegistry::Remove(SessionRuntime* runtime) noexcept {
   std::lock_guard<std::mutex> lock(mutex_);
-  sessions_.erase(&session);
+  runtimes_.erase(runtime);
 }
 
-std::vector<Session*> LiveSessionRegistry::Snapshot() const {
+std::vector<std::shared_ptr<SessionRuntime>> LiveSessionRegistry::Snapshot() const {
+  std::vector<std::shared_ptr<SessionRuntime>> alive;
+
   std::lock_guard<std::mutex> lock(mutex_);
-  return {sessions_.begin(), sessions_.end()};
+  alive.reserve(runtimes_.size());
+
+  for (auto it = runtimes_.begin(); it != runtimes_.end();) {
+    if (auto strong = it->second.lock()) {
+      alive.push_back(std::move(strong));
+      ++it;
+    } else {
+      it = runtimes_.erase(it);  // prune a runtime that expired between registration and this snapshot
+    }
+  }
+
+  return alive;
+}
+
+LiveSessionRegistry::AdmissionClosure LiveSessionRegistry::CloseAdmission() {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++closure_depth_;
+  }
+
+  return AdmissionClosure(*this);
+}
+
+void LiveSessionRegistry::ReleaseAdmissionClosure() noexcept {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (closure_depth_ > 0) {
+    --closure_depth_;
+  }
+}
+
+bool LiveSessionRegistry::IsAdmissionOpen() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return closure_depth_ == 0;
 }
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/live_session_registry.h
+++ b/sdk_v2/cpp/src/inferencing/session/live_session_registry.h
@@ -2,42 +2,112 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include <cstddef>
+#include <memory>
 #include <mutex>
-#include <unordered_set>
+#include <unordered_map>
 #include <vector>
 
 namespace fl {
 
-class Session;
+class SessionRuntime;
 
-/// Process-wide set of every live Session, maintained by Session's constructor and
-/// destructor.
+/// Process-wide set of every live session runtime, populated by MakeSessionRuntime() and pruned by
+/// ~SessionRuntime.
 ///
-/// SessionManager only knows about sessions that took a SessionRegistration, which the
-/// web-service handlers do but the direct API does not. Cancellation must reach *every*
-/// session: a non-terminating direct-API request is precisely the case that pins the
-/// model refcount and stalls manager teardown.
+/// It stores weak references to the stable, shared SessionRuntime — never Session facade addresses — so a
+/// Session can move (or be destroyed while an operation still runs) without duplicating or losing its
+/// cancellation identity, and so a promoted (strong) snapshot lets shutdown cancel a session even as it
+/// unwinds concurrently.
 ///
-/// This tracks sessions for cancellation only. It deliberately has no bearing on
-/// SessionManager::WaitForDrain(), because an idle session the caller still owns must
-/// not block shutdown.
+/// SessionManager only knows about sessions that took a SessionRegistration, which the web-service handlers
+/// do but the direct API does not. Cancellation must reach *every* session: a non-terminating direct-API
+/// request is precisely the case that pins the model refcount and stalls manager teardown.
+///
+/// Admission gate: while admission is closed (a SessionManager shutdown is in progress), a control that
+/// registers concurrently is immediately marked terminal, so a session created in the race window after the
+/// shutdown snapshot still has its operations rejected. Closure is *owned*, not a bare flag — see
+/// AdmissionClosure — so overlapping managers cannot reopen each other's shutdown, while sequential Manager
+/// recreation still admits new sessions once the previous manager is gone.
+///
+/// This tracks controls for cancellation only. It deliberately has no bearing on
+/// SessionManager::WaitForDrain(), because an idle session the caller still owns must not block shutdown.
 class LiveSessionRegistry {
  public:
+  /// Move-only ownership token for one closure of the admission gate.
+  ///
+  /// The registry is a leaked process-wide singleton shared across Manager lifetimes, so admission state
+  /// cannot be a bool that anyone may flip: a second manager's shutdown must not be able to reopen the first
+  /// manager's closure, and neither manager's teardown must reopen admission while the other is still
+  /// shutting down. Each closure holds a reference on a depth counter and releases exactly once; admission
+  /// is open only when no closure is outstanding.
+  class AdmissionClosure {
+   public:
+    AdmissionClosure() = default;
+    ~AdmissionClosure() noexcept { Release(); }
+
+    AdmissionClosure(AdmissionClosure&& other) noexcept
+        : registry_(other.registry_) {
+      other.registry_ = nullptr;
+    }
+
+    AdmissionClosure& operator=(AdmissionClosure&& other) noexcept {
+      if (this != &other) {
+        Release();
+        registry_ = other.registry_;
+        other.registry_ = nullptr;
+      }
+
+      return *this;
+    }
+
+    AdmissionClosure(const AdmissionClosure&) = delete;
+    AdmissionClosure& operator=(const AdmissionClosure&) = delete;
+
+    /// True while this token still holds admission closed.
+    bool Engaged() const { return registry_ != nullptr; }
+
+    /// Reopen this closure's share of the gate. Idempotent.
+    void Release() noexcept;
+
+   private:
+    friend class LiveSessionRegistry;
+
+    explicit AdmissionClosure(LiveSessionRegistry& registry) : registry_(&registry) {}
+
+    LiveSessionRegistry* registry_ = nullptr;
+  };
+
   static LiveSessionRegistry& Instance();
 
-  void Add(Session& session);
-  void Remove(Session& session);
+  /// Track `runtime` weakly. If admission is currently closed, the runtime is marked terminal immediately.
+  void Add(const std::shared_ptr<SessionRuntime>& runtime);
 
-  /// Snapshot of the live sessions. Returned by value so callers can cancel without
-  /// holding the lock — Session::Cancel() reaches into the inference engine and would
-  /// otherwise deadlock against a session unwinding and calling Remove().
-  std::vector<Session*> Snapshot() const;
+  /// Stop tracking `runtime`. Safe to call for an untracked runtime.
+  void Remove(SessionRuntime* runtime) noexcept;
+
+  /// Promoted snapshot of the live runtimes. Returned by value so callers can cancel without holding the
+  /// lock — CancelAll() reaches into the inference engine and would otherwise deadlock against a session
+  /// unwinding and calling Remove(). Expired weak entries are pruned.
+  std::vector<std::shared_ptr<SessionRuntime>> Snapshot() const;
+
+  /// Close admission for as long as the returned token lives. Runtimes registered while any token is
+  /// outstanding are marked terminal on arrival.
+  [[nodiscard]] AdmissionClosure CloseAdmission();
+
+  /// True while no closure token is outstanding.
+  bool IsAdmissionOpen() const;
 
  private:
   LiveSessionRegistry() = default;
 
+  /// Drop one closure reference. Called only by AdmissionClosure.
+  void ReleaseAdmissionClosure() noexcept;
+
   mutable std::mutex mutex_;
-  std::unordered_set<Session*> sessions_;
+  // Mutable so Snapshot() (logically const) can prune entries whose runtime expired without a Remove().
+  mutable std::unordered_map<SessionRuntime*, std::weak_ptr<SessionRuntime>> runtimes_;
+  size_t closure_depth_ = 0;
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/oga_generator_cancellable.cc
+++ b/sdk_v2/cpp/src/inferencing/session/oga_generator_cancellable.cc
@@ -6,13 +6,15 @@
 
 namespace fl {
 
-void OgaGeneratorCancellable::Cancel() {
+bool OgaGeneratorCancellable::Cancel() noexcept {
   // Engine-level termination interrupts an in-flight compute (e.g. a long encoder pass),
   // which a between-token flag check cannot do. Mirrors OnnxAudioGenerator::Cancel.
   try {
     generator_.SetRuntimeOption("terminate_session", "1");
-  } catch (const std::exception&) {
+    return true;
+  } catch (...) {
     // SetRuntimeOption may not be supported by all ORT GenAI builds.
+    return false;
   }
 }
 

--- a/sdk_v2/cpp/src/inferencing/session/oga_generator_cancellable.h
+++ b/sdk_v2/cpp/src/inferencing/session/oga_generator_cancellable.h
@@ -3,9 +3,12 @@
 #pragma once
 
 #include "inferencing/session/cancellable.h"
-#include "inferencing/session/request.h"
+#include "inferencing/session/operation_context.h"
 
+#include <atomic>
+#include <optional>
 #include <stdexcept>
+#include <type_traits>
 
 struct OgaGenerator;
 
@@ -15,7 +18,7 @@ namespace fl {
 ///
 /// Some paths (embeddings, streaming PCM transcription, Nemotron decode) drive an OgaGenerator
 /// directly instead of going through OnnxAudioGenerator, so they have no Cancel() of
-/// their own. Wrapping the generator lets Session publish it for cancellation, which
+/// their own. Wrapping the generator lets an operation publish it for cancellation, which
 /// is what makes those loops interruptible mid-compute rather than only between tokens.
 ///
 /// Non-owning: the wrapped generator must outlive this adapter.
@@ -23,29 +26,197 @@ class OgaGeneratorCancellable : public ICancellable {
  public:
   explicit OgaGeneratorCancellable(OgaGenerator& generator) : generator_(generator) {}
 
-  void Cancel() override;
+  bool Cancel() noexcept override;
 
  private:
   OgaGenerator& generator_;
 };
 
-/// Generate one token with a raw OGA generator.
-///
-/// ORT GenAI throws std::runtime_error when terminate_session interrupts an in-flight call. Treat that exception as
-/// an expected stop only when the associated request was canceled or timed out; unrelated engine failures propagate.
-/// This stays templated so OgaGenerator can remain forward-declared and the behavior can be tested without a model.
+namespace detail {
+
 template <typename Generator>
-[[nodiscard]] bool TryGenerateNextToken(Generator& generator, const Request& request) {
+[[nodiscard]] bool IsOperationTerminationConfirmed(Generator& generator, const OperationContext& operation) {
+  return operation.ShouldStop() &&
+         (operation.EngineCancelDelivered() || generator.IsSessionTerminated());
+}
+
+template <typename Generator>
+[[nodiscard]] bool IsGeneratorTerminationConfirmed(
+    Generator& generator, const std::atomic<bool>& engine_termination_delivered) {
+  return engine_termination_delivered.load(std::memory_order_acquire) ||
+         generator.IsSessionTerminated();
+}
+
+template <typename Action, typename TerminationConfirmed>
+[[nodiscard]] bool TryGeneratorVoidCall(const Action& action,
+                                        const TerminationConfirmed& termination_confirmed) {
   try {
-    generator.GenerateNextToken();
+    action();
     return true;
   } catch (const std::runtime_error&) {
-    if (request.ShouldStop()) {
+    if (termination_confirmed()) {
       return false;
     }
 
     throw;
   }
+}
+
+template <typename Result, typename Action, typename TerminationConfirmed>
+[[nodiscard]] std::optional<Result> TryGeneratorValueCall(
+    const Action& action, const TerminationConfirmed& termination_confirmed) {
+  try {
+    return std::optional<Result>{action()};
+  } catch (const std::runtime_error&) {
+    if (termination_confirmed()) {
+      return std::nullopt;
+    }
+
+    throw;
+  }
+}
+
+template <typename Generator, typename CancellationConfirmed>
+[[nodiscard]] bool IsGeneratorDoneCancellationSafeImpl(
+    Generator& generator, const CancellationConfirmed& cancellation_confirmed) {
+  // IsDone may throw after terminate_session lands, so query termination before it and re-check the exact
+  // evidence if cancellation lands between these calls.
+  if (generator.IsSessionTerminated() || cancellation_confirmed()) {
+    return true;
+  }
+
+  try {
+    return generator.IsDone();
+  } catch (const std::runtime_error&) {
+    if (cancellation_confirmed()) {
+      return true;
+    }
+
+    throw;
+  }
+}
+
+}  // namespace detail
+
+/// Query an OGA generator owned by a concrete wrapper that records exact successful terminate_session delivery.
+///
+/// A throwing SetRuntimeOption call can still leave the pinned OGA session terminated, so both evidence sources
+/// are checked before IsDone and again if IsDone raises std::runtime_error. Cancellation intent alone is never
+/// sufficient to suppress an unrelated runtime failure.
+template <typename Generator>
+[[nodiscard]] bool IsGeneratorDoneCancellationSafe(
+    Generator& generator, const std::atomic<bool>& engine_termination_delivered) {
+  return detail::IsGeneratorDoneCancellationSafeImpl(generator, [&] {
+    return detail::IsGeneratorTerminationConfirmed(generator, engine_termination_delivered);
+  });
+}
+
+/// Query a raw OGA generator driven by one exact operation.
+///
+/// Natural termination is checked first. A runtime_error is suppressed only when this operation is stopped and
+/// either its engine cancellation was delivered successfully or this generator confirms session termination.
+template <typename Generator>
+[[nodiscard]] bool IsGeneratorDoneCancellationSafe(Generator& generator,
+                                                    const OperationContext& operation) {
+  if (operation.ShouldStop()) {
+    return true;
+  }
+
+  return detail::IsGeneratorDoneCancellationSafeImpl(
+      generator, [&] { return detail::IsOperationTerminationConfirmed(generator, operation); });
+}
+
+/// Generate one token with a raw OGA generator, tolerating exactly one expected failure: the
+/// std::runtime_error ORT GenAI raises when terminate_session interrupts an in-flight call.
+///
+/// The suppression is deliberately narrow:
+///   1. *this* operation has a latched stop (not merely "some cancellation raced somewhere"),
+///   2. either an engine cancellation was delivered successfully to this operation or this generator itself
+///      reports that its session terminated.
+/// Anything else — a genuine engine failure that happens to coincide with a cancel — propagates unchanged.
+///
+/// Templated so OgaGenerator can stay forward-declared and the behaviour is testable without a model.
+template <typename Generator>
+[[nodiscard]] bool TryGenerateNextToken(Generator& generator, const OperationContext& operation) {
+  if (operation.ShouldStop()) {
+    return false;
+  }
+
+  return detail::TryGeneratorVoidCall(
+      [&] { generator.GenerateNextToken(); },
+      [&] { return detail::IsOperationTerminationConfirmed(generator, operation); });
+}
+
+/// Generate one token through a concrete wrapper. Cancellation intent is deliberately not consulted.
+template <typename Generator>
+[[nodiscard]] bool TryGenerateNextToken(
+    Generator& generator, const std::atomic<bool>& engine_termination_delivered) {
+  return detail::TryGeneratorVoidCall(
+      [&] { generator.GenerateNextToken(); },
+      [&] { return detail::IsGeneratorTerminationConfirmed(generator, engine_termination_delivered); });
+}
+
+/// Set inputs on a raw OGA generator published by one exact operation.
+template <typename Generator, typename Tensors>
+[[nodiscard]] bool TrySetGeneratorInputs(Generator& generator, Tensors& tensors,
+                                         const OperationContext& operation) {
+  if (operation.ShouldStop()) {
+    return false;
+  }
+
+  return detail::TryGeneratorVoidCall(
+      [&] { generator.SetInputs(tensors); },
+      [&] { return detail::IsOperationTerminationConfirmed(generator, operation); });
+}
+
+/// Read next tokens from a raw OGA generator published by one exact operation.
+template <typename Generator>
+[[nodiscard]] auto TryGetNextTokens(Generator& generator, const OperationContext& operation)
+    -> std::optional<std::remove_cvref_t<decltype(generator.GetNextTokens())>> {
+  using NextTokens = std::remove_cvref_t<decltype(generator.GetNextTokens())>;
+
+  if (operation.ShouldStop()) {
+    return std::nullopt;
+  }
+
+  return detail::TryGeneratorValueCall<NextTokens>(
+      [&] { return generator.GetNextTokens(); },
+      [&] { return detail::IsOperationTerminationConfirmed(generator, operation); });
+}
+
+/// Decode one token only while the exact raw-generator operation is still running. Tokenizer decoding is not
+/// an engine-termination call, so unrelated failures propagate unchanged.
+template <typename TokenizerStream, typename Token>
+[[nodiscard]] auto TryDecodeToken(TokenizerStream& stream, Token token, const OperationContext& operation)
+    -> std::optional<std::remove_cvref_t<decltype(stream.Decode(token))>> {
+  using Decoded = std::remove_cvref_t<decltype(stream.Decode(token))>;
+
+  if (operation.ShouldStop()) {
+    return std::nullopt;
+  }
+
+  return std::optional<Decoded>{stream.Decode(token)};
+}
+
+/// Account for one raw-generator token only while its exact operation is still running.
+[[nodiscard]] inline bool TryIncrementTokenCount(int& token_count, const OperationContext& operation) noexcept {
+  if (operation.ShouldStop()) {
+    return false;
+  }
+
+  ++token_count;
+  return true;
+}
+
+/// Read next tokens through a concrete wrapper. Cancellation intent is deliberately not consulted.
+template <typename Generator>
+[[nodiscard]] auto TryGetNextTokens(
+    Generator& generator, const std::atomic<bool>& engine_termination_delivered)
+    -> std::optional<std::remove_cvref_t<decltype(generator.GetNextTokens())>> {
+  using NextTokens = std::remove_cvref_t<decltype(generator.GetNextTokens())>;
+  return detail::TryGeneratorValueCall<NextTokens>(
+      [&] { return generator.GetNextTokens(); },
+      [&] { return detail::IsGeneratorTerminationConfirmed(generator, engine_termination_delivered); });
 }
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/operation.cc
+++ b/sdk_v2/cpp/src/inferencing/session/operation.cc
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "inferencing/session/operation.h"
+
+#include "exception.h"
+#include "inferencing/session/request_control.h"
+#include "inferencing/session/request_snapshot.h"
+#include "inferencing/session/session_runtime.h"
+
+#include <utility>
+
+namespace fl {
+
+namespace {
+
+void ClearResponse(Response& response) noexcept {
+  Response empty;
+  response.Swap(empty);
+}
+
+}  // namespace
+
+Operation::Operation(std::shared_ptr<SessionRuntime> runtime, std::shared_ptr<RequestControl> request_control,
+                     std::shared_ptr<const RequestSnapshot> request, std::shared_ptr<OperationState> state,
+                     uint64_t claim_epoch, ResponseVisibility visibility)
+    : runtime_(std::move(runtime)),
+      request_control_(std::move(request_control)),
+      request_(std::move(request)),
+      state_(std::move(state)),
+      claim_epoch_(claim_epoch),
+      visibility_(visibility) {
+}
+
+Operation::~Operation() noexcept {
+  // An Operation destroyed without being processed abandons its work: settle the state so a late cancel is a
+  // no-op, then drop the strong OperationState from the runtime and release the Request claim.
+  if (stage_.load(std::memory_order_acquire) == Stage::kFresh) {
+    state_->Abandon();
+  }
+
+  ReleaseRegistrations();
+}
+
+OperationOutcome Operation::Process(Response& response) {
+  Stage expected = Stage::kFresh;
+  if (!stage_.compare_exchange_strong(expected, Stage::kProcessing, std::memory_order_acq_rel,
+                                      std::memory_order_acquire)) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "operation has already been processed (single-use)");
+  }
+
+  // Release the claim and the registration on every exit path, including a throw from inference.
+  struct ReleaseGuard {
+    Operation& operation;
+
+    ~ReleaseGuard() noexcept {
+      operation.stage_.store(Stage::kDone, std::memory_order_release);
+      operation.ReleaseRegistrations();
+    }
+  } release_guard{*this};
+
+  // A reused caller-owned Response must never contribute stale output to this run. Install the release guard
+  // first so every exit after response cleanup still releases the operation's registrations.
+  ClearResponse(response);
+
+  try {
+    // No borrowing, no lifetime gate: the runtime was captured strongly at creation and the execution data
+    // is an immutable snapshot this Operation owns.
+    const auto outcome = runtime_->Run(state_, request_->Data(), response);
+
+    // Explicit (atomic) operations publish no response unless the run completed: clearing it stops a
+    // cancelled/timed-out/faulted operation from surfacing half-built output, and stops stale data from a
+    // reused Response object from masquerading as this run's result. The legacy convenience path
+    // (kLegacyPartial) deliberately preserves the response this run produced so generated-so-far output
+    // survives a cancellation or callback stop, per Session::ProcessRequest's contract.
+    if (outcome != OperationOutcome::kCompleted && visibility_ == ResponseVisibility::kExplicitAtomic) {
+      ClearResponse(response);
+    }
+
+    return outcome;
+  } catch (...) {
+    // Partial output is a cancellation-only legacy contract. Faults always leave a clean response, including
+    // when a modality had already populated a pending legacy result before a later operation failed.
+    ClearResponse(response);
+
+    // Backstop only. Run() marks the fault itself for std::exception — it has to, because the fault must be
+    // latched *before* it joins the watchdog and runs the derived cleanup hook. This catch covers the
+    // non-std throw that would otherwise leave the operation looking runnable. Marking twice is harmless;
+    // the original exception propagates unchanged either way.
+    state_->MarkFaulted();
+    throw;
+  }
+}
+
+void Operation::Cancel() noexcept {
+  state_->RequestStop(StopReason::kExternalCancel);
+}
+
+void Operation::ReleaseRegistrations() noexcept {
+  if (released_.test_and_set(std::memory_order_acq_rel)) {
+    return;
+  }
+
+  runtime_->DeregisterOperation(*state_);
+
+  // Identity + epoch scoped: releasing through the control never dereferences the Request itself, so this is
+  // safe even if the Request was destroyed while the operation was in flight.
+  request_control_->Release(*state_, claim_epoch_);
+}
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/operation.h
+++ b/sdk_v2/cpp/src/inferencing/session/operation.h
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include "inferencing/session/operation_state.h"
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+
+namespace fl {
+
+class RequestControl;
+class RequestSnapshot;
+class SessionRuntime;
+struct Response;
+
+/// Controls whether a stopped run's partial response is visible to the caller.
+///
+///   - kExplicitAtomic (the deferred Operation API): a run that does not complete publishes *no* response.
+///     Process() clears it so a cancelled/timed-out/faulted operation never surfaces half-built output, and a
+///     reused Response object cannot masquerade as the stopped run's result.
+///   - kLegacyPartial (the Session::ProcessRequest convenience): a cancellation or callback stop returns
+///     normally and preserves the generated-so-far response the modality publishes, matching the established
+///     streaming/SSE contract where a client hanging up is not an error. Process() still clears stale caller
+///     output before starting; only partial data produced by this run can survive its stop.
+enum class ResponseVisibility : uint8_t {
+  kExplicitAtomic,
+  kLegacyPartial,
+};
+
+/// A single-use, per-invocation unit of inference work.
+///
+/// Created synchronously by Session::CreateOperation (which snapshots the deadline, claims the Request,
+/// captures the immutable execution data and registers a strong OperationState with the runtime) and then
+/// executed exactly once via Process(). This is the internal core the ABI layer wraps as an opaque
+/// flOperation so it can build a create -> (optionally cancel) -> process flow instead of the current
+/// single-shot ProcessRequest call.
+///
+/// Lifetime: an Operation holds **no Session pointer and no Request pointer**. It holds
+///   - a strong `shared_ptr<SessionRuntime>`, captured synchronously at creation, so the executable state it
+///     runs against cannot disappear no matter what the caller does with the Session facade, and
+///   - a strong `shared_ptr<const RequestSnapshot>`, so the execution data is immutable and independently
+///     owned, and
+///   - the Request's stable RequestControl, used only for claim release and diagnostics by identity+epoch.
+/// Destroying an unprocessed Operation abandons it, releasing exactly its request claim (by identity and
+/// epoch) and its runtime registration.
+class Operation {
+ public:
+  Operation(std::shared_ptr<SessionRuntime> runtime, std::shared_ptr<RequestControl> request_control,
+            std::shared_ptr<const RequestSnapshot> request, std::shared_ptr<OperationState> state,
+            uint64_t claim_epoch, ResponseVisibility visibility = ResponseVisibility::kExplicitAtomic);
+  ~Operation() noexcept;
+
+  Operation(const Operation&) = delete;
+  Operation& operator=(const Operation&) = delete;
+  Operation(Operation&&) = delete;
+  Operation& operator=(Operation&&) = delete;
+
+  /// Execute the operation exactly once, filling `response`.
+  ///
+  /// If the operation was already stopped (sticky created/queued cancellation) it returns the corresponding
+  /// outcome without running any inference. Genuine inference errors propagate unchanged (the operation is
+  /// left kFaulted); cancellation, callback stop and timeout are reported through the returned outcome so
+  /// callers can branch on them — in particular kCancelled stays visible here, which is what the explicit
+  /// operation API maps to FOUNDRY_LOCAL_ERROR_OPERATION_CANCELLED.
+  ///
+  /// @throws fl::Exception (FOUNDRY_LOCAL_ERROR_INVALID_USAGE) if called more than once.
+  OperationOutcome Process(Response& response);
+
+  /// Cancel just this operation. Thread-safe, idempotent, signal-only. Sticky before the run starts; a
+  /// no-op once the operation has reached any terminal status or has been sealed.
+  void Cancel() noexcept;
+
+  bool IsProcessed() const { return stage_.load(std::memory_order_acquire) != Stage::kFresh; }
+
+  OperationStatus Status() const { return state_->Status(); }
+
+  const std::shared_ptr<OperationState>& State() const { return state_; }
+
+ private:
+  /// Single-use gate. Advanced with a CAS so two threads racing on Process() cannot both run.
+  enum class Stage : uint8_t { kFresh, kProcessing, kDone };
+
+  /// Deregister from the runtime and release the exact request claim. Idempotent.
+  void ReleaseRegistrations() noexcept;
+
+  std::shared_ptr<SessionRuntime> runtime_;
+  std::shared_ptr<RequestControl> request_control_;
+  std::shared_ptr<const RequestSnapshot> request_;
+  std::shared_ptr<OperationState> state_;
+  const uint64_t claim_epoch_;
+  const ResponseVisibility visibility_;
+  std::atomic<Stage> stage_{Stage::kFresh};
+  std::atomic_flag released_;  // C++20: value-initialised clear
+};
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/operation_context.h
+++ b/sdk_v2/cpp/src/inferencing/session/operation_context.h
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include "inferencing/session/cancel_slot.h"
+#include "inferencing/session/cancellable.h"
+#include "inferencing/session/operation_state.h"
+
+#include <memory>
+#include <utility>
+
+namespace fl {
+
+/// The explicit, per-run cancellation handle handed to every production inference path.
+///
+/// This replaces the old implicit model where a generation loop polled `Request::canceled` and generator
+/// registration resolved the "current" operation from thread-local state. Both were unsound: the Request
+/// flag is a reusable object-lifetime-scoped bit (a stale run could erase or observe another run's cancel),
+/// and thread-local resolution silently no-oped whenever a helper ran on a different thread. An
+/// OperationContext is passed down every modality helper that polls cancellation or publishes a generator,
+/// so the stop authority is always the exact operation driving the call.
+///
+/// Header-only: every member is a one-line forward to the shared OperationState, so a .cc would add a
+/// translation unit and an out-of-line call for no benefit.
+///
+/// Const-ness: the context is handed out as `const OperationContext&` because callees must not rebind it.
+/// The *state* it refers to is shared and mutable by design (the watchdog and external cancellers act on it
+/// concurrently), so the mutating operations are const member functions.
+class OperationContext {
+ public:
+  explicit OperationContext(std::shared_ptr<OperationState> state) : state_(std::move(state)) {}
+
+  OperationContext(const OperationContext&) = delete;
+  OperationContext& operator=(const OperationContext&) = delete;
+
+  /// True once this operation has been asked to stop, for any reason. The only stop authority production
+  /// generation loops may consult.
+  bool ShouldStop() const { return state_->IsStopped(); }
+
+  /// Why the operation stopped (kNone while running).
+  StopReason Reason() const { return state_->Reason(); }
+
+  /// Ask this exact operation to stop. Returns true only for the call that latched the stop.
+  bool RequestStop(StopReason reason) const { return state_->RequestStop(reason); }
+
+  /// True once a generator Cancel() (engine terminate_session) was actually delivered for this operation.
+  /// A generator that reports this is permanently terminated: it must not be rewound or reused.
+  bool EngineCancelDelivered() const { return state_->WasEngineCancelDelivered(); }
+
+  /// True once ProcessRequestImpl threw and the run settled as faulted. Modality cleanup hooks use it to
+  /// discard cross-request state (a cached generator, tool context) a failed run may have already mutated.
+  bool IsFaulted() const { return state_->Status() == OperationStatus::kFaulted; }
+
+  /// Close this run's outcome to cancellation immediately before committing it.
+  ///
+  /// The modality contract is strict, and the whole point of the seal is that it is checked in one place:
+  ///   1. every ActiveGenerator guard for this run has been destroyed,
+  ///   2. every engine read the commit depends on has already happened,
+  ///   3. every streaming callback that could ask to stop has quiesced (CallbackHandler::Quiesce),
+  ///   4. only then TrySeal().
+  /// On true the run owns its outcome and no later cancel or timeout can touch the generator, the session's
+  /// history, or the response. On false cancellation won: discard or roll back and report a stopped run.
+  bool TrySeal() const { return state_->TrySeal(); }
+
+  /// True once TrySeal() has succeeded for this run.
+  bool IsSealed() const { return state_->IsSealed(); }
+
+  /// Publish/withdraw a borrowed generator. Prefer the ActiveGenerator guard below over calling these.
+  OperationState::GeneratorRegistration RegisterGenerator(ICancellable& generator) const {
+    return state_->RegisterGenerator(generator);
+  }
+
+  void CancelGenerator(const std::shared_ptr<CancelSlot>& slot) const { state_->CancelGenerator(slot); }
+
+  void WithdrawGenerator(const std::shared_ptr<CancelSlot>& slot) const { state_->WithdrawGenerator(slot); }
+
+  const std::shared_ptr<OperationState>& State() const { return state_; }
+
+ private:
+  std::shared_ptr<OperationState> state_;
+};
+
+/// RAII guard publishing the generator currently driving a request so that a session cancel, an explicit
+/// operation cancel, or the per-operation deadline watchdog can interrupt it mid-compute.
+///
+/// The generator is registered with the *explicitly supplied* operation, so concurrent operations on the
+/// same session (embeddings) stay isolated: a stop of one operation only cancels its own generators.
+///
+/// Register-after-stop: if a stop was already latched when the guard is constructed, the cancellation is
+/// delivered here — through a lease, with no framework, operation or slot lock held — rather than inside the
+/// registration itself. The lease dies before the constructor returns, so the destructor's withdraw can
+/// never end up waiting on a lease this same thread still holds.
+///
+/// Destruction withdraws the slot and blocks until any in-flight Cancel() on it has returned, which is what
+/// makes it safe for the caller to destroy the generator right after the guard's scope ends.
+class ActiveGenerator {
+ public:
+  ActiveGenerator(const OperationContext& operation, ICancellable& generator) : operation_(operation) {
+    auto registration = operation_.RegisterGenerator(generator);
+    slot_ = std::move(registration.slot);
+
+    if (registration.cancel_required) {
+      operation_.CancelGenerator(slot_);
+    }
+  }
+
+  ~ActiveGenerator() noexcept { operation_.WithdrawGenerator(slot_); }
+
+  ActiveGenerator(const ActiveGenerator&) = delete;
+  ActiveGenerator& operator=(const ActiveGenerator&) = delete;
+
+ private:
+  const OperationContext& operation_;
+  std::shared_ptr<CancelSlot> slot_;
+};
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/operation_state.cc
+++ b/sdk_v2/cpp/src/inferencing/session/operation_state.cc
@@ -1,0 +1,384 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "inferencing/session/operation_state.h"
+
+#include "inferencing/session/request_control.h"
+#include "inferencing/session/session_runtime.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace fl {
+
+namespace {
+
+/// Terminal states can no longer be stopped, run, or re-finalized.
+bool IsTerminalStatus(OperationStatus status) {
+  switch (status) {
+    case OperationStatus::kCompleted:
+    case OperationStatus::kCallbackStopped:
+    case OperationStatus::kCancelled:
+    case OperationStatus::kTimedOut:
+    case OperationStatus::kFaulted:
+    case OperationStatus::kAbandoned:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/// The sticky status a stop imposes on an operation that never reached kRunning.
+OperationStatus StatusForStopReason(StopReason reason) {
+  switch (reason) {
+    case StopReason::kTimeout:
+      return OperationStatus::kTimedOut;
+    case StopReason::kCallbackStop:
+      return OperationStatus::kCallbackStopped;
+    default:
+      return OperationStatus::kCancelled;
+  }
+}
+
+}  // namespace
+
+OperationState::OperationState(std::weak_ptr<SessionRuntime> runtime, std::weak_ptr<RequestControl> request_control,
+                               std::optional<std::chrono::steady_clock::time_point> deadline,
+                               std::chrono::milliseconds budget, const TestHooks* test_hooks)
+    : runtime_(std::move(runtime)),
+      request_control_(std::move(request_control)),
+      deadline_(deadline),
+      budget_(budget),
+      test_hooks_(test_hooks) {
+}
+
+bool OperationState::DeadlineExpired() const {
+  return deadline_.has_value() && std::chrono::steady_clock::now() >= *deadline_;
+}
+
+OperationStatus OperationState::Status() const {
+  std::lock_guard<std::mutex> lock(mu_);
+  return status_;
+}
+
+bool OperationState::IsSettledLocked() const {
+  return IsTerminalStatus(status_);
+}
+
+bool OperationState::LatchStop(StopReason reason) {
+  auto expected = static_cast<uint8_t>(StopReason::kNone);
+  return stop_reason_.compare_exchange_strong(expected, static_cast<uint8_t>(reason), std::memory_order_acq_rel,
+                                              std::memory_order_acquire);
+}
+
+void OperationState::MarkQueued() {
+  std::lock_guard<std::mutex> lock(mu_);
+  if (status_ == OperationStatus::kCreated) {
+    status_ = OperationStatus::kQueued;
+  }
+}
+
+bool OperationState::MarkRunning() {
+  std::lock_guard<std::mutex> lock(mu_);
+  // Check the stop latch while holding the same lock RequestStop() uses to latch it. Otherwise a stop can
+  // land between an unlocked pre-check and this transition, allowing a cancelled queued operation to run.
+  if (IsStopped() || IsSettledLocked()) {
+    return false;
+  }
+
+  status_ = OperationStatus::kRunning;
+  return true;
+}
+
+OperationOutcome OperationState::Finalize() {
+  OperationOutcome outcome;
+
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    // Resolve the outcome under the same lock RequestStop() and TrySeal() use. A sealed run has no stop
+    // reason by construction, so the seal is consumed here simply by resolving to kCompleted; Finalize can
+    // never re-open an outcome the seal already closed.
+    outcome = OutcomeForStopReason(Reason());
+
+    // A fault already settled this operation; the caller is propagating the original exception.
+    if (status_ != OperationStatus::kFaulted) {
+      switch (outcome) {
+        case OperationOutcome::kTimedOut:
+          status_ = OperationStatus::kTimedOut;
+          break;
+        case OperationOutcome::kCallbackStopped:
+          status_ = OperationStatus::kCallbackStopped;
+          break;
+        case OperationOutcome::kCancelled:
+          status_ = OperationStatus::kCancelled;
+          break;
+        default:
+          status_ = OperationStatus::kCompleted;
+          break;
+      }
+    }
+
+    finished_ = true;
+  }
+
+  cv_.notify_all();
+  return outcome;
+}
+
+void OperationState::MarkFaulted() noexcept {
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    status_ = OperationStatus::kFaulted;
+    finished_ = true;
+  }
+
+  cv_.notify_all();
+}
+
+void OperationState::Abandon() noexcept {
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (!IsSettledLocked()) {
+      status_ = OperationStatus::kAbandoned;
+    }
+
+    finished_ = true;
+  }
+
+  cv_.notify_all();
+}
+
+bool OperationState::RequestStop(StopReason reason) noexcept {
+  if (reason == StopReason::kNone) {
+    return false;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+
+    // The seal is checked first and under the same lock that sets it: once the modality has committed its
+    // outcome, a late cancel or timeout must not reach a generator, a history commit, or the response.
+    if (sealed_) {
+      return false;
+    }
+
+    // Check terminal state and latch the stop atomically with respect to Finalize(), MarkFaulted(),
+    // Abandon(), and MarkRunning(). A late cancel must never change diagnostics after completion.
+    if (IsSettledLocked()) {
+      return false;
+    }
+
+    if (!LatchStop(reason)) {
+      return false;  // idempotent — the first stop wins and has already been delivered
+    }
+
+    // Sticky for a not-yet-running operation: MarkRunning() will refuse to start it.
+    if (status_ == OperationStatus::kCreated || status_ == OperationStatus::kQueued) {
+      status_ = StatusForStopReason(reason);
+    }
+
+    // Wake the watchdog: it must never outlive the stop it can no longer act on.
+    finished_ = true;
+
+    // Linearize diagnostics before Finalize can acquire mu_ and before Operation releases this request claim.
+    // Lock order is OperationState::mu_ -> RequestControl::claim_mu_; no engine or logger call occurs here.
+    MirrorStop(reason);
+  }
+
+  cv_.notify_all();
+
+  // Admission notification and engine cancellation run with no framework lock held.
+  DeliverStop();
+  return true;
+}
+
+std::chrono::steady_clock::time_point OperationState::NowLocked() const noexcept {
+  if (test_hooks_ != nullptr && test_hooks_->now != nullptr) {
+    return test_hooks_->now(test_hooks_->context);
+  }
+
+  return std::chrono::steady_clock::now();
+}
+
+bool OperationState::TrySeal() noexcept {
+  bool latched_timeout = false;
+
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (sealed_) {
+      return true;  // idempotent: the run already owns its outcome
+    }
+
+    if (IsStopped()) {
+      return false;  // cancellation or the deadline won the race earlier
+    }
+
+    // Sampling belongs to the terminal decision. Reading the clock before taking mu_ would let a thread pause
+    // with a pre-expiry value, resume after the deadline, and seal ahead of the watchdog.
+    const auto now = NowLocked();
+
+    // The deadline and the seal are decided together, under the one lock RequestStop() also latches through.
+    // If the budget has already elapsed with no earlier stop, latch the timeout right here instead of
+    // sealing — a run that overran its deadline must never be able to seal and report a natural outcome.
+    // Before the deadline the seal wins and closes the outcome to cancellation.
+    if (deadline_.has_value() && now >= *deadline_ && LatchStop(StopReason::kTimeout)) {
+      if (status_ == OperationStatus::kCreated || status_ == OperationStatus::kQueued) {
+        status_ = StatusForStopReason(StopReason::kTimeout);
+      }
+
+      finished_ = true;
+      latched_timeout = true;
+      MirrorStop(StopReason::kTimeout);
+    } else {
+      sealed_ = true;
+    }
+  }
+
+  // Wake the watchdog immediately either way: it can no longer act on this run.
+  cv_.notify_all();
+
+  // Admission notification and engine cancellation run with no framework lock held, exactly like RequestStop.
+  if (latched_timeout) {
+    DeliverStop();
+    return false;
+  }
+
+  return true;
+}
+
+bool OperationState::IsSealed() const {
+  std::lock_guard<std::mutex> lock(mu_);
+  return sealed_;
+}
+
+OperationState::GeneratorRegistration OperationState::RegisterGenerator(ICancellable& generator) {
+  GeneratorRegistration registration{CancelSlot::Create(generator), false};
+
+  {
+    std::lock_guard<std::mutex> slot_lock(slot_mu_);
+    if (IsStopped()) {
+      // Retain this slot only in the returned registration. The caller will cancel it once outside the lock;
+      // publishing it as well would let the stop's detached snapshot deliver a second cancellation.
+      registration.cancel_required = true;
+    } else {
+      // A stop that latches after this check cannot snapshot until it acquires slot_mu_, so it will detach this
+      // publication and become its sole cancellation owner.
+      slots_.push_back(registration.slot);
+    }
+  }
+
+  return registration;
+}
+
+void OperationState::CancelGenerator(const std::shared_ptr<CancelSlot>& slot) noexcept {
+  if (!slot) {
+    return;
+  }
+
+  const CancelLease lease = slot->Acquire();
+  if (!lease) {
+    return;
+  }
+
+  if (lease.Cancel()) {
+    engine_cancel_delivered_.store(true, std::memory_order_release);
+  }
+}
+
+void OperationState::WithdrawGenerator(const std::shared_ptr<CancelSlot>& slot) noexcept {
+  if (!slot) {
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> slot_lock(slot_mu_);
+    slots_.erase(std::remove(slots_.begin(), slots_.end(), slot), slots_.end());
+  }
+
+  // Outside slot_mu_ on purpose: Withdraw() blocks until every outstanding lease is released, and a
+  // canceller holding one of those leases must be able to finish without needing the registry lock.
+  slot->Withdraw();
+}
+
+void OperationState::CancelGenerators() noexcept {
+  std::vector<std::shared_ptr<CancelSlot>> to_cancel;
+
+  {
+    std::lock_guard<std::mutex> slot_lock(slot_mu_);
+    to_cancel.swap(slots_);
+  }
+
+  for (const auto& slot : to_cancel) {
+    // A slot already withdrawn yields an empty lease and does not count as delivered.
+    CancelGenerator(slot);
+  }
+}
+
+void OperationState::MirrorStop(StopReason reason) noexcept {
+  auto request_control = request_control_.lock();
+  if (!request_control) {
+    return;
+  }
+
+  request_control->MirrorStop(*this, RequestEpoch(), reason);
+}
+
+void OperationState::DeliverStop() noexcept {
+  if (auto runtime = runtime_.lock()) {
+    runtime->NotifyAdmission();
+  }
+
+  if (test_hooks_ != nullptr && test_hooks_->before_generator_drain != nullptr) {
+    test_hooks_->before_generator_drain(test_hooks_->context);
+  }
+
+  CancelGenerators();
+}
+
+bool OperationState::WaitForDeadline() {
+  if (!deadline_.has_value()) {
+    return false;
+  }
+
+  bool latched = false;
+
+  {
+    std::unique_lock<std::mutex> lock(mu_);
+
+    // Wake early if the run finished, was sealed, or was stopped; otherwise sleep out the budget.
+    cv_.wait_until(lock, *deadline_, [this] { return finished_ || sealed_ || IsStopped(); });
+
+    // Latch the timeout under the same lock acquisition that observed expiry — there is no separate
+    // observe-then-unlock-then-latch window a seal could slip through. Only a run that is still unsettled,
+    // unsealed and unstopped, with the deadline genuinely elapsed, becomes a timeout here.
+    if (!finished_ && !sealed_ && !IsStopped() && std::chrono::steady_clock::now() >= *deadline_ &&
+        LatchStop(StopReason::kTimeout)) {
+      if (status_ == OperationStatus::kCreated || status_ == OperationStatus::kQueued) {
+        status_ = StatusForStopReason(StopReason::kTimeout);
+      }
+
+      finished_ = true;
+      latched = true;
+      MirrorStop(StopReason::kTimeout);
+    }
+  }
+
+  // Notify and cancel outside the lock, exactly like RequestStop. Returns true only for the call that actually
+  // latched the timeout, so a watchdog that lost the race against a completing or sealed run stays silent.
+  if (latched) {
+    cv_.notify_all();
+    DeliverStop();
+  }
+
+  return latched;
+}
+
+void OperationState::NotifyWatcher() noexcept {
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    finished_ = true;
+  }
+
+  cv_.notify_all();
+}
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/operation_state.h
+++ b/sdk_v2/cpp/src/inferencing/session/operation_state.h
@@ -1,0 +1,269 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include "inferencing/session/cancel_slot.h"
+#include "inferencing/session/cancellable.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace fl {
+
+class RequestControl;
+class SessionRuntime;
+
+/// Why an operation was asked to stop. Latched exactly once — first stop wins — so the reason a run ended is
+/// unambiguous even when a session cancel, a deadline, and a callback stop all fire at once.
+enum class StopReason : uint8_t {
+  kNone = 0,        ///< Still running (or finished naturally).
+  kExternalCancel,  ///< Session::Cancel(), Operation::Cancel(), or the C ABI Request_Cancel.
+  kTimeout,         ///< The operation's absolute deadline expired.
+  kCallbackStop,    ///< A streaming callback returned non-zero or threw.
+};
+
+/// Terminal outcome of a single operation run. Consumed by Session::ProcessRequest, which maps the failure
+/// outcomes onto the public error contract.
+enum class OperationOutcome {
+  kCompleted,        ///< Inference ran to a natural stop (stop / length / tool-calls).
+  kCallbackStopped,  ///< A streaming callback asked to stop. Normal completion with FINISH_NONE.
+  kCancelled,        ///< Cancelled by the session, the operation, or the request.
+  kTimedOut,         ///< The operation's absolute deadline expired.
+  kFaulted,          ///< Inference threw. The original exception is propagated by the caller.
+  kAbandoned,        ///< The operation was destroyed without ever being processed.
+};
+
+/// Lifecycle of an operation. Advances monotonically; terminal states never revert.
+enum class OperationStatus {
+  kCreated,          ///< Registered, not yet admitted to run.
+  kQueued,           ///< Waiting in the serial admission gate for a permit.
+  kRunning,          ///< Executing ProcessRequestImpl.
+  kCompleted,        ///< Ran to completion.
+  kCallbackStopped,  ///< Stopped by a streaming callback.
+  kCancelled,        ///< Cancelled (sticky if it never reached kRunning).
+  kTimedOut,         ///< Deadline expired.
+  kFaulted,          ///< ProcessRequestImpl threw.
+  kAbandoned,        ///< Operation destroyed without being processed.
+};
+
+/// The outcome a latched stop maps to. kNone means the run was not stopped at all.
+constexpr OperationOutcome OutcomeForStopReason(StopReason reason) {
+  switch (reason) {
+    case StopReason::kTimeout:
+      return OperationOutcome::kTimedOut;
+    case StopReason::kCallbackStop:
+      return OperationOutcome::kCallbackStopped;
+    case StopReason::kExternalCancel:
+      return OperationOutcome::kCancelled;
+    case StopReason::kNone:
+    default:
+      return OperationOutcome::kCompleted;
+  }
+}
+
+/// Per-invocation run authority. One OperationState backs exactly one Operation and one runtime run.
+///
+/// Ownership: SessionRuntime holds a *strong* ref while the operation is registered; Operation holds a
+/// strong ref for its lifetime; OperationState holds only *weak* refs back to its runtime and request
+/// control. That keeps the state alive for the whole run (including the watchdog thread) without an
+/// ownership cycle, and without any raw Session/Request pointer that could dangle.
+///
+/// Locking discipline — the runtime rule is "never call into ORT or the logger under a framework lock":
+///   - `stop_reason_` is an atomic latch, so a stop can be *observed* without taking any lock.
+///   - `mu_` guards the lifecycle status, the completion seal and the watchdog condition variable. RequestStop
+///     and TrySeal both synchronise here, which is what makes "seal wins / stop wins" a single decision.
+///     An accepted stop mirrors its diagnostic while this lock is still held, taking
+///     RequestControl::claim_mu_ below it. No path holds claim_mu_ while acquiring mu_: TryClaim only performs
+///     the atomic epoch bind, ActiveOperation releases its snapshot lock before RequestStop, and Release takes
+///     only the claim lock.
+///   - `slot_mu_` guards only the *vector* of generator cancel slots. A stop detaches the vector by swap;
+///     every ICancellable::Cancel() runs afterwards, lock-free, under a CancelLease that pins
+///     the target. Lock order stays acyclic: SessionRuntime::mu_ -> OperationState::mu_, slot_mu_ standalone,
+///     CancelSlot::mu_ below slot_mu_ and never above it.
+///
+/// TestHooks is a model-free deterministic seam. Both callbacks are invoked without allocation: `now` while
+/// mu_ is held, and `before_generator_drain` after every framework lock has been released.
+class OperationState {
+ public:
+  struct TestHooks {
+    using NowFn = std::chrono::steady_clock::time_point (*)(void*) noexcept;
+    using HookFn = void (*)(void*) noexcept;
+
+    NowFn now = nullptr;
+    HookFn before_generator_drain = nullptr;
+    void* context = nullptr;
+  };
+
+  /// The result of publishing a generator: the slot that owns the publication, plus whether the caller must
+  /// deliver a cancellation because a stop had already been latched. The caller delivers it *outside* every
+  /// lock — see ActiveGenerator.
+  struct GeneratorRegistration {
+    std::shared_ptr<CancelSlot> slot;
+    bool cancel_required = false;
+  };
+
+  OperationState(std::weak_ptr<SessionRuntime> runtime, std::weak_ptr<RequestControl> request_control,
+                 std::optional<std::chrono::steady_clock::time_point> deadline, std::chrono::milliseconds budget,
+                 const TestHooks* test_hooks = nullptr);
+
+  OperationState(const OperationState&) = delete;
+  OperationState& operator=(const OperationState&) = delete;
+
+  /// The absolute deadline snapshotted at creation (includes any serialized queue wait), or nullopt.
+  const std::optional<std::chrono::steady_clock::time_point>& Deadline() const { return deadline_; }
+  bool HasDeadline() const { return deadline_.has_value(); }
+
+  /// True once the deadline instant has passed. Cheap and lock-free; used by the admission gate and by the
+  /// concurrent (embeddings) path to refuse a run whose budget was already spent while queued.
+  bool DeadlineExpired() const;
+
+  /// The originally requested budget, snapshotted for log and error messages.
+  std::chrono::milliseconds Budget() const { return budget_; }
+
+  OperationStatus Status() const;
+
+  /// The owning runtime, or nullptr if it has already been destroyed.
+  std::shared_ptr<SessionRuntime> Runtime() const { return runtime_.lock(); }
+
+  /// True once a stop has been latched. Lock-free — this is the single production stop authority.
+  bool IsStopped() const { return Reason() != StopReason::kNone; }
+
+  StopReason Reason() const { return static_cast<StopReason>(stop_reason_.load(std::memory_order_acquire)); }
+
+  /// True once a generator Cancel() (engine terminate_session) was actually delivered for this operation.
+  bool WasEngineCancelDelivered() const { return engine_cancel_delivered_.load(std::memory_order_acquire); }
+
+  /// Bind the request-claim epoch this operation owns. Called by RequestControl::TryClaim while the state is
+  /// still unreachable by any other thread, so no synchronisation beyond the atomic store is needed.
+  void BindRequestEpoch(uint64_t epoch) { request_epoch_.store(epoch, std::memory_order_release); }
+  uint64_t RequestEpoch() const { return request_epoch_.load(std::memory_order_acquire); }
+
+  // --- lifecycle transitions (called by SessionRuntime while orchestrating the run) ---
+
+  /// Move Created -> Queued. No-op if already past Created.
+  void MarkQueued();
+
+  /// Move to Running. Returns false if a stop was already latched or the operation already settled — the
+  /// caller must not run.
+  bool MarkRunning();
+
+  /// Record the terminal outcome and wake the watchdog. Returns the resolved outcome, derived solely from
+  /// the latched stop reason (no Request diagnostics are consulted). A sealed operation has no stop reason
+  /// by construction, so it always resolves to kCompleted.
+  OperationOutcome Finalize();
+
+  /// Terminal fault: ProcessRequestImpl threw. Wakes the watchdog so it can never act on a faulted run.
+  void MarkFaulted() noexcept;
+
+  /// Mark the operation abandoned (unprocessed Operation destroyed). Idempotent.
+  void Abandon() noexcept;
+
+  // --- cancellation ---
+
+  /// Latch a stop and deliver it: cancels this operation's published generators (engine terminate_session),
+  /// wakes the admission gate and the watchdog, and mirrors the stop into the Request's diagnostics.
+  ///
+  /// Thread-safe, idempotent, and never waits on a Session or Request lifetime lock. Returns true only for
+  /// the call that actually latched the stop, so a watchdog that lost the completion race stays quiet.
+  /// Returns false immediately — before any slot is even looked at — once the run has been sealed.
+  bool RequestStop(StopReason reason) noexcept;
+
+  // --- completion seal ---
+
+  /// Close the outcome to cancellation. Called by the modality layer once every generator slot has been
+  /// withdrawn and every callback decision has quiesced, immediately before it commits its response and any
+  /// session-visible state.
+  ///
+  /// Returns true if this run owns the outcome: no stop had been latched, and none can be latched from here
+  /// on. Returns false if cancellation or the deadline won the race — the modality must then roll back or
+  /// discard whatever it was about to commit and report a stopped run.
+  ///
+  /// Idempotent: a second call on an already-sealed operation returns true.
+  bool TrySeal() noexcept;
+
+  /// True once TrySeal() has succeeded.
+  bool IsSealed() const;
+
+  // --- generator publication (per-operation, isolated from sibling operations) ---
+
+  /// Publish a borrowed generator so a stop of *this* operation can interrupt it mid-compute.
+  ///
+  /// Returns the owning slot and, when a stop had already been latched, `cancel_required = true`. The caller
+  /// must then deliver the cancellation itself, outside every lock — this function never calls into the
+  /// engine while holding the slot registry.
+  [[nodiscard]] GeneratorRegistration RegisterGenerator(ICancellable& generator);
+
+  /// Deliver cancellation to one registered slot, if it still has a live target. The engine-delivery bit is
+  /// published only when the target confirms terminate_session succeeded, so an unsupported cancellation
+  /// attempt cannot hide an unrelated engine failure.
+  void CancelGenerator(const std::shared_ptr<CancelSlot>& slot) noexcept;
+
+  /// Withdraw a published generator. Removes the slot from the registry, then blocks until every outstanding
+  /// lease on it has been released, so the generator is never dereferenced after the caller destroys it.
+  void WithdrawGenerator(const std::shared_ptr<CancelSlot>& slot) noexcept;
+
+  // --- watchdog support ---
+
+  /// Block until the deadline elapses or the run finishes/stops. Returns true only if the deadline expired
+  /// with the run still active.
+  bool WaitForDeadline();
+
+  /// Wake WaitForDeadline() (used by the finalize paths).
+  void NotifyWatcher() noexcept;
+
+ private:
+  /// Latch `reason` if no stop has been latched yet. Returns true if this call won. Caller holds mu_.
+  bool LatchStop(StopReason reason);
+
+  /// True once the operation has settled and can no longer be stopped. Caller holds mu_.
+  bool IsSettledLocked() const;
+
+  /// Read the steady clock while mu_ is held. The injected clock is used only by model-free tests.
+  std::chrono::steady_clock::time_point NowLocked() const noexcept;
+
+  /// Deliver the lock-free side effects of a stop already latched and mirrored under mu_: wake the serial
+  /// admission gate and cancel every published generator. Shared by RequestStop, the deadline watchdog
+  /// (WaitForDeadline) and the seal-time timeout latch.
+  void DeliverStop() noexcept;
+
+  /// Detach every published generator under slot_mu_, then deliver each cancellation through a lease with no
+  /// lock held. The swap cannot allocate and also makes each published slot eligible for delivery at most once.
+  void CancelGenerators() noexcept;
+
+  /// Mirror the stop into the bound request control's diagnostic bits while mu_ is held. Takes
+  /// RequestControl::claim_mu_ second and never dereferences the Request — diagnostics must be committed
+  /// before Finalize can release the claim, but must never invoke cancellation.
+  void MirrorStop(StopReason reason) noexcept;
+
+  std::weak_ptr<SessionRuntime> runtime_;
+  std::weak_ptr<RequestControl> request_control_;
+  std::atomic<uint64_t> request_epoch_{0};
+  const std::optional<std::chrono::steady_clock::time_point> deadline_;
+  const std::chrono::milliseconds budget_;
+  const TestHooks* const test_hooks_;
+
+  /// The single production stop authority. Atomic so it can be polled from a token loop and read from the
+  /// slot registry without ever nesting the lifecycle mutex.
+  std::atomic<uint8_t> stop_reason_{static_cast<uint8_t>(StopReason::kNone)};
+  std::atomic<bool> engine_cancel_delivered_{false};
+
+  mutable std::mutex mu_;
+  std::condition_variable cv_;  // watchdog wakes on this
+  OperationStatus status_ = OperationStatus::kCreated;
+  bool finished_ = false;
+
+  /// Set by TrySeal(). Once true, RequestStop() is a no-op: the run owns its outcome.
+  bool sealed_ = false;
+
+  /// Guards the slot vector only — never held across an engine call.
+  std::mutex slot_mu_;
+  std::vector<std::shared_ptr<CancelSlot>> slots_;
+};
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/request.h
+++ b/sdk_v2/cpp/src/inferencing/session/request.h
@@ -1,53 +1,127 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #pragma once
 
+#include "inferencing/session/request_control.h"
 #include "items/item.h"
 #include "util/key_value_pairs.h"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace fl {
 
-/// Generic inference request — pure input data.
-/// Items are stored as borrowed pointers. Owned items are kept alive in owned_items.
+/// Generic inference request — pure input data plus a stable, shared claim control that binds it to at most
+/// one in-flight operation at a time.
+///
+/// Item storage. `items` is the ordered view; every entry is either *retained* (its shared_ptr lives in
+/// owned_items_, so the Request keeps it alive) or *borrowed* (the caller keeps it alive, per the
+/// AddBorrowedItem contract). Owned items are held by shared_ptr rather than unique_ptr so a RequestSnapshot
+/// can take exact shared ownership of them instead of copying — several item types are deliberately
+/// non-copyable, and a live streaming ItemQueue cannot be copied at all.
+///
+/// Run-state authority lives in the OperationState reached through `control_`, never here. The
+/// `canceled`/`timed_out` flags are **views onto a diagnostic mirror that lives in that control**, describing
+/// the bound operation's stop state for the current claim epoch: they are written by that operation, read by
+/// tests and by callers that want to know how a run ended, and are never consulted by production generation
+/// loops (those take an explicit OperationContext). Keeping the bits in the control is what lets a stop
+/// record them without ever locking — or even touching — the Request. `canceled` additionally routes an
+/// externally requested cancel to the bound operation so the existing C ABI `Request_Cancel` (which assigns
+/// `true` to it) still interrupts the engine.
+///
+/// The Request has **no destructor lifetime gate**. An operation never borrows the live Request across a
+/// suspension point; it runs against a RequestSnapshot captured synchronously at CreateOperation. Waiting in
+/// ~Request would be both unsound (the wait starts after destruction has begun) and deadlock-prone (a
+/// streaming callback that drops the Request from inside its own run would wait on itself).
 struct Request {
-  std::vector<Item*> items;  // all items (borrowed pointers)
+  /// Read/write view onto one of the control-owned diagnostic bits (see DiagnosticBit).
+  ///
+  /// The bit itself lives in the shared RequestControl, not in the Request. That is what lets the bound
+  /// operation mirror a stop without touching the Request at all, and it makes the mirror travel with the
+  /// control across a move.
+  ///
+  /// The view keeps the `.store()/.load()/= true/if (flag)` syntax the C ABI and existing callers use.
+  /// Assigning true (or store(true)) on a routing view additionally *routes* to the bound operation (engine
+  /// terminate_session included) instead of merely latching a bit. Once the ABI layer calls
+  /// Request::CancelActiveOperation() directly the routing shim can be dropped.
+  class DiagnosticFlag {
+   public:
+    constexpr DiagnosticFlag(DiagnosticBit bit, bool routes_cancel) noexcept
+        : bit_(bit), routes_cancel_(routes_cancel) {}
+
+    DiagnosticFlag(const DiagnosticFlag&) = delete;
+    DiagnosticFlag& operator=(const DiagnosticFlag&) = delete;
+
+    /// Bind the view to its enclosing Request. Called from every Request constructor; a move never copies
+    /// the pointer, so it always refers to the object this view is a member of and can never dangle.
+    void BindOwner(const Request& owner) { owner_ = &owner; }
+
+    /// `request->canceled = true;` — the shape the C ABI uses.
+    DiagnosticFlag& operator=(bool value) {
+      Write(value, std::memory_order_relaxed);
+      return *this;
+    }
+
+    void store(bool value, std::memory_order order = std::memory_order_relaxed) { Write(value, order); }
+
+    bool load(std::memory_order order = std::memory_order_relaxed) const;
+
+    explicit operator bool() const { return load(); }
+
+    /// Mirror write. Deliberately bypasses cancel routing: a caller already delivering the stop would
+    /// otherwise re-enter the operation it is stopping.
+    void StoreDiagnostic(bool value, std::memory_order order = std::memory_order_relaxed) const;
+
+   private:
+    /// Store the bit and, for a routing view, atomically select either the bound operation or the idle
+    /// compatibility diagnostic.
+    void Write(bool value, std::memory_order order);
+
+    /// The control that owns the bits, or nullptr on a moved-from Request.
+    RequestControl* Control() const;
+
+    /// The enclosing Request. Never dangles: it points at the object this view is a member of.
+    const Request* owner_ = nullptr;
+    const DiagnosticBit bit_;
+    const bool routes_cancel_;
+  };
+
+  std::vector<Item*> items;  // ordered view over retained + borrowed items
   KeyValuePairs options;
 
-  /// Cancellation flag — set by the C API or streaming callback handler to cancel
-  /// an in-flight request. Checked in generation loops. Atomic because it is written
-  /// by one thread (callback worker or C API) and read by another (generator loop).
-  /// Uses relaxed ordering since it is a one-way flag and exact timing doesn't matter.
-  mutable std::atomic<bool> canceled{false};
+  /// Diagnostic mirror of the bound operation's stop state; assigning true also routes an external cancel to
+  /// that operation. The bit lives in the shared control, so it is written by one thread (callback worker,
+  /// watchdog, or C API) and read by another without ever locking the Request.
+  mutable DiagnosticFlag canceled{DiagnosticBit::kCancelled, /*routes_cancel=*/true};
 
-  /// Set to true when the request was stopped because its deadline expired rather than
-  /// by an explicit Cancel(). Callers use this to distinguish a timeout from a user cancel.
-  mutable std::atomic<bool> timed_out{false};
+  /// Set when the run stopped because its deadline expired rather than by an explicit cancel. Diagnostic
+  /// mirror only; callers use it to distinguish a timeout from a user cancel.
+  mutable DiagnosticFlag timed_out{DiagnosticBit::kTimedOut, /*routes_cancel=*/false};
 
-  Request() = default;
+  Request() {
+    BindDiagnostics();
+  }
 
-  Request(Request&& other) noexcept
-      : items(std::move(other.items)),
-        options(std::move(other.options)),
-        canceled(other.canceled.load(std::memory_order_relaxed)),
-        timed_out(other.timed_out.load(std::memory_order_relaxed)),
-        timeout_ms_(other.timeout_ms_.load(std::memory_order_relaxed)),
-        deadline_ticks_(other.deadline_ticks_.load(std::memory_order_relaxed)),
-        owned_items(std::move(other.owned_items)) {}
+  ~Request() = default;
+
+  /// Moving transfers the *exact* claim control — identity, epoch, claim and diagnostic bits — to the
+  /// destination. The claim is never duplicated and no control is allocated for a move: the moved-from
+  /// Request is left with none at all, so it can no longer be used to create an operation (CreateOperation
+  /// rejects it with INVALID_USAGE).
+  Request(Request&& other) noexcept : Request(NoControlTag{}) {
+    MoveFrom(std::move(other));
+  }
 
   Request& operator=(Request&& other) noexcept {
-    items = std::move(other.items);
-    options = std::move(other.options);
-    canceled.store(other.canceled.load(std::memory_order_relaxed), std::memory_order_relaxed);
-    timed_out.store(other.timed_out.load(std::memory_order_relaxed), std::memory_order_relaxed);
-    timeout_ms_.store(other.timeout_ms_.load(std::memory_order_relaxed), std::memory_order_relaxed);
-    deadline_ticks_.store(other.deadline_ticks_.load(std::memory_order_relaxed), std::memory_order_relaxed);
-    owned_items = std::move(other.owned_items);
+    if (this != &other) {
+      MoveFrom(std::move(other));
+    }
+
     return *this;
   }
 
@@ -55,7 +129,7 @@ struct Request {
   Request& operator=(const Request&) = delete;
 
   /// Set a wall-clock budget for the request. Zero (the default) means no deadline.
-  /// Takes effect on the next ArmDeadline() — i.e. the next ProcessRequest call.
+  /// Takes effect on the next operation created for this request.
   void SetTimeout(std::chrono::milliseconds timeout) {
     timeout_ms_.store(timeout.count() < 0 ? 0 : static_cast<uint64_t>(timeout.count()), std::memory_order_relaxed);
   }
@@ -64,11 +138,20 @@ struct Request {
     return std::chrono::milliseconds(timeout_ms_.load(std::memory_order_relaxed));
   }
 
-  /// Start the timeout clock and clear per-run stop state. Called by Session::ProcessRequest
-  /// so a Request reused across calls gets a fresh budget each time.
+  /// Clear the diagnostic mirror. Production runs get this for free: a won claim clears the bits under the
+  /// claim lock (RequestControl::TryClaim), so they always describe the operation that currently owns the
+  /// Request. This stays for the legacy ArmDeadline path below. No-op on a moved-from Request.
+  void ResetDiagnostics() const {
+    if (control_) {
+      control_->ResetDiagnostics();
+    }
+  }
+
+  /// Legacy/diagnostic deadline helpers. Production runs get their budget from the operation's absolute
+  /// deadline (snapshotted at CreateOperation, watchdog-enforced); these remain for direct-Request unit
+  /// coverage that drives a generator without a Session.
   void ArmDeadline() const {
-    canceled.store(false, std::memory_order_relaxed);
-    timed_out.store(false, std::memory_order_relaxed);
+    ResetDiagnostics();
 
     const auto budget = timeout_ms_.load(std::memory_order_relaxed);
     if (budget == 0) {
@@ -83,9 +166,8 @@ struct Request {
   /// Clear the deadline so a later check cannot trip after the run has ended.
   void DisarmDeadline() const { deadline_ticks_.store(0, std::memory_order_relaxed); }
 
-  /// True once the request should stop — either explicitly cancelled or past its deadline.
-  /// Deadline expiry latches `canceled` so the existing post-loop cancellation handling
-  /// (rewind, finish_reason, history rollback) applies unchanged to timeouts.
+  /// Legacy/diagnostic stop check: true once the mirror says cancelled or the legacy armed deadline passed.
+  /// **Not** a production stop authority — production paths poll OperationContext::ShouldStop().
   bool ShouldStop() const {
     if (canceled.load(std::memory_order_relaxed)) {
       return true;
@@ -101,14 +183,25 @@ struct Request {
     }
 
     timed_out.store(true, std::memory_order_relaxed);
-    canceled.store(true, std::memory_order_relaxed);
+    canceled.StoreDiagnostic(true);
     return true;
   }
 
-  /// Add a pre-allocated owned item.
+  /// Add a pre-allocated owned item. The Request keeps it alive; a RequestSnapshot retains the same object
+  /// rather than copying it.
   void AddOwnedItem(std::unique_ptr<Item> item) {
+    AddRetainedItem(std::shared_ptr<Item>(std::move(item)));
+  }
+
+  /// Retain an already-shared item. Used by RequestSnapshot to take exact shared ownership of the source
+  /// Request's items, which is what makes a deferred Process safe for non-copyable item types.
+  void AddRetainedItem(std::shared_ptr<Item> item) {
+    if (!item) {
+      return;
+    }
+
     items.push_back(item.get());
-    owned_items.push_back(std::move(item));
+    owned_items_.push_back(std::move(item));
   }
 
   /// Add a borrowed item (caller must keep it alive).
@@ -116,13 +209,133 @@ struct Request {
     items.push_back(item);
   }
 
+  /// The items this Request keeps alive, in insertion order.
+  const std::vector<std::shared_ptr<Item>>& OwnedItems() const { return owned_items_; }
+
+  /// The shared owner of `item` if this Request retains it, otherwise nullptr (a borrowed item).
+  std::shared_ptr<Item> FindOwnedItem(const Item* item) const {
+    auto it = std::find_if(owned_items_.begin(), owned_items_.end(),
+                           [item](const std::shared_ptr<Item>& owned) { return owned.get() == item; });
+    return it != owned_items_.end() ? *it : nullptr;
+  }
+
+  // --- operation binding ---
+
+  /// The stable claim control. An Operation holds this shared_ptr instead of a `Request&`, so a claim can be
+  /// released by identity and epoch without ever dereferencing the Request. Null only on a moved-from
+  /// Request, which Session::CreateOperation rejects with FOUNDRY_LOCAL_ERROR_INVALID_USAGE.
+  const std::shared_ptr<RequestControl>& Control() const { return control_; }
+
+  /// Cancel the operation currently bound to this Request, if any. Returns true when a cancel was routed to an
+  /// active operation, false when the Request is idle or moved-from. This is the hook the ABI's Request_Cancel
+  /// routes through so a cancel targets only the active operation (interrupting its generators mid-compute)
+  /// rather than latching a reusable atomic.
+  ///
+  /// ActiveOperation snapshots the state under RequestControl::claim_mu_ and releases that lock before
+  /// entering OperationState::RequestStop. The only nested order is the accepted-stop diagnostic path,
+  /// OperationState::mu_ -> RequestControl::claim_mu_; this future API routing path never holds both and does
+  /// not prewrite an idle diagnostic. Engine cancellation runs after both locks have been released.
+  bool CancelActiveOperation() const {
+    if (!control_) {
+      return false;  // moved-from shell: it can no longer own an operation
+    }
+
+    // ActiveOperation() takes claim_mu_, copies the shared_ptr and releases it, so the RequestStop below runs
+    // with no RequestControl lock held.
+    auto operation = control_->ActiveOperation();
+    if (!operation) {
+      return false;  // idle: nothing bound, so routing a cancel is a no-op
+    }
+
+    operation->RequestStop(StopReason::kExternalCancel);
+    return true;
+  }
+
  private:
   using Clock = std::chrono::steady_clock;
 
+  /// Tag for the allocation-free shell the move constructor starts from: `control_` stays null and is
+  /// immediately replaced by the source's control, so no RequestControl is allocated for a move and both
+  /// move paths stay noexcept.
+  struct NoControlTag {};
+
+  explicit Request(NoControlTag) noexcept : control_(nullptr) {
+    BindDiagnostics();
+  }
+
+  /// Point both diagnostic views at this object. Called from every constructor.
+  void BindDiagnostics() noexcept {
+    canceled.BindOwner(*this);
+    timed_out.BindOwner(*this);
+  }
+
+  /// Shared move implementation. The destination's previous control is simply dropped: an operation that
+  /// still holds it keeps it alive and releases against it by identity and epoch, and because operations run
+  /// against a snapshot they were never reading this Request's storage in the first place.
+  void MoveFrom(Request&& other) noexcept {
+    items = std::move(other.items);
+    options = std::move(other.options);
+    owned_items_ = std::move(other.owned_items_);
+    timeout_ms_.store(other.timeout_ms_.load(std::memory_order_relaxed), std::memory_order_relaxed);
+    deadline_ticks_.store(other.deadline_ticks_.load(std::memory_order_relaxed), std::memory_order_relaxed);
+
+    // The diagnostic mirror lives in the control, so transferring it carries the flags across unchanged and
+    // leaves the moved-from Request reporting the clean state.
+    control_ = std::move(other.control_);
+    other.control_.reset();
+    other.items.clear();
+    other.owned_items_.clear();
+  }
+
   mutable std::atomic<uint64_t> timeout_ms_{0};
-  /// steady_clock time_point ticks for the current run's deadline; 0 means unarmed.
+  /// steady_clock time_point ticks for the legacy armed deadline; 0 means unarmed.
   mutable std::atomic<int64_t> deadline_ticks_{0};
-  std::vector<std::unique_ptr<Item>> owned_items;  // owned items (lifetime)
+
+  /// Stable claim gate and diagnostic mirror; shared with the Operation that claimed it. Null only on a
+  /// moved-from Request, which can no longer be claimed and reports clean diagnostics.
+  std::shared_ptr<RequestControl> control_ = std::make_shared<RequestControl>();
+
+  /// Items whose lifetime this Request owns, in insertion order.
+  std::vector<std::shared_ptr<Item>> owned_items_;
 };
+
+inline RequestControl* Request::DiagnosticFlag::Control() const {
+  return owner_ != nullptr ? owner_->control_.get() : nullptr;
+}
+
+inline bool Request::DiagnosticFlag::load(std::memory_order order) const {
+  // A moved-from Request owns no control and therefore no diagnostics: report the clean state instead of
+  // dereferencing.
+  const RequestControl* control = Control();
+  return control != nullptr && control->Diagnostic(bit_, order);
+}
+
+inline void Request::DiagnosticFlag::StoreDiagnostic(bool value, std::memory_order order) const {
+  if (RequestControl* control = Control()) {
+    control->SetDiagnostic(bit_, value, order);
+  }
+}
+
+inline void Request::DiagnosticFlag::Write(bool value, std::memory_order order) {
+  // A non-routing view (timed_out), a clearing write, or a view with no owner latches the diagnostic bit
+  // directly — there is nothing to linearize against.
+  if (!routes_cancel_ || !value || owner_ == nullptr) {
+    StoreDiagnostic(value, order);
+    return;
+  }
+
+  RequestControl* control = Control();
+  if (control == nullptr) {
+    return;
+  }
+
+  // Select the active epoch or preserve the legacy idle diagnostic under the same claim lock TryClaim uses.
+  // RequestStop runs after that lock is released. If an operation existed but has since sealed, its rejected
+  // stop deliberately does not fall back to a diagnostic write.
+  auto operation = control->ActiveOperationOrSetIdleCancelled(order);
+  if (operation) {
+    operation->RequestStop(StopReason::kExternalCancel);
+  }
+}
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/request_control.cc
+++ b/sdk_v2/cpp/src/inferencing/session/request_control.cc
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "inferencing/session/request_control.h"
+
+namespace fl {
+
+RequestControl::ClaimResult RequestControl::TryClaim(const std::shared_ptr<OperationState>& state) {
+  std::lock_guard<std::mutex> lock(claim_mu_);
+  if (claimed_) {
+    return {};
+  }
+
+  ++epoch_;
+  claimed_ = true;
+
+  // Clear the previous run's mirror under the same lock that gates it: the claim that wins always starts
+  // from a deterministically clean slate, with no window for a late stop of the previous run to land after.
+  ClearDiagnosticsLocked();
+
+  // Bind the epoch before publishing the state: until `operation_` is set nothing else can reach it, so the
+  // diagnostic mirror can never run against epoch 0.
+  state->BindRequestEpoch(epoch_);
+  operation_ = state;
+
+  return ClaimResult{.claimed = true, .epoch = epoch_};
+}
+
+void RequestControl::Release(const OperationState& state, uint64_t epoch) noexcept {
+  // Drop the strong ref outside the lock: releasing the last reference here would run ~OperationState under
+  // the claim lock.
+  std::shared_ptr<OperationState> released;
+
+  {
+    std::lock_guard<std::mutex> lock(claim_mu_);
+
+    // Exact identity + epoch match: a stale release from an already-finished operation must not clear the
+    // claim of a later run on the same Request.
+    if (!claimed_ || epoch_ != epoch || operation_.get() != &state) {
+      return;
+    }
+
+    claimed_ = false;
+    released = std::move(operation_);
+    operation_.reset();
+  }
+}
+
+std::shared_ptr<OperationState> RequestControl::ActiveOperation() const {
+  std::lock_guard<std::mutex> lock(claim_mu_);
+  return operation_;
+}
+
+std::shared_ptr<OperationState> RequestControl::ActiveOperationOrSetIdleCancelled(std::memory_order order) {
+  std::lock_guard<std::mutex> lock(claim_mu_);
+  if (operation_) {
+    return operation_;
+  }
+
+  // TryClaim clears this under the same lock before publishing a new epoch, so an idle compatibility write
+  // can describe only the idle/previous epoch and can never leak into a newly claimed operation.
+  cancelled_.store(true, order);
+  return {};
+}
+
+void RequestControl::ResetDiagnostics() {
+  std::lock_guard<std::mutex> lock(claim_mu_);
+  ClearDiagnosticsLocked();
+}
+
+void RequestControl::MirrorStop(const OperationState& state, uint64_t epoch, StopReason reason) noexcept {
+  std::lock_guard<std::mutex> lock(claim_mu_);
+
+  // Exact identity + epoch match: a finished operation must never write into a later run's diagnostics.
+  if (!claimed_ || epoch_ != epoch || operation_.get() != &state) {
+    return;
+  }
+
+  if (reason == StopReason::kTimeout) {
+    timed_out_.store(true, std::memory_order_relaxed);
+  }
+
+  // Mirror writes bypass the Request's cancel routing on purpose: routing here would re-enter the operation
+  // that is already delivering this very stop.
+  cancelled_.store(true, std::memory_order_relaxed);
+}
+
+void RequestControl::ClearDiagnosticsLocked() {
+  cancelled_.store(false, std::memory_order_relaxed);
+  timed_out_.store(false, std::memory_order_relaxed);
+}
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/request_control.h
+++ b/sdk_v2/cpp/src/inferencing/session/request_control.h
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include "inferencing/session/operation_state.h"
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+
+namespace fl {
+
+/// One of the control-owned diagnostic bits describing how the current (or last) run ended.
+///
+/// The bits deliberately live in the RequestControl rather than in the Request: mirroring a stop must never
+/// reach through anything the Request owns, because the thread delivering that stop may be the run itself.
+/// Keeping them here also means the mirror travels with the control across a move, and that a destroyed
+/// Request can never make a stop block.
+enum class DiagnosticBit : uint8_t {
+  kCancelled,  ///< The bound operation was asked to stop, for any reason.
+  kTimedOut,   ///< ... and the reason was its own deadline expiring.
+};
+
+/// Stable, shared claim identity for one Request.
+///
+/// The control owns *claim identity only* — deliberately not the Request's storage or lifetime. An earlier
+/// shape put a reader/writer "owner gate" here and had ~Request block on it so an in-flight operation could
+/// borrow the live Request. That is unsound: the wait happens after destruction has already begun, and a
+/// callback that releases the Request from inside its own run self-deadlocks. Execution data is snapshotted
+/// instead (see RequestSnapshot), so nothing ever borrows a Request across a suspension point and this class
+/// reduces to claim bookkeeping plus a diagnostic mirror.
+///
+/// At most one operation may hold a Request at a time and each claim gets a monotonic epoch. Release and
+/// MirrorStop validate the exact OperationState **and** epoch, so a stale release or a late stop from a
+/// finished operation can never touch a later run's claim. The same lock gates the diagnostic mirror, so a
+/// new claim always starts from a deterministically cleared state.
+///
+/// Lock order is OperationState::mu_ -> claim_mu_. TryClaim calls only BindRequestEpoch (an atomic store)
+/// while holding claim_mu_; operation snapshots release claim_mu_ before RequestStop; Release takes only
+/// claim_mu_. No path nests the locks in the opposite order.
+class RequestControl {
+ public:
+  struct ClaimResult {
+    bool claimed = false;
+    uint64_t epoch = 0;
+  };
+
+  RequestControl() = default;
+
+  RequestControl(const RequestControl&) = delete;
+  RequestControl& operator=(const RequestControl&) = delete;
+
+  // --- claim state ---
+
+  /// Claim the Request for `state`. Fails if another operation already holds it. On success the diagnostic
+  /// mirror is cleared and the state is bound to the new epoch, both before it becomes reachable through
+  /// ActiveOperation().
+  ClaimResult TryClaim(const std::shared_ptr<OperationState>& state);
+
+  /// Release the claim held by exactly `state` at exactly `epoch`. A mismatched (stale) release is ignored.
+  void Release(const OperationState& state, uint64_t epoch) noexcept;
+
+  /// The operation currently holding this Request, or nullptr when idle. Used by the C ABI cancel path.
+  std::shared_ptr<OperationState> ActiveOperation() const;
+
+  /// For the legacy routed `request.canceled = true` shape, atomically choose one epoch under claim_mu_:
+  /// return a strong snapshot of its active operation, or write the idle cancelled diagnostic. The caller
+  /// releases claim_mu_ before RequestStop; if the returned operation later rejects a post-seal stop there is
+  /// deliberately no fallback diagnostic write.
+  std::shared_ptr<OperationState> ActiveOperationOrSetIdleCancelled(
+      std::memory_order order = std::memory_order_relaxed);
+
+  // --- diagnostic mirror (control-owned; lock-free to read) ---
+
+  /// Read one diagnostic bit. Never blocks.
+  bool Diagnostic(DiagnosticBit bit, std::memory_order order = std::memory_order_relaxed) const {
+    return (bit == DiagnosticBit::kTimedOut ? timed_out_ : cancelled_).load(order);
+  }
+
+  /// Write one diagnostic bit directly. Deliberately bypasses the Request's cancel routing: the caller is
+  /// either the operation already delivering the stop or a diagnostic-only legacy path.
+  void SetDiagnostic(DiagnosticBit bit, bool value, std::memory_order order = std::memory_order_relaxed) {
+    (bit == DiagnosticBit::kTimedOut ? timed_out_ : cancelled_).store(value, order);
+  }
+
+  /// Clear both diagnostic bits, serialised against MirrorStop through claim_mu_.
+  void ResetDiagnostics();
+
+  /// Mirror a latched stop into the diagnostic bits. Called while OperationState::mu_ is held and validates
+  /// the exact state and epoch under claim_mu_, so the diagnostic is committed before Finalize can release
+  /// the claim. Never dereferences the Request or invokes cancellation.
+  void MirrorStop(const OperationState& state, uint64_t epoch, StopReason reason) noexcept;
+
+ private:
+  /// Clear the mirror. Caller holds claim_mu_.
+  void ClearDiagnosticsLocked();
+
+  mutable std::mutex claim_mu_;
+  std::shared_ptr<OperationState> operation_;
+  uint64_t epoch_ = 0;
+  bool claimed_ = false;
+
+  /// Accepted-stop mirrors and routed idle writes are serialized by claim_mu_, so neither can contaminate a
+  /// later claim. Diagnostic-only compatibility writes remain lock-free. All reads are lock-free and
+  /// independent of the owning Request's lifetime.
+  std::atomic<bool> cancelled_{false};
+  std::atomic<bool> timed_out_{false};
+};
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/request_snapshot.cc
+++ b/sdk_v2/cpp/src/inferencing/session/request_snapshot.cc
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "inferencing/session/request_snapshot.h"
+
+#include "items/message_item.h"
+#include "items/text_item.h"
+#include "items/tool_call_item.h"
+#include "items/tool_result_item.h"
+
+#include <utility>
+
+namespace fl {
+
+namespace {
+
+/// Deep-clone a *borrowed* item so the snapshot owns it outright.
+///
+/// Only the self-contained value types are clonable. Everything else — a live ItemQueue, a TensorItem whose
+/// buffer belongs to a custom deleter, a BytesItem/AudioItem/ImageItem pointing at caller memory — either
+/// cannot be copied at all or would silently change meaning if it were, so those stay borrowed and the
+/// AddBorrowedItem contract ("the caller keeps it alive") continues to apply for the duration of the run.
+std::shared_ptr<Item> CloneBorrowedItem(const Item& source) {
+  switch (source.type) {
+    case FOUNDRY_LOCAL_ITEM_TEXT: {
+      const auto& text = static_cast<const TextItem&>(source);
+      return std::make_shared<TextItem>(text.text, text.text_type);
+    }
+
+    case FOUNDRY_LOCAL_ITEM_MESSAGE:
+      // MessageItem's copy constructor deep-clones every part (see MessageItem::CloneApiPart), including
+      // image/audio payloads, so the clone has no dependency on the source's lifetime.
+      return std::make_shared<MessageItem>(static_cast<const MessageItem&>(source));
+
+    case FOUNDRY_LOCAL_ITEM_TOOL_RESULT: {
+      const auto& result = static_cast<const ToolResultItem&>(source);
+      return std::make_shared<ToolResultItem>(result.call_id, result.result);
+    }
+
+    case FOUNDRY_LOCAL_ITEM_TOOL_CALL: {
+      const auto& call = static_cast<const ToolCallItem&>(source);
+      return std::make_shared<ToolCallItem>(call.call_id, call.name, call.arguments);
+    }
+
+    default:
+      return nullptr;
+  }
+}
+
+}  // namespace
+
+std::shared_ptr<const RequestSnapshot> RequestSnapshot::Capture(const Request& source) {
+  // make_shared cannot reach the private constructor; the snapshot is built here and handed out as const.
+  std::shared_ptr<RequestSnapshot> snapshot(new RequestSnapshot());
+
+  snapshot->data_.options = source.options;
+  snapshot->data_.SetTimeout(source.Timeout());
+  snapshot->data_.items.reserve(source.items.size());
+
+  for (Item* item : source.items) {
+    if (item == nullptr) {
+      continue;
+    }
+
+    // Exact shared ownership for anything the Request already owns: no copy, identity preserved, and the
+    // caller can drop the Request without freeing it.
+    if (auto retained = source.FindOwnedItem(item)) {
+      snapshot->data_.AddRetainedItem(std::move(retained));
+      continue;
+    }
+
+    if (auto cloned = CloneBorrowedItem(*item)) {
+      snapshot->data_.AddRetainedItem(std::move(cloned));
+      continue;
+    }
+
+    snapshot->data_.AddBorrowedItem(item);
+    snapshot->has_borrowed_items_ = true;
+  }
+
+  return snapshot;
+}
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/request_snapshot.h
+++ b/sdk_v2/cpp/src/inferencing/session/request_snapshot.h
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include "inferencing/session/request.h"
+
+#include <memory>
+
+namespace fl {
+
+/// Immutable execution data for one operation, captured synchronously at CreateOperation.
+///
+/// Why this exists. An Operation may be created now and processed later, possibly on another thread, while
+/// the caller still owns the Request and is free to mutate, move or destroy it. Two obvious answers are both
+/// wrong: copying the Request does not compile (it is non-copyable, and several item types are non-copyable
+/// by design), and gating ~Request on an in-flight run is unsound and self-deadlocks when the run's own
+/// callback releases the Request. So the operation runs against this snapshot instead, and never touches the
+/// caller's Request at all.
+///
+/// What is captured, per item:
+///   - **Retained items** (added via AddOwnedItem, which is what the C ABI's take_ownership path and every
+///     internal builder use): the snapshot takes *shared ownership* of the exact same object. No copy, so
+///     non-copyable payloads — a live streaming ItemQueue, a TensorItem with a custom deleter — keep working
+///     and keep their identity, and the caller releasing the Request cannot free them.
+///   - **Borrowed items** (AddBorrowedItem): copyable types are deep-cloned into snapshot-owned storage.
+///     Types that cannot be cloned without changing their meaning are borrowed through only for the
+///     synchronous Session::ProcessRequest convenience, whose caller already guarantees their lifetime.
+///     Explicit deferred operations reject such a snapshot at creation.
+///
+/// Claim identity is deliberately *not* part of this type. The Operation holds the source Request's
+/// RequestControl separately, so cancellation and diagnostics still target the exact reusable Request by
+/// epoch while execution reads only immutable data.
+class RequestSnapshot {
+ public:
+  /// Capture `source`. Throws only what item cloning throws (allocation).
+  static std::shared_ptr<const RequestSnapshot> Capture(const Request& source);
+
+  RequestSnapshot(const RequestSnapshot&) = delete;
+  RequestSnapshot& operator=(const RequestSnapshot&) = delete;
+
+  /// The stable request the modality layer executes against.
+  const Request& Data() const { return data_; }
+
+  /// True when at least one item is borrowed from caller storage the snapshot could not take over. The
+  /// explicit deferred-operation path rejects this; only synchronous ProcessRequest may accept it.
+  bool HasBorrowedItems() const { return has_borrowed_items_; }
+
+ private:
+  RequestSnapshot() = default;
+
+  Request data_;
+  bool has_borrowed_items_ = false;
+};
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/response.h
+++ b/sdk_v2/cpp/src/inferencing/session/response.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include <foundry_local/foundry_local_c.h>
@@ -28,6 +29,17 @@ struct Response {
   // arbitrary response metadata (e.g. completion_id, created, model).
   // internal usage only currently but can be surfaced if needed.
   KeyValuePairs metadata;
+
+  /// Exchange complete response ownership without allocating. Modality code uses this as its only
+  /// post-seal publication step, and Operation uses it to clear stale or faulted output safely.
+  void Swap(Response& other) noexcept {
+    using std::swap;
+
+    items.swap(other.items);
+    swap(finish_reason, other.finish_reason);
+    swap(usage, other.usage);
+    swap(metadata, other.metadata);
+  }
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/session.cc
+++ b/sdk_v2/cpp/src/inferencing/session/session.cc
@@ -7,53 +7,33 @@
 #include "inferencing/generative/chat/chat_session.h"
 #include "inferencing/generative/embeddings/embeddings_session.h"
 #include "inferencing/model_load_manager.h"
-#include "inferencing/session/live_session_registry.h"
-#include "inferencing/session/session_manager.h"
+#include "inferencing/session/operation.h"
+#include "inferencing/session/request_control.h"
+#include "inferencing/session/request_snapshot.h"
+#include "logger.h"
 #include "manager.h"
 #include "model.h"
 #include "telemetry/telemetry.h"
 #include "telemetry/telemetry_action_tracker.h"
 #include "utils.h"
 
-#include <nlohmann/json.hpp>
-
+#include <chrono>
 #include <memory>
+#include <optional>
+#include <utility>
 
 namespace fl {
 
-Session::Session(const fl::Model& catalog_model, ILogger& logger, ITelemetry& telemetry,
-                 bool allow_concurrent_requests)
-    : catalog_model_(catalog_model),
-      logger_(logger),
-      telemetry_(telemetry),
-      allow_concurrent_requests_(allow_concurrent_requests) {
-  LiveSessionRegistry::Instance().Add(*this);
-}
+Session::~Session() noexcept {
+  if (!runtime_) {
+    return;  // moved-from shell: the destination owns the runtime
+  }
 
-// Moving relocates the session, so the registry must follow the object's address.
-// The moved-from shell stays registered until its own destructor runs; cancelling it is
-// harmless because its cancel state moved with it.
-Session::Session(Session&& other) noexcept
-    : catalog_model_(other.catalog_model_),
-      logger_(other.logger_),
-      telemetry_(other.telemetry_),
-      tool_definitions_(std::move(other.tool_definitions_)),
-      session_options_(std::move(other.session_options_)),
-      callback_fn_(std::move(other.callback_fn_)),
-      callback_user_data_(other.callback_user_data_),
-      allow_concurrent_requests_(other.allow_concurrent_requests_),
-      request_mutex_(std::move(other.request_mutex_)),
-      cancel_state_(std::move(other.cancel_state_)) {
-  // Give the moved-from shell fresh state rather than null pointers: it stays live (and
-  // reachable from the registry) until its destructor runs, and Cancel() may race with it.
-  other.request_mutex_ = std::make_unique<std::mutex>();
-  other.cancel_state_ = std::make_unique<CancelState>();
-
-  LiveSessionRegistry::Instance().Add(*this);
-}
-
-Session::~Session() {
-  LiveSessionRegistry::Instance().Remove(*this);
+  // Signal-only, and deliberately so. Cancelling here guarantees that dropping the last handle to a session
+  // stops a runaway generation instead of leaving it pinning the model, and returning immediately is what
+  // makes it legal to release a Session from inside its own streaming callback. Physical destruction of the
+  // runtime — and of the model lease it holds — happens when the last operation/callback reference goes.
+  runtime_->CancelAll();
 }
 
 std::unique_ptr<Session> Session::Create(const fl::Model& model) {
@@ -65,17 +45,18 @@ std::unique_ptr<Session> Session::Create(const fl::Model& model) {
 
   try {
     if (mgr.IsShutdownRequested()) {
-      FL_LOG_AND_THROW(logger, FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
-                       "cannot create session during shutdown");
+      FL_LOG_AND_THROW(logger, FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "cannot create session during shutdown");
     }
 
     if (!model.IsLoaded()) {
       FL_LOG_AND_THROW(logger, FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "model must be loaded before creating a session");
     }
 
-    auto& lm = mgr.GetModelLoadManager();
-    auto* loaded = lm.GetLoadedModel(model.Id());
-    if (!loaded) {
+    // Acquire the lease *before* building anything: the load check and the lease increment happen in one
+    // critical section inside the manager, so the model cannot be unloaded out from under the runtime that
+    // is about to adopt it.
+    auto lease = mgr.GetModelLoadManager().AcquireLoadedModel(model.Id());
+    if (!lease.has_value()) {
       FL_LOG_AND_THROW(logger, FOUNDRY_LOCAL_ERROR_INTERNAL, "loaded model not found in load manager");
     }
 
@@ -83,19 +64,19 @@ std::unique_ptr<Session> Session::Create(const fl::Model& model) {
 
     const auto& info = model.Info();
     if (info.task == "chat-completion" || info.task == "vision-language-chat") {
-      auto session = std::make_unique<ChatSession>(model, *loaded, logger, telemetry);
+      auto session = std::make_unique<ChatSession>(model, std::move(*lease), logger, telemetry);
       tracker.SetStatus(ActionStatus::kSuccess);
       return session;
     }
 
     if (info.task == "automatic-speech-recognition") {
-      auto session = std::make_unique<AudioSession>(model, *loaded, logger, telemetry);
+      auto session = std::make_unique<AudioSession>(model, std::move(*lease), logger, telemetry);
       tracker.SetStatus(ActionStatus::kSuccess);
       return session;
     }
 
     if (info.task == "embeddings") {
-      auto session = std::make_unique<EmbeddingsSession>(model, *loaded, logger, telemetry);
+      auto session = std::make_unique<EmbeddingsSession>(model, std::move(*lease), logger, telemetry);
       tracker.SetStatus(ActionStatus::kSuccess);
       return session;
     }
@@ -107,181 +88,117 @@ std::unique_ptr<Session> Session::Create(const fl::Model& model) {
   }
 }
 
-void Session::UndoTurns(size_t /*count*/) {
-  FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "UndoTurns is not supported for this session type");
-}
-
-void Session::AddToolDefinition(ToolDefinition tool_def) {
-  if (!nlohmann::json::accept(tool_def.json_schema)) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-             "ToolDefinition.json_schema is not valid JSON for tool: " + tool_def.name);
-  }
-
-  tool_definitions_.push_back(std::move(tool_def));
-}
-
 void Session::Cancel() {
-  std::vector<ICancellable*> generators;
-  std::vector<const Request*> requests;
-
-  {
-    std::lock_guard<std::mutex> lock(cancel_state_->mutex);
-    cancel_state_->cancel_requested = true;
-    generators = cancel_state_->active_generators;
-    requests = cancel_state_->active_requests_list;
-  }
-
-  // Latch the flag on every in-flight request, not just the generators. Interrupting the
-  // engine alone is not enough: the loops would exit but the run would still be reported
-  // as a natural stop, and cancelled turns would be committed to history. Cancellation
-  // during prefill is exactly this case — it produces no tokens, so nothing else marks it.
-  for (const auto* request : requests) {
-    request->canceled.store(true, std::memory_order_relaxed);
-  }
-
-  // Wake the deadline watchdog so it exits instead of sleeping out the full budget.
-  cancel_state_->cv.notify_all();
-
-  // Cancel outside the lock: each Cancel() reaches into ORT GenAI, and holding the
-  // mutex across that would block the request thread's generator bookkeeping.
-  for (auto* generator : generators) {
-    generator->Cancel();
-  }
-}
-
-void Session::AddActiveGenerator(ICancellable* generator) {
-  bool cancel_now = false;
-
-  {
-    std::lock_guard<std::mutex> lock(cancel_state_->mutex);
-    cancel_state_->active_generators.push_back(generator);
-
-    // Cancel() may have landed between the caller's pre-flight check and this
-    // publication. Apply the pending stop to the newly-visible generator so the
-    // request cannot slip past an already-issued cancellation.
-    cancel_now = cancel_state_->cancel_requested;
-  }
-
-  if (cancel_now) {
-    generator->Cancel();
-  }
-}
-
-void Session::RemoveActiveGenerator(ICancellable* generator) {
-  std::lock_guard<std::mutex> lock(cancel_state_->mutex);
-  auto& generators = cancel_state_->active_generators;
-  generators.erase(std::remove(generators.begin(), generators.end(), generator), generators.end());
-}
-
-void Session::WatchDeadline(const Request& request) {
-  const auto timeout = request.Timeout();
-
-  std::unique_lock<std::mutex> lock(cancel_state_->mutex);
-
-  // Wait out the budget, but wake early if the request finished or was cancelled —
-  // otherwise ProcessRequest would block on joining this thread for the full timeout.
-  const bool woken = cancel_state_->cv.wait_for(lock, timeout, [this] {
-    return cancel_state_->active_requests == 0 || cancel_state_->cancel_requested;
-  });
-
-  if (woken) {
+  if (!runtime_) {
     return;
   }
 
-  // Deadline expired. Latch the timeout on the request so generation loops stop at the
-  // next token boundary, and cancel the active generators to interrupt an in-flight
-  // compute (a long prefill can exceed the budget without ever reaching a boundary).
-  request.canceled.store(true, std::memory_order_relaxed);
-  request.timed_out.store(true, std::memory_order_relaxed);
+  // Terminal, signal-only: mark the runtime terminal and stop every registered operation. Never waits.
+  runtime_->CancelAll();
+}
 
-  auto generators = cancel_state_->active_generators;
-  lock.unlock();
+std::unique_ptr<Operation> Session::CreateOperation(const Request& request) {
+  return CreateOperationImpl(request, /*allow_borrowed_items=*/false, ResponseVisibility::kExplicitAtomic);
+}
 
-  logger_.Log(LogLevel::Warning,
-              fmt::format("request exceeded its {}ms deadline; cancelling", timeout.count()));
+std::unique_ptr<Operation> Session::CreateOperationImpl(const Request& request, bool allow_borrowed_items,
+                                                        ResponseVisibility visibility) {
+  // Capture the implementation before doing any work. ProcessRequest subsequently runs only through the
+  // Operation's strong reference, so a callback may release the facade without ending the executable state.
+  const auto runtime = runtime_;
+  if (!runtime) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "session has been moved from and can no longer run requests");
+  }
 
-  for (auto* generator : generators) {
-    generator->Cancel();
+  // Reject a terminal session up front. RegisterOperation re-checks atomically to close the race where the
+  // session goes terminal between here and registration.
+  if (runtime->IsTerminal()) {
+    // Preserve the legacy late-admission diagnostic without disturbing a Request claimed by another operation.
+    if (const auto& request_control = request.Control()) {
+      static_cast<void>(request_control->ActiveOperationOrSetIdleCancelled());
+    }
+
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "session has been cancelled");
+  }
+
+  // Snapshot the timeout into an absolute deadline immediately so the budget covers any serialized queue
+  // wait before the run actually starts. The budget itself is kept for logs and error messages.
+  const auto timeout = request.Timeout();
+  std::optional<std::chrono::steady_clock::time_point> deadline;
+  if (timeout.count() > 0) {
+    deadline = std::chrono::steady_clock::now() + timeout;
+  }
+
+  const std::shared_ptr<RequestControl>& request_control = request.Control();
+  if (!request_control) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "request has been moved from and can no longer be used");
+  }
+
+  auto state = std::make_shared<OperationState>(runtime, request_control, deadline, timeout);
+
+  // Claim the Request. A second concurrent operation on the same Request is rejected. A won claim also
+  // clears the previous run's diagnostic mirror under the claim lock, so those flags always describe the
+  // operation that currently owns the Request.
+  const auto claim = request_control->TryClaim(state);
+  if (!claim.claimed) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "request is already in use by another operation");
+  }
+
+  try {
+    // Capture execution data now, while the caller is still inside this synchronous call. Everything the run
+    // needs is either shared-owned or deep-cloned here; the operation never reads the caller's Request again.
+    auto snapshot = RequestSnapshot::Capture(request);
+
+    if (!allow_borrowed_items && snapshot->HasBorrowedItems()) {
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
+               "deferred operations require owned or clonable request items; use AddOwnedItem or the "
+               "synchronous ProcessRequest convenience for non-clonable borrowed items");
+    }
+
+    if (!runtime->RegisterOperation(state)) {
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "session has been cancelled");
+    }
+
+    return std::make_unique<Operation>(runtime, request_control, std::move(snapshot), state, claim.epoch,
+                                       visibility);
+  } catch (...) {
+    // Roll back everything this call took: a terminal session, a failed snapshot capture, or a failed
+    // allocation of either the registration vector entry or the Operation itself must not leave the Request
+    // claimed or the state registered.
+    runtime->DeregisterOperation(*state);
+    request_control->Release(*state, claim.epoch);
+    throw;
   }
 }
 
 void Session::ProcessRequest(const Request& request, Response& response) {
-  // Serialize requests unless the derived class opted into concurrency.
-  std::unique_lock<std::mutex> lock(*request_mutex_, std::defer_lock);
-  if (!allow_concurrent_requests_) {
-    lock.lock();
+  auto operation = CreateOperationImpl(request, /*allow_borrowed_items=*/true, ResponseVisibility::kLegacyPartial);
+  const OperationOutcome outcome = operation->Process(response);
+
+  // Legacy convenience contract, preserved exactly. A deadline is the only stop that becomes an exception
+  // here: a request that outlived its budget is a broken caller contract. Every other stop — an explicit
+  // session/operation/request cancel, or a streaming callback hanging up — is a *normal* return with
+  // finish_reason == NONE, which is what keeps the existing SSE behaviour intact. The explicit
+  // Operation::Process() path still surfaces kCancelled so the operation API can map it separately.
+  if (outcome == OperationOutcome::kTimedOut) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_TIMEOUT, "request timed out after ", operation->State()->Budget().count(), "ms");
   }
 
-  // A session cancelled during teardown must not start new work — otherwise a caller
-  // looping over requests could keep the model refcount pinned past Manager::Shutdown.
-  {
-    std::lock_guard<std::mutex> cancel_lock(cancel_state_->mutex);
-    if (cancel_state_->cancel_requested) {
-      request.canceled.store(true, std::memory_order_relaxed);
-      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "session has been cancelled");
-    }
-
-    ++cancel_state_->active_requests;
-    cancel_state_->active_requests_list.push_back(&request);
+  if (outcome == OperationOutcome::kAbandoned) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "request was abandoned before it could run");
   }
 
-  // Start the wall-clock budget (if any) and clear stale stop state from a prior run.
-  request.ArmDeadline();
+  if (outcome != OperationOutcome::kCompleted) {
+    response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
+  }
+}
 
-  // Watchdog enforces the deadline for paths that would otherwise block indefinitely
-  // inside the engine. Only started when a timeout was requested — no cost otherwise.
-  std::thread watchdog;
-  if (request.Timeout().count() > 0) {
-    watchdog = std::thread(&Session::WatchDeadline, this, std::cref(request));
+SessionRuntime& Session::CheckedRuntime() const {
+  if (!runtime_) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "session has been moved from and can no longer be used");
   }
 
-  // Guarantees the watchdog is woken and joined on every exit path, including throws.
-  // Declared after the thread so it runs first on unwind.
-  struct RunScope {
-    Session& session;
-    const Request& request;
-    std::thread& watchdog;
-
-    ~RunScope() {
-      {
-        std::lock_guard<std::mutex> lock(session.cancel_state_->mutex);
-        --session.cancel_state_->active_requests;
-
-        auto& list = session.cancel_state_->active_requests_list;
-        list.erase(std::remove(list.begin(), list.end(), &request), list.end());
-      }
-
-      session.cancel_state_->cv.notify_all();
-
-      if (watchdog.joinable()) {
-        watchdog.join();
-      }
-
-      // The watchdog can no longer access this request's generator. Serialized sessions still hold request_mutex_
-      // because its lock outlives this scope; concurrent sessions must provide their own exclusion in this hook.
-      session.OnRequestFinished(request);
-      request.DisarmDeadline();
-    }
-  } run_scope{*this, request, watchdog};
-
-  ActionTracker tracker(Action::kSessionProcessRequest, telemetry_);
-  tracker.SetModelId(CatalogModel().Id());
-
-  try {
-    ProcessRequestImpl(request, response);
-
-    tracker.SetStatus(request.canceled.load(std::memory_order_relaxed) ? ActionStatus::kCanceled
-                                                                      : ActionStatus::kSuccess);
-  } catch (const std::exception& ex) {
-    tracker.RecordException(ex);
-    throw;
-  }
-
-  // A timeout is a failure of the caller's contract, not a silent truncation: surface it
-  // so callers can distinguish "the model stopped early" from "we ran out of time".
-  if (request.timed_out.load(std::memory_order_relaxed)) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_TIMEOUT, "request timed out after ", request.Timeout().count(), "ms");
-  }
+  return *runtime_;
 }
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/session.h
+++ b/sdk_v2/cpp/src/inferencing/session/session.h
@@ -1,238 +1,154 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #pragma once
 
-#include <algorithm>
-#include <chrono>
-#include <condition_variable>
-#include <functional>
+#include <cstdint>
 #include <memory>
-#include <mutex>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include <foundry_local/foundry_local_c.h>
 
-#include "inferencing/session/callback_handler.h"
-#include "inferencing/session/cancellable.h"
 #include "inferencing/session/request.h"
 #include "inferencing/session/response.h"
+#include "inferencing/session/session_runtime.h"
 #include "inferencing/session/types.h"
 #include "util/key_value_pairs.h"
 
 namespace fl {
 
-class ILogger;     // forward declaration
-class ITelemetry;  // forward declaration
-class Model;       // forward declaration
+class Model;      // forward declaration
+class Operation;  // forward declaration — per-invocation unit of work created by CreateOperation
 
-/// Base class for model inference sessions.
-/// Manages lifecycle, request dispatch, streaming callbacks, and tool definitions.
-/// Derived classes hold a reference to their specific loaded model type.
+/// Defined in operation.h. Controls whether a stopped run's partially-built response is cleared
+/// (kExplicitAtomic, the deferred Operation API) or preserved (kLegacyPartial, ProcessRequest).
+enum class ResponseVisibility : uint8_t;
+
+/// Handle to a model inference session.
 ///
-/// Derived classes specialize for different inference patterns:
-///   - ChatSession: conversational text generation with message history
-///   - Future: predictive inference, realtime audio, multi-modal
+/// A Session is a **facade**: it owns nothing but a `shared_ptr<SessionRuntime>` and forwards. All
+/// executable state — model lease, modality state, options, tool definitions, callback, terminal flag,
+/// admission gate, live operations — lives in the runtime, which is separately allocated and shared.
+///
+/// What that buys, and why the previous design could not:
+///   - **Moves are trivial and safe.** Moving a Session moves a shared_ptr. There is no half-moved object to
+///     protect, so PrepareMove/FinishMove, the executor gate and the `owns_session_` refcount-ownership
+///     flags are all gone.
+///   - **Destruction never waits.** `~Session` signals CancelAll() and drops its reference. It does not
+///     block on in-flight work, which is what makes it safe to release a Session from inside its own
+///     streaming callback — the previous destructor-owner-lock scheme deadlocked there, and was undefined
+///     behaviour anyway because the wait started after destruction had begun.
+///   - **Execution never dereferences a Session.** An Operation captures the runtime strongly at
+///     CreateOperation, so the runtime (and the model lease inside it) outlives the facade exactly as long
+///     as some operation or callback still needs it, and is destroyed immediately afterwards.
+///
+/// Derived facades (ChatSession, AudioSession, EmbeddingsSession) add construction and typed accessors only;
+/// they hold no state of their own and need no destructor or move-constructor ceremony.
 class Session {
  public:
-  virtual ~Session();
+  using StreamingCallbackFn = SessionRuntime::StreamingCallbackFn;
 
-  Session(Session&&) noexcept;
+  explicit Session(std::shared_ptr<SessionRuntime> runtime) : runtime_(std::move(runtime)) {}
+
+  /// Signal-only: cancels every operation of this session and drops the owner reference. Never waits.
+  virtual ~Session() noexcept;
+
+  Session(Session&&) noexcept = default;
   Session& operator=(Session&&) = delete;
 
   Session(const Session&) = delete;
   Session& operator=(const Session&) = delete;
 
-  /// Factory: creates the correct derived Session for the model's task type.
+  /// Factory: creates the correct derived Session for the model's task type, holding a model lease acquired
+  /// atomically against unload.
   static std::unique_ptr<Session> Create(const Model& model);
 
   /// Returns the concrete session type (no RTTI needed).
-  virtual SessionType Type() const = 0;
+  SessionType Type() const { return CheckedRuntime().Type(); }
 
-  /// Process a request: overlays session parameters, delegates to the derived
-  /// class, then waits for all async streaming callbacks to complete.
-  /// Waiting here keeps the Request reference valid for the lifetime of any
-  /// in-flight callbacks and ensures the Response is fully populated on return.
+  /// Create a single-use operation for `request`, synchronously and before any worker scheduling.
   ///
-  /// Cancellation applies to every path, streaming or not:
-  ///   - `Session::Cancel()` from another thread stops the run promptly.
-  ///   - `Request::SetTimeout()` bounds the run with a wall-clock deadline.
-  /// Both work by flagging the Request and calling Cancel() on the active generator,
-  /// so an in-flight ORT GenAI compute is interrupted rather than waited out.
+  /// Snapshots the request's timeout into an absolute steady-clock deadline immediately (so the budget
+  /// includes any serialized queue wait), claims the Request (rejecting concurrent use of the same Request
+  /// with FOUNDRY_LOCAL_ERROR_INVALID_USAGE), captures an immutable RequestSnapshot of the execution data,
+  /// rejects a terminal or moved-from session with the same error, and registers a strong per-operation
+  /// state with the runtime. A failure anywhere after the claim rolls the claim and the registration back.
+  ///
+  /// @throws fl::Exception (FOUNDRY_LOCAL_ERROR_INVALID_USAGE) if the session is terminal or moved-from, or
+  ///         the Request is already in use by another operation.
+  std::unique_ptr<Operation> CreateOperation(const Request& request);
+
+  /// Convenience create -> process. Overlays session parameters (in the runtime), runs the operation, and
+  /// waits for all async streaming callbacks to complete before returning.
+  ///
+  /// Outcome contract (unchanged legacy behaviour):
+  ///   - Natural stop -> returns normally.
+  ///   - Any cancellation that is not a deadline — an explicit Session/Operation/Request cancel, or a
+  ///     streaming callback asking to stop -> returns normally with
+  ///     response.finish_reason == FOUNDRY_LOCAL_FINISH_NONE.
+  ///   - A deadline expiry -> fl::Exception(FOUNDRY_LOCAL_ERROR_TIMEOUT).
+  ///   - Submitting on an already-terminal session -> fl::Exception(FOUNDRY_LOCAL_ERROR_INVALID_USAGE).
+  ///   - A genuine inference error -> the original exception, unchanged.
+  ///
+  /// Note the deliberate asymmetry with Operation::Process(), which reports kCancelled so the explicit
+  /// operation API can map it to FOUNDRY_LOCAL_ERROR_OPERATION_CANCELLED.
   void ProcessRequest(const Request& request, Response& response);
 
-  /// Signal every in-flight request on this session to stop, and cause the next ProcessRequest
-  /// on this session to abort immediately. Safe to call from any thread; idempotent.
-  ///
-  /// This is the teardown hook: it guarantees a runaway non-streaming generation
-  /// releases the session's model refcount instead of pinning the model loaded.
+  /// Terminal, irreversible session cancel. Signals every created/running operation to stop and rejects
+  /// future CreateOperation calls. Safe to call from any thread; idempotent; signal-only.
   void Cancel();
 
   /// Add a tool definition to this session.
   /// @throws fl::Exception if tool_def.json_schema is not valid JSON.
-  void AddToolDefinition(ToolDefinition tool_def);
+  void AddToolDefinition(ToolDefinition tool_def) { CheckedRuntime().AddToolDefinition(std::move(tool_def)); }
 
-  /// Remove a previously-added tool definition by name.
-  /// Returns true if a matching tool was found and removed, false otherwise.
+  /// Remove a previously-added tool definition by name. Returns true if one was found and removed.
   bool RemoveToolDefinition(const std::string& tool_name) {
-    auto it = std::find_if(tool_definitions_.begin(), tool_definitions_.end(),
-                           [&](const ToolDefinition& td) { return td.name == tool_name; });
-    if (it == tool_definitions_.end()) {
-      return false;
-    }
-
-    tool_definitions_.erase(it);
-    return true;
+    return CheckedRuntime().RemoveToolDefinition(tool_name);
   }
 
   /// Get the tool definitions added to this session.
-  const std::vector<ToolDefinition>& ToolDefinitions() const {
-    return tool_definitions_;
-  }
+  const std::vector<ToolDefinition>& ToolDefinitions() const { return CheckedRuntime().ToolDefinitions(); }
 
-  /// Remove all tool definitions from this session. Needed when a session is reused across
-  /// requests (e.g. via Responses API `previous_response_id`) and the new request brings its
-  /// own tools — the request-is-self-contained model means stale tools must not leak across turns.
-  void ClearToolDefinitions() {
-    tool_definitions_.clear();
-  }
+  /// Remove all tool definitions from this session. Needed when a session is reused across requests (e.g.
+  /// via Responses API `previous_response_id`) and the new request brings its own tools — the
+  /// request-is-self-contained model means stale tools must not leak across turns.
+  void ClearToolDefinitions() { CheckedRuntime().ClearToolDefinitions(); }
 
   /// Get the number of completed turns. Only meaningful for chat sessions.
-  virtual size_t TurnCount() const { return 0; }
+  size_t TurnCount() const { return CheckedRuntime().TurnCount(); }
 
   /// Undo the last `count` turns. Only meaningful for chat sessions.
   /// @throws fl::Exception if the session type does not support turn management or count > TurnCount().
-  virtual void UndoTurns(size_t count);
+  void UndoTurns(size_t count) { CheckedRuntime().UndoTurns(count); }
 
   /// Session-level parameters overlaid onto each request.
-  void SetSessionOptions(const KeyValuePairs& options) {
-    session_options_ = options;
-    SetSessionOptionsImpl(session_options_);
+  void SetSessionOptions(const KeyValuePairs& options) { CheckedRuntime().SetSessionOptions(options); }
+
+  void SetStreamingCallback(StreamingCallbackFn callback, void* user_data = nullptr) {
+    CheckedRuntime().SetStreamingCallback(std::move(callback), user_data);
   }
 
-  using StreamingCallbackFn = std::function<int(flStreamingCallbackData, void*)>;
-  void SetStreamingCallback(StreamingCallbackFn callback, void* user_data = nullptr) {
-    callback_fn_ = std::move(callback);
-    callback_user_data_ = user_data;
-  }
+  /// The stable, shared runtime. Exposed for the ABI layer and for SessionManager, which keys registration
+  /// on runtime identity rather than on a facade address that can move. Returned by value so the caller
+  /// immediately owns a lifetime pin; null on a moved-from Session.
+  std::shared_ptr<SessionRuntime> Runtime() const { return runtime_; }
 
  protected:
-  Session(const fl::Model& catalog_model, ILogger& logger, ITelemetry& telemetry,
-          bool allow_concurrent_requests = false);
-
-  const fl::Model& CatalogModel() const { return catalog_model_; }
-
-  ILogger& Logger() { return logger_; }
-
-  virtual void SetSessionOptionsImpl(const KeyValuePairs& /*options*/) {}
-
-  /// Merge session-level options with per-request options.
-  /// Returns a copy of session options with request options overlaid (request wins on conflict).
-  /// Derived classes call this when they want a single resolved option set.
-  KeyValuePairs MergedOptions(const KeyValuePairs& request_options) const {
-    if (request_options.empty()) {
-      return session_options_;
-    }
-
-    KeyValuePairs merged = session_options_;
-    for (const auto& [key, value] : request_options) {
-      merged.Add(key, value);
-    }
-
-    return merged;
-  }
-
-  /// Derived classes implement the actual generation logic.
-  /// `on_token` is the resolved streaming callback (may be empty).
-  /// Requests are serialized if the derived class does not opt into concurrency via allow_concurrent_requests_.
-  virtual void ProcessRequestImpl(const Request& request, Response& response) = 0;
-
-  /// Create a per-request callback handler. Returns nullptr if no callback is set.
-  /// The handler is owned by the caller (unique_ptr) and drains+joins on destruction.
-  std::unique_ptr<CallbackHandler> CreateCallbackHandler(const Request& request) {
-    if (!callback_fn_) {
-      return nullptr;
-    }
-
-    return std::make_unique<CallbackHandler>(request, callback_fn_, logger_, callback_user_data_);
-  }
-
-  /// Called once the request has finished and its deadline watchdog has joined. Derived classes use it to drop
-  /// state a timeout invalidated after the deadline cancellation callback can no longer reach the generator.
-  virtual void OnRequestFinished(const Request& /*request*/) noexcept {}
-
-  const KeyValuePairs& SessionOptions() const { return session_options_; }
-
-  /// RAII guard publishing the generator currently driving a request so that
-  /// Session::Cancel() and the deadline watchdog can interrupt it mid-compute.
-  ///
-  /// Derived classes create one for the scope in which a generator is live. If
-  /// cancellation was already requested when the guard is constructed, the
-  /// generator is cancelled immediately — this closes the race where Cancel()
-  /// lands between the pre-flight check and the generator becoming visible.
-  ///
-  /// Multiple guards may be live at once: sessions that opt into concurrency
-  /// (embeddings) run several requests in parallel, and a nested scope can publish
-  /// a second generator. All registered generators are cancelled together.
-  class ActiveGenerator {
-   public:
-    ActiveGenerator(Session& session, ICancellable& generator)
-        : session_(session), generator_(generator) {
-      session_.AddActiveGenerator(&generator_);
-    }
-
-    ~ActiveGenerator() { session_.RemoveActiveGenerator(&generator_); }
-
-    ActiveGenerator(const ActiveGenerator&) = delete;
-    ActiveGenerator& operator=(const ActiveGenerator&) = delete;
-
-   private:
-    Session& session_;
-    ICancellable& generator_;
-  };
+  /// The runtime, validated to be non-null. Used by the typed facades for their static_cast.
+  SessionRuntime& RuntimeRef() const { return CheckedRuntime(); }
 
  private:
-  /// Publish a generator driving a request. Cancels it inline if a stop was already
-  /// requested, so a generator created after Cancel() cannot run unbounded.
-  void AddActiveGenerator(ICancellable* generator);
+  /// Shared implementation for the explicit deferred API and the synchronous convenience path.
+  /// Deferred operations reject non-clonable borrowed items; ProcessRequest may retain them because it does
+  /// not return until processing and callback drain have completed.
+  std::unique_ptr<Operation> CreateOperationImpl(const Request& request, bool allow_borrowed_items,
+                                                 ResponseVisibility visibility);
 
-  /// Withdraw a generator once its scope ends.
-  void RemoveActiveGenerator(ICancellable* generator);
+  /// Access the runtime or reject use of a moved-from facade without dereferencing a null shared_ptr.
+  SessionRuntime& CheckedRuntime() const;
 
-  /// Body of the deadline watchdog thread. Sleeps until the request's deadline and
-  /// then interrupts the run, unless woken earlier because the request completed.
-  void WatchDeadline(const Request& request);
-
-  const fl::Model& catalog_model_;
-  ILogger& logger_;
-  ITelemetry& telemetry_;
-  std::vector<ToolDefinition> tool_definitions_;
-  KeyValuePairs session_options_;
-  StreamingCallbackFn callback_fn_;
-  void* callback_user_data_ = nullptr;
-  const bool allow_concurrent_requests_;
-  mutable std::unique_ptr<std::mutex> request_mutex_ = std::make_unique<std::mutex>();
-
-  /// Guards active_generator_/cancel_requested_ and pairs with the condition variable for
-  /// the watchdog. Held behind a unique_ptr because Session must remain movable (the
-  /// Responses API caches ChatSessions by move) and mutex/condition_variable are not.
-  /// Separate from request_mutex_: Cancel() must be serviceable while a request holds that lock.
-  struct CancelState {
-    std::mutex mutex;
-    std::condition_variable cv;
-    std::vector<ICancellable*> active_generators;
-    /// In-flight requests, so Cancel() can latch the flag that drives finish_reason and
-    /// history rollback. Tracked alongside generators because a request may be cancelled
-    /// before it publishes one (e.g. during prefill).
-    std::vector<const Request*> active_requests_list;
-    bool cancel_requested = false;
-    /// Number of requests currently running, so the watchdog knows when to stop waiting.
-    /// A count rather than a flag because concurrent sessions overlap requests.
-    int active_requests = 0;
-  };
-
-  std::unique_ptr<CancelState> cancel_state_ = std::make_unique<CancelState>();
+  std::shared_ptr<SessionRuntime> runtime_;
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/session_manager.cc
+++ b/sdk_v2/cpp/src/inferencing/session/session_manager.cc
@@ -6,6 +6,7 @@
 #include "inferencing/generative/chat/chat_session.h"
 #include "inferencing/session/live_session_registry.h"
 #include "inferencing/session/session.h"
+#include "inferencing/session/session_runtime.h"
 
 #include <cassert>
 #include <vector>
@@ -16,6 +17,8 @@ namespace fl {
 
 SessionManager::SessionManager(ILogger& logger, size_t cache_capacity)
     : logger_(logger), cache_capacity_(cache_capacity) {
+  // Deliberately does not touch the process-wide admission gate. The registry is a leaked singleton shared
+  // across Manager lifetimes; a new Manager must never reopen a closure another Manager still owns.
 }
 
 SessionManager::~SessionManager() {
@@ -23,26 +26,41 @@ SessionManager::~SessionManager() {
   ClearCache();
 
   WaitForDrain();
+
+  // admission_closure_ is released by its own destructor, after the drain above: this Manager's shutdown is
+  // the only thing it ever held closed, so a sequentially recreated Manager admits new sessions again.
 }
 
 void SessionManager::Register(Session& session) {
-  // Check shutting_down_ and insert under the same lock CancelAll() uses to flip the flag and iterate.
-  // Reading the flag outside the lock would let a session observe false, lose the race to the cancel
-  // sweep, then insert itself afterward — running uncanceled while shutdown waits to drain.
-  std::lock_guard<std::mutex> lock(mutex_);
+  // Track the stable runtime, not the facade address: handlers move sessions into background threads, and a
+  // moved facade must not look like a different (or a vanished) registration.
+  const auto runtime = session.Runtime();
+  if (!runtime) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "cannot register a moved-from session");
+  }
 
+  // Check shutdown and insert under the same lock so a registration cannot slip past the manager gate.
+  std::lock_guard<std::mutex> lock(mutex_);
   if (shutting_down_.load()) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "cannot create session during shutdown");
   }
 
-  sessions_.insert(&session);
+  sessions_.insert(runtime.get());
 }
 
 void SessionManager::Deregister(Session& session) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  auto erased = sessions_.erase(&session);
+  SessionRuntime* runtime = session.Runtime().get();
+  bool missing = false;
+  bool drained = false;
 
-  if (erased == 0) {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto erased = runtime != nullptr ? sessions_.erase(runtime) : 0;
+    missing = erased == 0;
+    drained = sessions_.empty();
+  }
+
+  if (missing) {
     // Bug: session was not registered. Log loudly but don't throw — this may be
     // called from a destructor where throwing would call std::terminate().
     logger_.Log(LogLevel::Error, "SessionManager::Deregister called for unregistered session");
@@ -50,40 +68,37 @@ void SessionManager::Deregister(Session& session) {
     return;
   }
 
-  if (sessions_.empty()) {
+  if (drained) {
     drain_cv_.notify_all();
   }
 }
 
 void SessionManager::CancelAll() {
   {
-    // Publish shutdown under the same lock used by Register() before clearing the cache or taking the live
-    // snapshot. No registered request or cache check-in can slip past the cancellation sweep.
+    // Close both manager and process-wide admission before clearing the cache or taking the live snapshot.
     std::lock_guard<std::mutex> lock(mutex_);
-    shutting_down_.store(true);
+    if (!shutting_down_.exchange(true)) {
+      admission_closure_ = LiveSessionRegistry::Instance().CloseAdmission();
+    }
   }
 
   // Clear cache after closing admission so a concurrent check-in cannot repopulate it.
   ClearCache();
 
-  // Cancel every live session, not just registered ones: direct-API sessions never take a
+  // Cancel every live session runtime, not just registered ones: direct-API sessions never take a
   // SessionRegistration, yet a runaway request on one is exactly what pins the model.
   //
-  // Snapshot first and cancel outside any lock — Session::Cancel() reaches into the ORT
-  // GenAI engine, and a cancelled session unwinding calls back into Deregister().
-  std::vector<Session*> to_cancel = LiveSessionRegistry::Instance().Snapshot();
+  // Snapshot promotes the weak entries to strong ones and cancels outside any lock — CancelAll() reaches
+  // into the ORT GenAI engine, and a cancelled session unwinding calls back into Deregister(). Holding
+  // strong runtime references also means a facade released concurrently cannot pull the runtime out from
+  // under this loop.
+  std::vector<std::shared_ptr<SessionRuntime>> to_cancel = LiveSessionRegistry::Instance().Snapshot();
 
   logger_.Log(LogLevel::Information,
               fmt::format("SessionManager: cancelling all sessions ({} live)", to_cancel.size()));
 
-  for (auto* session : to_cancel) {
-    try {
-      session->Cancel();
-    } catch (const std::exception& ex) {
-      // Cancellation is best-effort during shutdown; one wedged session must not
-      // prevent the others from being signalled.
-      logger_.Log(LogLevel::Warning, fmt::format("SessionManager: failed to cancel a session: {}", ex.what()));
-    }
+  for (const auto& control : to_cancel) {
+    control->CancelAll();
   }
 }
 
@@ -94,14 +109,19 @@ void SessionManager::WaitForDrain(std::chrono::milliseconds timeout) {
     return;
   }
 
+  const auto initial_count = sessions_.size();
+  lock.unlock();
   logger_.Log(LogLevel::Information,
-              fmt::format("SessionManager: waiting for {} active sessions to drain", sessions_.size()));
+              fmt::format("SessionManager: waiting for {} active sessions to drain", initial_count));
 
-  bool drained = drain_cv_.wait_for(lock, timeout, [this] { return sessions_.empty(); });
+  lock.lock();
+  const bool drained = drain_cv_.wait_for(lock, timeout, [this] { return sessions_.empty(); });
+  const auto remaining = sessions_.size();
+  lock.unlock();
 
   if (!drained) {
     logger_.Log(LogLevel::Warning,
-                fmt::format("SessionManager: drain timed out with {} sessions still active", sessions_.size()));
+                fmt::format("SessionManager: drain timed out with {} sessions still active", remaining));
   }
 }
 
@@ -113,16 +133,20 @@ size_t SessionManager::ActiveCount() const {
 // --- Session cache ---
 
 std::unique_ptr<ChatSession> SessionManager::CheckOut(const std::string& key) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  auto it = cache_.find(key);
+  std::unique_ptr<ChatSession> session;
 
-  if (it == cache_.end()) {
-    return nullptr;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = cache_.find(key);
+
+    if (it == cache_.end()) {
+      return nullptr;
+    }
+
+    session = std::move(it->second.session);
+    lru_order_.erase(it->second.lru_iter);
+    cache_.erase(it);
   }
-
-  auto session = std::move(it->second.session);
-  lru_order_.erase(it->second.lru_iter);
-  cache_.erase(it);
 
   logger_.Log(LogLevel::Debug, fmt::format("SessionManager: checked out cached session for '{}'", key));
   return session;
@@ -131,6 +155,8 @@ std::unique_ptr<ChatSession> SessionManager::CheckOut(const std::string& key) {
 void SessionManager::CheckIn(const std::string& key, std::unique_ptr<ChatSession> session) {
   // Collect evicted sessions to destroy outside the lock.
   std::vector<std::unique_ptr<ChatSession>> evicted;
+  bool discarded = false;
+  size_t cache_size = 0;
 
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -138,34 +164,39 @@ void SessionManager::CheckIn(const std::string& key, std::unique_ptr<ChatSession
     // A response handler may finish while shutdown is cancelling live work. Do not let it repopulate the cache after
     // CancelAll() has cleared it; cached sessions are deregistered and therefore invisible to WaitForDrain().
     if (shutting_down_.load()) {
-      logger_.Log(LogLevel::Debug, "SessionManager: discarding session checked in during shutdown");
-      return;
+      discarded = true;
+    } else {
+      // Replace existing entry for this key (if any)
+      auto existing = cache_.find(key);
+      if (existing != cache_.end()) {
+        evicted.push_back(std::move(existing->second.session));
+        lru_order_.erase(existing->second.lru_iter);
+        cache_.erase(existing);
+      }
+
+      // Evict LRU if at capacity
+      while (cache_.size() >= cache_capacity_) {
+        const auto& lru_key = lru_order_.back();
+        auto lru_it = cache_.find(lru_key);
+        evicted.push_back(std::move(lru_it->second.session));
+        cache_.erase(lru_it);
+        lru_order_.pop_back();
+      }
+
+      // Insert new entry
+      lru_order_.push_front(key);
+      cache_[key] = CacheEntry{std::move(session), lru_order_.begin()};
+      cache_size = cache_.size();
     }
-
-    // Replace existing entry for this key (if any)
-    auto existing = cache_.find(key);
-    if (existing != cache_.end()) {
-      evicted.push_back(std::move(existing->second.session));
-      lru_order_.erase(existing->second.lru_iter);
-      cache_.erase(existing);
-    }
-
-    // Evict LRU if at capacity
-    while (cache_.size() >= cache_capacity_) {
-      const auto& lru_key = lru_order_.back();
-      auto lru_it = cache_.find(lru_key);
-      evicted.push_back(std::move(lru_it->second.session));
-      cache_.erase(lru_it);
-      lru_order_.pop_back();
-    }
-
-    // Insert new entry
-    lru_order_.push_front(key);
-    cache_[key] = CacheEntry{std::move(session), lru_order_.begin()};
-
-    logger_.Log(LogLevel::Debug,
-                fmt::format("SessionManager: checked in session under '{}' (cache size: {})", key, cache_.size()));
   }
+
+  if (discarded) {
+    logger_.Log(LogLevel::Debug, "SessionManager: discarding session checked in during shutdown");
+    return;
+  }
+
+  logger_.Log(LogLevel::Debug,
+              fmt::format("SessionManager: checked in session under '{}' (cache size: {})", key, cache_size));
 
   // Evicted sessions destroyed here, outside lock
   if (!evicted.empty()) {
@@ -180,7 +211,7 @@ size_t SessionManager::CacheSize() const {
 }
 
 bool SessionManager::EvictCached(const std::string& key) {
-  // Destroy outside the lock: ~ChatSession calls Deregister which re-acquires mutex_.
+  // Destroy outside the lock: facade destruction cancels its operations and may run operation cleanup.
   std::unique_ptr<ChatSession> evicted;
 
   {

--- a/sdk_v2/cpp/src/inferencing/session/session_manager.h
+++ b/sdk_v2/cpp/src/inferencing/session/session_manager.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "inferencing/session/live_session_registry.h"
 #include "logger.h"
 
 #include <atomic>
@@ -18,6 +19,7 @@ namespace fl {
 
 class ChatSession;
 class Session;
+class SessionRuntime;
 
 /// Interface for session lifecycle tracking.
 /// Session depends on this — not the concrete SessionManager.
@@ -108,9 +110,20 @@ class SessionManager : public ISessionManager {
   ILogger& logger_;
   size_t cache_capacity_;
   std::atomic<bool> shutting_down_{false};
+
+  /// Held from this manager's CancelAll() until this manager is destroyed, so a session created in the
+  /// shutdown race window is rejected. Ownership (rather than a global open/close flag) is what stops one
+  /// manager's teardown from reopening another manager's in-progress shutdown; releasing it on destruction
+  /// is what lets a sequentially recreated Manager admit sessions again.
+  LiveSessionRegistry::AdmissionClosure admission_closure_;
   mutable std::mutex mutex_;
   std::condition_variable drain_cv_;
-  std::unordered_set<Session*> sessions_;
+
+  /// Keyed on the *runtime*, not on the Session facade address. A facade is a movable shared_ptr wrapper, so
+  /// its address is not stable identity; the runtime is allocated once and never moves. Storing raw runtime
+  /// pointers is safe because a registration is strictly bracketed by SessionRegistration, which is itself
+  /// scoped inside the facade's lifetime, and because nothing here ever dereferences the pointer.
+  std::unordered_set<SessionRuntime*> sessions_;
 
   // LRU cache: front of lru_order_ = most recently used
   std::list<std::string> lru_order_;

--- a/sdk_v2/cpp/src/inferencing/session/session_runtime.cc
+++ b/sdk_v2/cpp/src/inferencing/session/session_runtime.cc
@@ -1,0 +1,304 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "inferencing/session/session_runtime.h"
+
+#include "exception.h"
+#include "inferencing/session/live_session_registry.h"
+#include "logger.h"
+#include "model.h"
+#include "telemetry/telemetry.h"
+#include "telemetry/telemetry_action_tracker.h"
+
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <fmt/format.h>
+#include <system_error>
+#include <thread>
+#include <utility>
+
+namespace fl {
+
+SessionRuntime::SessionRuntime(const fl::Model& catalog_model, ILogger& logger, ITelemetry& telemetry,
+                               ModelSessionLease lease, bool allow_concurrent_requests)
+    : catalog_model_id_(catalog_model.Id()),
+      catalog_model_info_(catalog_model.Info()),
+      logger_(logger),
+      telemetry_(telemetry),
+      model_lease_(std::move(lease)),
+      allow_concurrent_requests_(allow_concurrent_requests) {
+}
+
+SessionRuntime::~SessionRuntime() noexcept {
+  // Reaching here means no operation, callback or facade still references this runtime, so there is nothing
+  // to wait for — only the registry entry to drop. Derived state and then the model lease are released by
+  // the normal destruction order after this body returns.
+  LiveSessionRegistry::Instance().Remove(this);
+}
+
+void SessionRuntime::UndoTurns(size_t /*count*/) {
+  FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "UndoTurns is not supported for this session type");
+}
+
+void SessionRuntime::AddToolDefinition(ToolDefinition tool_def) {
+  if (!nlohmann::json::accept(tool_def.json_schema)) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+             "ToolDefinition.json_schema is not valid JSON for tool: " + tool_def.name);
+  }
+
+  tool_definitions_.push_back(std::move(tool_def));
+}
+
+// ===========================================================================
+// Operation registry and terminal state
+// ===========================================================================
+
+bool SessionRuntime::IsTerminal() const {
+  std::lock_guard<std::mutex> lock(mu_);
+  return terminal_;
+}
+
+bool SessionRuntime::RegisterOperation(const std::shared_ptr<OperationState>& state) {
+  std::lock_guard<std::mutex> lock(mu_);
+  if (terminal_) {
+    return false;
+  }
+
+  operations_.push_back(state);
+  return true;
+}
+
+void SessionRuntime::DeregisterOperation(const OperationState& state) noexcept {
+  // Drop the strong ref outside the lock: releasing the last reference here would run ~OperationState under
+  // the structural lock, and its slot registry must never nest this one.
+  std::shared_ptr<OperationState> released;
+
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    auto it = std::find_if(operations_.begin(), operations_.end(),
+                           [&](const std::shared_ptr<OperationState>& op) { return op.get() == &state; });
+    if (it == operations_.end()) {
+      return;
+    }
+
+    released = std::move(*it);
+    operations_.erase(it);
+  }
+}
+
+void SessionRuntime::CancelAll() noexcept {
+  std::vector<std::shared_ptr<OperationState>> to_cancel;
+
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    terminal_ = true;
+    to_cancel.swap(operations_);
+  }
+
+  // Wake any queued run so it observes the terminal state and bails before entering ProcessRequestImpl.
+  admission_cv_.notify_all();
+
+  // Stop outside every framework lock: each stop reaches into the ORT GenAI engine through a cancel lease.
+  for (const auto& operation : to_cancel) {
+    operation->RequestStop(StopReason::kExternalCancel);
+  }
+}
+
+void SessionRuntime::MarkTerminal() noexcept {
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    terminal_ = true;
+  }
+
+  admission_cv_.notify_all();
+}
+
+// ===========================================================================
+// Serial admission gate
+// ===========================================================================
+
+OperationOutcome SessionRuntime::AcquireSerialPermit(OperationState& state) {
+  StopReason latch = StopReason::kNone;
+
+  {
+    std::unique_lock<std::mutex> lock(mu_);
+    state.MarkQueued();
+
+    const auto ready = [&] { return !serial_busy_ || terminal_ || state.IsStopped(); };
+
+    if (state.HasDeadline()) {
+      // Wait no longer than the operation's absolute deadline, which already includes this queue wait.
+      admission_cv_.wait_until(lock, *state.Deadline(), ready);
+    } else {
+      admission_cv_.wait(lock, ready);
+    }
+
+    if (!state.IsStopped()) {
+      if (terminal_) {
+        latch = StopReason::kExternalCancel;
+      } else if (state.DeadlineExpired()) {
+        // Re-check the deadline before granting: a permit that becomes free exactly at expiry must not let
+        // an already-spent budget into inference.
+        latch = StopReason::kTimeout;
+      } else {
+        serial_busy_ = true;
+        return OperationOutcome::kCompleted;
+      }
+    }
+  }
+
+  // Latch outside mu_: RequestStop() calls back into NotifyAdmission() and into the engine.
+  if (latch != StopReason::kNone) {
+    state.RequestStop(latch);
+  }
+
+  return OutcomeForStopReason(state.Reason());
+}
+
+void SessionRuntime::ReleaseSerialPermit() {
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    serial_busy_ = false;
+  }
+
+  admission_cv_.notify_all();
+}
+
+void SessionRuntime::NotifyAdmission() noexcept {
+  // Take mu_ as a synchronization barrier before notifying. A queued operation's stop is latched in the
+  // *operation's* atomic (not under mu_), so without this barrier the wakeup could be lost between a
+  // waiter's predicate re-check and its sleep. Acquiring mu_ here blocks until any such waiter is parked.
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+  }
+
+  admission_cv_.notify_all();
+}
+
+// ===========================================================================
+// Execution
+// ===========================================================================
+
+OperationOutcome SessionRuntime::Run(const std::shared_ptr<OperationState>& state, const Request& request,
+                                     Response& response) {
+  const OperationContext operation(state);
+
+  // 1. Admission. Chat/audio serialize through the gate, which wakes for a permit, this operation's stop,
+  //    its deadline, or a terminal session cancel — a queued stop never enters ProcessRequestImpl.
+  //    Concurrent runtimes (embeddings) skip the gate, so nothing else would re-check an already-spent
+  //    budget before inference starts.
+  bool holds_permit = false;
+
+  if (!allow_concurrent_requests_) {
+    if (AcquireSerialPermit(*state) != OperationOutcome::kCompleted) {
+      response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
+      return state->Finalize();
+    }
+
+    holds_permit = true;
+  } else if (state->DeadlineExpired()) {
+    state->RequestStop(StopReason::kTimeout);
+    response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
+    return state->Finalize();
+  }
+
+  struct PermitGuard {
+    SessionRuntime& runtime;
+    const bool& holds;
+
+    ~PermitGuard() noexcept {
+      if (holds) {
+        runtime.ReleaseSerialPermit();
+      }
+    }
+  } permit_guard{*this, holds_permit};
+
+  // 2. Transition to Running. A stop latched while queued is sticky, so the run is refused here.
+  if (!state->MarkRunning()) {
+    response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
+    return state->Finalize();
+  }
+
+  // 3. Start the per-operation deadline watchdog. It touches only the OperationState — never this runtime
+  //    and never the Request — so it can never outlive an object it would dereference.
+  std::thread watchdog;
+  if (state->HasDeadline()) {
+    ILogger& logger = logger_;
+    const long long budget_ms = static_cast<long long>(state->Budget().count());
+
+    try {
+      watchdog = std::thread([state, &logger, budget_ms] {
+        // WaitForDeadline latches and mirrors the timeout under its lifecycle lock, then performs admission
+        // wake and generator cancellation outside every lock. It returns true only for the call that actually
+        // won the race against a completing or sealed run, so only that call logs.
+        if (state->WaitForDeadline()) {
+          logger.Log(LogLevel::Warning, fmt::format("request exceeded its {}ms deadline; cancelling", budget_ms));
+        }
+      });
+    } catch (const std::system_error& ex) {
+      // Without a watchdog the deadline cannot be enforced; fail the operation instead of running unbounded.
+      // The permit guard above and Operation's release guard undo the admission and the claim.
+      state->MarkFaulted();
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "failed to start the request deadline watchdog: ", ex.what());
+    }
+  }
+
+  // Finalize on every exit path (including a throw from ProcessRequestImpl): wake and join the watchdog so
+  // it can no longer touch this operation's generators, then run the derived cleanup hook.
+  struct RunScope {
+    SessionRuntime& runtime;
+    const OperationContext& operation;
+    const Request& request;
+    const std::shared_ptr<OperationState>& state;
+    std::thread& watchdog;
+
+    ~RunScope() noexcept {
+      state->NotifyWatcher();
+
+      if (watchdog.joinable()) {
+        watchdog.join();
+      }
+
+      runtime.OnRequestFinished(operation, request);
+    }
+  } run_scope{*this, operation, request, state, watchdog};
+
+  ActionTracker tracker(Action::kSessionProcessRequest, telemetry_);
+  tracker.SetModelId(CatalogModelId());
+
+  // A deadline can expire while the watchdog thread is being created. Do not enter modality code once that
+  // stop is already visible; this is the final admission check immediately before inference.
+  if (operation.ShouldStop()) {
+    tracker.SetStatus(ActionStatus::kCanceled);
+    response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
+    return state->Finalize();
+  }
+
+  try {
+    ProcessRequestImpl(operation, request, response);
+
+    // Normalize *only* unsealed stopped runs. A sealed run has already committed a real outcome and must
+    // keep its finish reason; an unsealed stopped run must not report a natural stop, whatever the modality
+    // left behind before it noticed.
+    if (operation.ShouldStop() && !operation.IsSealed()) {
+      response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
+    }
+
+    tracker.SetStatus(operation.IsSealed() || !operation.ShouldStop() ? ActionStatus::kSuccess
+                                                                     : ActionStatus::kCanceled);
+  } catch (const std::exception& ex) {
+    tracker.RecordException(ex);
+
+    // Terminal fault before the watchdog is joined: the operation must never be left looking runnable.
+    state->MarkFaulted();
+    throw;
+  } catch (...) {
+    // Preserve non-std failures unchanged, but still settle the operation before RunScope performs cleanup.
+    state->MarkFaulted();
+    throw;
+  }
+
+  return state->Finalize();
+}
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/session/session_runtime.h
+++ b/sdk_v2/cpp/src/inferencing/session/session_runtime.h
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include <algorithm>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <foundry_local/foundry_local_c.h>
+
+#include "inferencing/model_session_lease.h"
+#include "inferencing/session/callback_handler.h"
+#include "inferencing/session/live_session_registry.h"
+#include "inferencing/session/operation_context.h"
+#include "inferencing/session/operation_state.h"
+#include "inferencing/session/request.h"
+#include "inferencing/session/response.h"
+#include "inferencing/session/types.h"
+#include "model_info.h"
+#include "util/key_value_pairs.h"
+
+namespace fl {
+
+class ILogger;
+class ITelemetry;
+class Model;
+
+/// The separately allocated, shared, polymorphic body of a session.
+///
+/// Everything executable lives here: the model lease, the modality state, the common options and tool
+/// definitions, the streaming callback, the terminal flag, the serial admission gate and the set of live
+/// operations. The `Session` object callers hold is only a movable shared_ptr facade over one of these.
+///
+/// Why the split exists. The previous shape kept the executable state on the Session itself and made
+/// ~Session wait on a reader/writer "owner gate" so an in-flight run could keep borrowing it. That is
+/// undefined behaviour — the wait begins after destruction has already started and after derived members
+/// have died — and it self-deadlocks whenever the thing releasing the session is the session's own streaming
+/// callback. Here an Operation captures a strong shared_ptr to the runtime at CreateOperation and never
+/// dereferences a Session at all, so:
+///   - Session destruction is *signal-only*: cancel every operation, drop the owner reference, return. It
+///     never waits and can safely run on a callback thread.
+///   - Physical destruction of the runtime — and therefore of the modality state and the model lease —
+///     happens once the last operation or callback reference goes away, which is by construction after every
+///     user of that state has finished.
+///   - There is no ownership cycle: the runtime holds operations strongly, operations hold the runtime
+///     strongly only for the duration of their own lifetime, and OperationState refers back weakly.
+///
+/// A runtime never moves. Moving a Session moves a shared_ptr; cancellation identity, the registry entry,
+/// the terminal flag and every registered operation are untouched by construction.
+class SessionRuntime : public std::enable_shared_from_this<SessionRuntime> {
+ public:
+  using StreamingCallbackFn = std::function<int(flStreamingCallbackData, void*)>;
+
+  virtual ~SessionRuntime() noexcept;
+
+  SessionRuntime(const SessionRuntime&) = delete;
+  SessionRuntime& operator=(const SessionRuntime&) = delete;
+  SessionRuntime(SessionRuntime&&) = delete;
+  SessionRuntime& operator=(SessionRuntime&&) = delete;
+
+  /// The concrete session type (no RTTI needed).
+  virtual SessionType Type() const = 0;
+
+  /// Number of completed turns. Only meaningful for chat runtimes.
+  virtual size_t TurnCount() const { return 0; }
+
+  /// Undo the last `count` turns. Only meaningful for chat runtimes.
+  /// @throws fl::Exception if the runtime does not support turn management or count > TurnCount().
+  virtual void UndoTurns(size_t count);
+
+  // --- configuration (forwarded from the facade) ---
+
+  /// @throws fl::Exception if tool_def.json_schema is not valid JSON.
+  void AddToolDefinition(ToolDefinition tool_def);
+
+  bool RemoveToolDefinition(const std::string& tool_name) {
+    auto it = std::find_if(tool_definitions_.begin(), tool_definitions_.end(),
+                           [&](const ToolDefinition& td) { return td.name == tool_name; });
+    if (it == tool_definitions_.end()) {
+      return false;
+    }
+
+    tool_definitions_.erase(it);
+    return true;
+  }
+
+  const std::vector<ToolDefinition>& ToolDefinitions() const { return tool_definitions_; }
+
+  void ClearToolDefinitions() { tool_definitions_.clear(); }
+
+  void SetSessionOptions(const KeyValuePairs& options) {
+    session_options_ = options;
+    SetSessionOptionsImpl(session_options_);
+  }
+
+  void SetStreamingCallback(StreamingCallbackFn callback, void* user_data) {
+    callback_fn_ = std::move(callback);
+    callback_user_data_ = user_data;
+  }
+
+  // --- operation registry and terminal state ---
+
+  /// True once CancelAll()/MarkTerminal() has made this session terminal. Future operations are rejected.
+  bool IsTerminal() const;
+
+  /// Reject creation while terminal, otherwise register `state` strongly. Returns false if terminal (the
+  /// caller must reject with FOUNDRY_LOCAL_ERROR_INVALID_USAGE).
+  bool RegisterOperation(const std::shared_ptr<OperationState>& state);
+
+  /// Drop the strong ref to `state`. Safe to call for an operation that was never registered.
+  void DeregisterOperation(const OperationState& state) noexcept;
+
+  /// Terminal, irreversible, signal-only. Marks the session terminal, wakes the admission gate, and stops
+  /// every registered operation. Never waits for operations, callbacks, or anything else.
+  void CancelAll() noexcept;
+
+  /// Force the session terminal without enumerating operations. Used by the registry when a runtime is
+  /// registered while shutdown admission is closed, so its future operations are rejected.
+  void MarkTerminal() noexcept;
+
+  // --- serial admission gate (chat/audio: one run at a time, but interruptibly) ---
+
+  /// Wait for the serial permit. Wakes for: permit available, this operation stopped, the operation's
+  /// deadline, or terminal session cancel. Latches the stop itself (outside the gate lock) so the caller
+  /// only has to branch on the returned decision:
+  ///   kCompleted -> permit granted, caller should run.
+  ///   anything else -> caller must not run; the outcome is already latched on the state.
+  OperationOutcome AcquireSerialPermit(OperationState& state);
+
+  /// Release the serial permit taken by AcquireSerialPermit and wake the next waiter.
+  void ReleaseSerialPermit();
+
+  /// Wake all admission waiters (used when an operation is stopped so a queued run re-evaluates).
+  void NotifyAdmission() noexcept;
+
+  // --- execution ---
+
+  /// Orchestrate one operation run: serial admission gate, deadline watchdog, ProcessRequestImpl, finalize.
+  /// Called only by Operation::Process, which holds this runtime alive for the whole call. `request` is the
+  /// operation's immutable snapshot — never the caller's live Request.
+  OperationOutcome Run(const std::shared_ptr<OperationState>& state, const Request& request, Response& response);
+
+ protected:
+  SessionRuntime(const fl::Model& catalog_model, ILogger& logger, ITelemetry& telemetry, ModelSessionLease lease,
+                 bool allow_concurrent_requests = false);
+
+  const std::string& CatalogModelId() const { return catalog_model_id_; }
+
+  const ModelInfo& CatalogModelInfo() const { return catalog_model_info_; }
+
+  ILogger& Logger() { return logger_; }
+
+  /// The leased model. Only valid on a runtime constructed with an engaged lease.
+  GenAIModelInstance& Model() const { return model_lease_.Model(); }
+
+  virtual void SetSessionOptionsImpl(const KeyValuePairs& /*options*/) {}
+
+  /// Merge session-level options with per-request options.
+  /// Returns a copy of session options with request options overlaid (request wins on conflict).
+  KeyValuePairs MergedOptions(const KeyValuePairs& request_options) const {
+    if (request_options.empty()) {
+      return session_options_;
+    }
+
+    KeyValuePairs merged = session_options_;
+    for (const auto& [key, value] : request_options) {
+      merged.Add(key, value);
+    }
+
+    return merged;
+  }
+
+  /// Derived runtimes implement the actual generation logic.
+  ///
+  /// `operation` is the explicit, per-run stop authority: generation loops poll operation.ShouldStop(),
+  /// generator publication goes through ActiveGenerator(operation, ...), and the outcome is committed only
+  /// after operation.TrySeal() succeeds. It must be threaded through every helper that polls cancellation,
+  /// registers a generator or commits state — pure input-parsing helpers stay Request-only.
+  virtual void ProcessRequestImpl(const OperationContext& operation, const Request& request,
+                                  Response& response) = 0;
+
+  /// Create a per-request callback handler bound to this operation. Returns nullptr if no callback is set.
+  /// The handler is owned by the caller (unique_ptr) and drains+joins on destruction, which must happen
+  /// before `operation` goes out of scope — guaranteed because handlers are locals of ProcessRequestImpl.
+  std::unique_ptr<CallbackHandler> CreateCallbackHandler(const OperationContext& operation) {
+    if (!callback_fn_) {
+      return nullptr;
+    }
+
+    return std::make_unique<CallbackHandler>(operation, callback_fn_, logger_, callback_user_data_);
+  }
+
+  /// Called once the request has finished and its deadline watchdog has joined. Derived runtimes use it to
+  /// drop state a timeout or an engine-delivered cancellation invalidated after the watchdog can no longer
+  /// reach the generator. `operation` is the finishing operation — passed explicitly, never inferred.
+  virtual void OnRequestFinished(const OperationContext& /*operation*/, const Request& /*request*/) noexcept {}
+
+  const KeyValuePairs& SessionOptions() const { return session_options_; }
+
+ private:
+  /// Catalog metadata is copied at construction. The catalog may refresh or be destroyed independently once
+  /// the runtime has its model lease, so no operation may retain a borrowed Model reference.
+  std::string catalog_model_id_;
+  ModelInfo catalog_model_info_;
+
+  /// Runtime services follow the Manager lifetime contract: production callers retain the Manager until all
+  /// sessions/operations are released, while direct internal constructors must keep their supplied services
+  /// alive. Unlike the old design, no Session or Request object is borrowed by an operation.
+  ILogger& logger_;
+  ITelemetry& telemetry_;
+
+  /// The model lease lives on the base, which is destroyed *after* every derived member. That ordering is
+  /// load-bearing: a derived runtime's cached generators and OGA state die first, and only then is the lease
+  /// released, so the model can never be unloaded while something derived is still using it.
+  ModelSessionLease model_lease_;
+
+  std::vector<ToolDefinition> tool_definitions_;
+  KeyValuePairs session_options_;
+  StreamingCallbackFn callback_fn_;
+  void* callback_user_data_ = nullptr;
+  const bool allow_concurrent_requests_;
+
+  mutable std::mutex mu_;
+  std::condition_variable admission_cv_;
+  bool terminal_ = false;
+  bool serial_busy_ = false;
+  std::vector<std::shared_ptr<OperationState>> operations_;
+};
+
+/// Create a runtime and publish it to the process-wide live registry in one step.
+///
+/// Registration cannot happen inside the constructor (shared_from_this is not yet usable there) and must
+/// not be left to callers, because a runtime that is invisible to the registry would survive a shutdown
+/// cancel and pin its model. The registry holds the runtime weakly; the facade holds the strong reference.
+template <typename Runtime, typename... Args>
+std::shared_ptr<Runtime> MakeSessionRuntime(Args&&... args) {
+  auto runtime = std::make_shared<Runtime>(std::forward<Args>(args)...);
+  LiveSessionRegistry::Instance().Add(runtime);
+  return runtime;
+}
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/manager.cc
+++ b/sdk_v2/cpp/src/manager.cc
@@ -519,21 +519,21 @@ void Manager::Shutdown() {
   logger_->Log(LogLevel::Information, "Shutdown requested");
 
   // Order matters:
-  //   1. Reject new loads so callers gated on IsShutdownRequested can stop early.
-  //   2. Cancel in-flight generations BEFORE stopping the web service. StopWebService() hard-joins
-  //      streaming threads; a generation grinding in ORT GenAI only stops when request.canceled is
-  //      set, so cancelling first is what lets JoinAll() return promptly instead of deadlocking
-  //      process shutdown.
-  //   3. Stop the web service (JoinAll now unblocks), then drain HTTP-tracked sessions.
-  //   4. Unload all models, polling per-model session refcount for direct-API users who haven't
-  //      dropped their flSession* yet. Bounded by timeout so a stuck caller can't block shutdown.
-  model_load_manager_->RejectNewLoads();
+  //   1. Close load admission without waiting, so callers gated on IsShutdownRequested can stop early.
+  //   2. Cancel all live sessions so in-flight generation stops now.
+  //   3. Stop the web service. Stopping joins in-flight streaming responses, so it must follow cancellation:
+  //      stopping first would block for the full remaining duration of a stream nothing has interrupted yet.
+  //   4. Only after cancellation and service join, drain model loads/unloads admitted before closure.
+  //   5. Drain cancelled sessions, then unload models, polling per-model session refcount for direct-API users
+  //      who haven't dropped their flSession* yet. Bounded by timeout so a stuck caller cannot block forever.
+  model_load_manager_->CloseLoadAdmission();
   session_manager_->CancelAll();
 
   if (web_service_running_) {
     StopWebService();
   }
 
+  model_load_manager_->DrainModelLifecycleWork();
   session_manager_->WaitForDrain();
   model_load_manager_->UnloadAll();
 }

--- a/sdk_v2/cpp/src/service/audio_transcriptions_handler.cc
+++ b/sdk_v2/cpp/src/service/audio_transcriptions_handler.cc
@@ -57,14 +57,14 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> AudioTranscriptionsHandler
 }
 
 std::shared_ptr<HttpRequestHandler::OutgoingResponse> AudioTranscriptionsHandler::ResolveModel(
-    const std::string& model_name, Model*& model, GenAIModelInstance*& loaded) {
+    const std::string& model_name, Model*& model, std::optional<ModelSessionLease>& lease) {
   model = ctx_.catalog.GetModelVariant(model_name);
   if (!model) {
     return ErrorResponse(Status::CODE_404, "Model not found", "No model matching '" + model_name + "'");
   }
 
-  loaded = ctx_.model_load_manager.GetLoadedModel(model->Id());
-  if (!loaded) {
+  lease = ctx_.model_load_manager.AcquireLoadedModel(model->Id());
+  if (!lease.has_value()) {
     return ErrorResponse(Status::CODE_400, "Model not loaded",
                          "Model '" + model_name + "' must be loaded before inference");
   }
@@ -121,8 +121,8 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> AudioTranscriptionsHandler
   // 3. Resolve model
   std::string model_name = req.model;
   Model* model = nullptr;
-  GenAIModelInstance* loaded = nullptr;
-  if (auto err = ResolveModel(model_name, model, loaded)) {
+  std::optional<ModelSessionLease> lease;
+  if (auto err = ResolveModel(model_name, model, lease)) {
     tracker.SetStatus(ActionStatus::kClientError);
     return err;
   }
@@ -135,7 +135,7 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> AudioTranscriptionsHandler
 
   // 5. Dispatch to streaming or non-streaming
   try {
-    AudioSession session(*model, *loaded, ctx_.logger, ctx_.telemetry);
+    AudioSession session(*model, std::move(*lease), ctx_.logger, ctx_.telemetry);
 
     if (stream) {
       tracker.SetStatus(ActionStatus::kSuccess);

--- a/sdk_v2/cpp/src/service/audio_transcriptions_handler.h
+++ b/sdk_v2/cpp/src/service/audio_transcriptions_handler.h
@@ -4,9 +4,11 @@
 
 #ifdef FOUNDRY_LOCAL_HAS_WEB_SERVICE
 
+#include "inferencing/model_session_lease.h"
 #include "service/handler_utils.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace fl {
@@ -15,7 +17,6 @@ struct ServiceContext;
 struct AudioTranscriptionRequest;
 class AudioSession;
 class Model;
-class GenAIModelInstance;
 struct Request;
 
 // ========================================================================
@@ -33,9 +34,9 @@ class AudioTranscriptionsHandler : public HttpRequestHandler {
   std::shared_ptr<OutgoingResponse> ParseAndValidateRequest(const std::string& body,
                                                             AudioTranscriptionRequest& req);
 
-  /// Look up model in catalog and verify it's loaded and supports audio.
+  /// Look up the catalog model, atomically lease its loaded runtime, and verify it supports audio.
   std::shared_ptr<OutgoingResponse> ResolveModel(const std::string& model_name,
-                                                 Model*& model, GenAIModelInstance*& loaded);
+                                                 Model*& model, std::optional<ModelSessionLease>& lease);
 
   /// Build a Request with an OPENAI_JSON-tagged TEXT item from the original body string.
   void BuildOpenAIJsonRequest(const std::string& body, Request& session_request);

--- a/sdk_v2/cpp/src/service/chat_completions_handler.cc
+++ b/sdk_v2/cpp/src/service/chat_completions_handler.cc
@@ -60,14 +60,14 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> ChatCompletionsHandler::Pa
 }
 
 std::shared_ptr<HttpRequestHandler::OutgoingResponse> ChatCompletionsHandler::ResolveModel(
-    const std::string& model_name, Model*& model, GenAIModelInstance*& loaded) {
+    const std::string& model_name, Model*& model, std::optional<ModelSessionLease>& lease) {
   model = ctx_.catalog.GetModelVariant(model_name);
   if (!model) {
     return ErrorResponse(Status::CODE_404, "Model not found", "No model matching '" + model_name + "'");
   }
 
-  loaded = ctx_.model_load_manager.GetLoadedModel(model->Id());
-  if (!loaded) {
+  lease = ctx_.model_load_manager.AcquireLoadedModel(model->Id());
+  if (!lease.has_value()) {
     return ErrorResponse(Status::CODE_400, "Model not loaded",
                          "Model '" + model_name + "' must be loaded before inference");
   }
@@ -130,8 +130,8 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> ChatCompletionsHandler::ha
   // 2. Resolve model
   std::string model_name = req.model;
   Model* model = nullptr;
-  GenAIModelInstance* loaded = nullptr;
-  if (auto err = ResolveModel(model_name, model, loaded)) {
+  std::optional<ModelSessionLease> lease;
+  if (auto err = ResolveModel(model_name, model, lease)) {
     return err;
   }
 
@@ -149,7 +149,7 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> ChatCompletionsHandler::ha
 
   // 6. Run inference via ChatSession
   try {
-    ChatSession session(*model, *loaded, ctx_.logger, ctx_.telemetry);
+    ChatSession session(*model, std::move(*lease), ctx_.logger, ctx_.telemetry);
 
     if (stream) {
       tracker.SetStatus(ActionStatus::kSuccess);

--- a/sdk_v2/cpp/src/service/chat_completions_handler.h
+++ b/sdk_v2/cpp/src/service/chat_completions_handler.h
@@ -4,9 +4,11 @@
 
 #ifdef FOUNDRY_LOCAL_HAS_WEB_SERVICE
 
+#include "inferencing/model_session_lease.h"
 #include "service/handler_utils.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace fl {
@@ -15,7 +17,6 @@ struct ServiceContext;
 struct ChatCompletionRequest;
 class ChatSession;
 class Model;
-class GenAIModelInstance;
 struct Request;
 
 // ========================================================================
@@ -34,10 +35,10 @@ class ChatCompletionsHandler : public HttpRequestHandler {
   std::shared_ptr<OutgoingResponse> ParseAndValidateRequest(const std::string& body,
                                                             ChatCompletionRequest& req);
 
-  /// Look up model in catalog and verify it's loaded. Sets output pointers.
+  /// Look up the catalog model and atomically lease its loaded runtime.
   /// Returns an error response on failure, nullptr on success.
   std::shared_ptr<OutgoingResponse> ResolveModel(const std::string& model_name,
-                                                 Model*& model, GenAIModelInstance*& loaded);
+                                                 Model*& model, std::optional<ModelSessionLease>& lease);
 
   /// Build a Request with an OPENAI_JSON-tagged TEXT item from the original body string.
   /// Populates catalog defaults and model-specific options (tool_call_start/end).

--- a/sdk_v2/cpp/src/service/embeddings_handler.cc
+++ b/sdk_v2/cpp/src/service/embeddings_handler.cc
@@ -67,8 +67,8 @@ class EmbeddingsHandler : public HttpRequestHandler {
       return ErrorResponse(Status::CODE_404, "Model not found", model_name);
     }
 
-    auto* loaded = ctx_.model_load_manager.GetLoadedModel(model->Id());
-    if (!loaded) {
+    auto lease = ctx_.model_load_manager.AcquireLoadedModel(model->Id());
+    if (!lease.has_value()) {
       tracker.SetStatus(ActionStatus::kClientError);
       return ErrorResponse(Status::CODE_400, "Model not loaded", model_name);
     }
@@ -77,7 +77,7 @@ class EmbeddingsHandler : public HttpRequestHandler {
 
     // 4. Create session and process each input
     try {
-      EmbeddingsSession session(*model, *loaded, ctx_.logger, ctx_.telemetry);
+      EmbeddingsSession session(*model, std::move(*lease), ctx_.logger, ctx_.telemetry);
       SessionRegistration reg(ctx_.session_manager, session);
 
       Request session_request;

--- a/sdk_v2/cpp/src/service/responses_handler.cc
+++ b/sdk_v2/cpp/src/service/responses_handler.cc
@@ -79,14 +79,14 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> ResponsesHandler::ParseAnd
 }
 
 std::shared_ptr<HttpRequestHandler::OutgoingResponse> ResponsesHandler::ResolveModel(
-    const std::string& model_name, Model*& model, GenAIModelInstance*& loaded) {
+    const std::string& model_name, Model*& model, std::optional<ModelSessionLease>& lease) {
   model = ctx_.catalog.GetModelVariant(model_name);
   if (!model) {
     return ErrorResponse(Status::CODE_404, "Model not found", "No model matching '" + model_name + "'");
   }
 
-  loaded = ctx_.model_load_manager.GetLoadedModel(model->Id());
-  if (!loaded) {
+  lease = ctx_.model_load_manager.AcquireLoadedModel(model->Id());
+  if (!lease.has_value()) {
     return ErrorResponse(Status::CODE_400, "Model not loaded",
                          "Model '" + model_name + "' must be loaded before inference");
   }
@@ -155,8 +155,8 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> ResponsesHandler::handle(
   // 2. Resolve model
   std::string model_name = params.model;
   Model* model = nullptr;
-  GenAIModelInstance* loaded = nullptr;
-  if (auto err = ResolveModel(model_name, model, loaded)) {
+  std::optional<ModelSessionLease> lease;
+  if (auto err = ResolveModel(model_name, model, lease)) {
     tracker.SetStatus(ActionStatus::kClientError);
     return err;
   }
@@ -198,7 +198,7 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> ResponsesHandler::handle(
 
   try {
     if (!session) {
-      session = std::make_unique<ChatSession>(*model, *loaded, ctx_.logger, ctx_.telemetry);
+      session = std::make_unique<ChatSession>(*model, std::move(*lease), ctx_.logger, ctx_.telemetry);
     }
 
     // Sessions can be reused via previous_response_id; clear any stale tool defs from the prior

--- a/sdk_v2/cpp/src/service/responses_handler.h
+++ b/sdk_v2/cpp/src/service/responses_handler.h
@@ -4,9 +4,11 @@
 
 #ifdef FOUNDRY_LOCAL_HAS_WEB_SERVICE
 
+#include "inferencing/model_session_lease.h"
 #include "service/handler_utils.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace fl {
@@ -15,7 +17,6 @@ struct ServiceContext;
 struct Request;
 class ChatSession;
 class Model;
-class GenAIModelInstance;
 
 namespace responses {
 struct ResponseCreateParams;
@@ -40,10 +41,10 @@ class ResponsesHandler : public HttpRequestHandler {
                                                             nlohmann::json& req_json,
                                                             responses::ResponseCreateParams& params);
 
-  /// Look up model in catalog and verify it's loaded. Sets output pointers.
+  /// Look up the catalog model and atomically lease its loaded runtime.
   /// Returns an error response on failure, nullptr on success.
   std::shared_ptr<OutgoingResponse> ResolveModel(const std::string& model_name,
-                                                 Model*& model, GenAIModelInstance*& loaded);
+                                                 Model*& model, std::optional<ModelSessionLease>& lease);
 
   /// Load previous response context when chaining via previous_response_id.
   /// The json storage objects are passed by reference because the output pointers alias into them.

--- a/sdk_v2/cpp/test/CMakeLists.txt
+++ b/sdk_v2/cpp/test/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(foundry_local_tests
     internal_api/model_load_manager_test.cc
     internal_api/model_sorting_test.cc
     internal_api/oga_generator_cancellable_test.cc
+    internal_api/operation_test.cc
     internal_api/platform_path_test.cc
     internal_api/response_converter_test.cc
     internal_api/response_store_test.cc

--- a/sdk_v2/cpp/test/internal_api/callback_handler_test.cc
+++ b/sdk_v2/cpp/test/internal_api/callback_handler_test.cc
@@ -9,7 +9,10 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
+#include <mutex>
 #include <stdexcept>
+#include <string>
 #include <thread>
 
 #include "inferencing/session/request.h"
@@ -110,4 +113,36 @@ TEST(CallbackHandlerTest, NormalCallbackCancelsViaReturnValue) {
 
   EXPECT_EQ(invocations.load(), 1);
   EXPECT_TRUE(request.canceled.load());
+}
+
+TEST(CallbackHandlerTest, FinalItemIsDeliveredAfterOperationHasStopped) {
+  auto state = std::make_shared<OperationState>(
+      std::weak_ptr<SessionRuntime>{}, std::weak_ptr<RequestControl>{}, std::nullopt,
+      std::chrono::milliseconds(0));
+  OperationContext operation(state);
+  ASSERT_TRUE(state->RequestStop(StopReason::kExternalCancel));
+
+  std::mutex mutex;
+  std::string delivered_text;
+
+  auto callback = [&](flStreamingCallbackData data, void*) -> int {
+    auto* queue = reinterpret_cast<ItemQueue*>(data.item_queue);
+    auto item = queue->TryPop();
+    if (item && item->type == FOUNDRY_LOCAL_ITEM_TEXT) {
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        delivered_text = static_cast<TextItem&>(*item).text;
+      }
+    }
+
+    return 0;
+  };
+
+  CallbackHandler handler(operation, callback, fl::test::NullLog());
+  handler.PushItem(std::make_unique<TextItem>("dropped"));
+  handler.PushFinalItem(std::make_unique<TextItem>("cancelled-terminal"));
+  handler.Quiesce();
+
+  std::lock_guard<std::mutex> lock(mutex);
+  EXPECT_EQ(delivered_text, "cancelled-terminal");
 }

--- a/sdk_v2/cpp/test/internal_api/model_load_manager_test.cc
+++ b/sdk_v2/cpp/test/internal_api/model_load_manager_test.cc
@@ -11,9 +11,15 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <condition_variable>
+#include <exception>
 #include <filesystem>
 #include <fstream>
+#include <future>
+#include <mutex>
 #include <string>
+#include <thread>
 
 namespace {
 
@@ -41,6 +47,61 @@ class CpuOnlyDetector : public fl::IEpDetector {
   std::map<std::string, std::vector<std::string>> GetAvailableDevicesToEPs() const override {
     return {{"CPU", {"CPUExecutionProvider"}}};
   }
+};
+
+class BlockingGpuEpDetector : public fl::IEpDetector {
+ public:
+  std::map<std::string, std::vector<std::string>> GetAvailableDevicesToEPs() const override {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      availability_queried_ = true;
+    }
+    cv_.notify_all();
+
+    return {
+        {"CPU", {"CPUExecutionProvider"}},
+        {"GPU", {"CUDAExecutionProvider"}},
+    };
+  }
+
+  bool PrepareForModelLoad(std::string_view /*ep_name*/) override {
+    std::unique_lock<std::mutex> lock(mutex_);
+    entered_ = true;
+    cv_.notify_all();
+    cv_.wait(lock, [this] { return released_; });
+    return false;
+  }
+
+  bool WaitUntilEntered() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, std::chrono::seconds(5), [this] { return entered_; });
+  }
+
+  bool WaitUntilAvailabilityQueried() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, std::chrono::seconds(5), [this] { return availability_queried_; });
+  }
+
+  bool PreparationEnteredWithin(std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, timeout, [this] { return entered_; });
+  }
+
+  void Release() {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      released_ = true;
+    }
+
+    cv_.notify_all();
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  mutable std::condition_variable cv_;
+  mutable bool availability_queried_ = false;
+  bool entered_ = false;
+  bool released_ = false;
 };
 
 /// Creates a minimal model directory with a dummy genai_config.json.
@@ -178,6 +239,104 @@ TEST(ModelLoadManagerTest, LoadGenericGpuModel_CudaAvailable_AutoSelectsCuda) {
 
   EXPECT_EQ(ep.prepared_ep, "CUDAExecutionProvider");
 }
+
+TEST(ModelLoadManagerTest, CloseLoadAdmissionReturnsBeforeAdmittedLoadDrains) {
+  BlockingGpuEpDetector ep;
+  fl::StderrLogger logger;
+  fl::ModelLoadManager manager(ep, logger);
+  TempModelDir dir("nonblocking-load-closure");
+
+  std::exception_ptr load_error;
+  std::thread loader([&] {
+    try {
+      static_cast<void>(manager.LoadModel(dir.path(), "nonblocking-load-closure",
+                                          fl::ExecutionProvider::kCUDA));
+    } catch (...) {
+      load_error = std::current_exception();
+    }
+  });
+
+  const bool load_entered = ep.WaitUntilEntered();
+  if (!load_entered) {
+    ep.Release();
+    loader.join();
+    FAIL() << "admitted load did not reach EP preparation";
+    return;
+  }
+
+  std::promise<void> close_returned;
+  auto close_future = close_returned.get_future();
+  std::thread closer([&] {
+    manager.CloseLoadAdmission();
+    close_returned.set_value();
+  });
+
+  const bool returned_without_drain =
+      close_future.wait_for(std::chrono::seconds(1)) == std::future_status::ready;
+
+  ep.Release();
+  closer.join();
+  loader.join();
+  manager.DrainModelLifecycleWork();
+
+  EXPECT_TRUE(returned_without_drain);
+  EXPECT_TRUE(load_error != nullptr);
+  EXPECT_THROW(
+      static_cast<void>(manager.LoadModel(dir.path(), "rejected-after-closure",
+                                          fl::ExecutionProvider::kCUDA)),
+      fl::Exception);
+}
+
+#ifdef _WIN32
+TEST(ModelLoadManagerTest, EpPreparationAndModelConstructionAreProcessSerializedOnWindows) {
+  BlockingGpuEpDetector first_ep;
+  BlockingGpuEpDetector second_ep;
+  fl::StderrLogger logger;
+  fl::ModelLoadManager first_manager(first_ep, logger);
+  fl::ModelLoadManager second_manager(second_ep, logger);
+  TempModelDir first_dir("serialized-ep-first");
+  TempModelDir second_dir("serialized-ep-second");
+
+  std::thread first_loader([&] {
+    try {
+      static_cast<void>(first_manager.LoadModel(first_dir.path(), "serialized-ep-first",
+                                                fl::ExecutionProvider::kCUDA));
+    } catch (...) {
+    }
+  });
+
+  const bool first_entered = first_ep.WaitUntilEntered();
+  if (!first_entered) {
+    first_ep.Release();
+    first_loader.join();
+    FAIL() << "first load did not reach EP preparation";
+    return;
+  }
+
+  std::thread second_loader([&] {
+    try {
+      static_cast<void>(second_manager.LoadModel(second_dir.path(), "serialized-ep-second",
+                                                 fl::ExecutionProvider::kCUDA));
+    } catch (...) {
+    }
+  });
+
+  const bool second_reached_preparation_boundary = second_ep.WaitUntilAvailabilityQueried();
+  const bool second_entered_while_first_held_lock =
+      second_ep.PreparationEnteredWithin(std::chrono::milliseconds(250));
+
+  first_ep.Release();
+  first_loader.join();
+
+  const bool second_eventually_entered = second_ep.WaitUntilEntered();
+  second_ep.Release();
+  second_loader.join();
+
+  ASSERT_TRUE(second_reached_preparation_boundary);
+  EXPECT_FALSE(second_entered_while_first_held_lock);
+  EXPECT_TRUE(second_eventually_entered);
+}
+#endif
 
 // ---------------------------------------------------------------------------
 // Unload-with-live-sessions tests (real model load)

--- a/sdk_v2/cpp/test/internal_api/oga_generator_cancellable_test.cc
+++ b/sdk_v2/cpp/test/internal_api/oga_generator_cancellable_test.cc
@@ -4,7 +4,9 @@
 #include "inferencing/session/oga_generator_cancellable.h"
 
 #include "exception.h"
+#include "inferencing/session/operation_context.h"
 #include "inferencing/session/session.h"
+#include "inferencing/session/session_runtime.h"
 #include "internal_api/test_helpers.h"
 #include "model.h"
 #include "model_info.h"
@@ -14,12 +16,17 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace {
 
+/// Fake generator whose GenerateNextToken always fails. `session_terminated` models what the real
+/// OgaGenerator reports after terminate_session: only when it is true may TryGenerateNextToken treat the
+/// failure as an expected stop.
 class ThrowingGenerator {
  public:
   void GenerateNextToken() {
@@ -27,10 +34,71 @@ class ThrowingGenerator {
     throw std::runtime_error(message);
   }
 
+  bool IsSessionTerminated() const { return session_terminated; }
+
   int call_count = 0;
+  bool session_terminated = false;
   std::string message = "engine failure";
 };
 
+class StopThenThrowGenerator {
+ public:
+  StopThenThrowGenerator(const fl::OperationContext& operation, bool report_terminated)
+      : operation_(operation), report_terminated_(report_terminated) {}
+
+  void GenerateNextToken() {
+    ++call_count;
+    operation_.RequestStop(fl::StopReason::kExternalCancel);
+    session_terminated_ = report_terminated_;
+    throw std::runtime_error(message);
+  }
+
+  bool IsSessionTerminated() const { return session_terminated_; }
+
+  int call_count = 0;
+  std::string message = "engine failure after stop raced";
+
+ private:
+  const fl::OperationContext& operation_;
+  const bool report_terminated_;
+  bool session_terminated_ = false;
+};
+
+class RawCallCounter {
+ public:
+  void SetInputs(int& /*tensors*/) { ++set_inputs_count; }
+  void GenerateNextToken() { ++generate_count; }
+
+  std::vector<int32_t> GetNextTokens() {
+    ++get_tokens_count;
+    return {42};
+  }
+
+  bool IsDone() {
+    ++is_done_count;
+    return false;
+  }
+
+  bool IsSessionTerminated() const { return false; }
+
+  int set_inputs_count = 0;
+  int generate_count = 0;
+  int get_tokens_count = 0;
+  int is_done_count = 0;
+};
+
+class DecodeCallCounter {
+ public:
+  const char* Decode(int32_t /*token*/) {
+    ++decode_count;
+    return "decoded";
+  }
+
+  int decode_count = 0;
+};
+
+/// Fake generator that blocks inside GenerateNextToken until it is cancelled, then fails exactly the way
+/// ORT GenAI does once terminate_session has been delivered.
 class BlockingGenerator : public fl::ICancellable {
  public:
   void GenerateNextToken() {
@@ -43,25 +111,37 @@ class BlockingGenerator : public fl::ICancellable {
     throw std::runtime_error("session terminated");
   }
 
-  void Cancel() override {
+  /// noexcept, matching ICancellable: cancellation is delivered from framework boundaries that cannot
+  /// handle a failure.
+  bool Cancel() noexcept override {
     {
       std::lock_guard<std::mutex> lock(mutex_);
       canceled_ = true;
+      terminated_ = true;
     }
 
     canceled_cv_.notify_all();
+    return true;
+  }
+
+  bool IsSessionTerminated() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return terminated_;
   }
 
  private:
-  std::mutex mutex_;
+  mutable std::mutex mutex_;
   std::condition_variable canceled_cv_;
   bool canceled_ = false;
+  bool terminated_ = false;
 };
 
-class RawGeneratorSession : public fl::Session {
+/// Model-free runtime: it publishes a fake generator through ActiveGenerator and drives it exactly the way a
+/// modality does, without ever touching the model lease (which is left empty).
+class RawGeneratorRuntime : public fl::SessionRuntime {
  public:
-  RawGeneratorSession(const fl::Model& catalog_model, fl::ILogger& logger, fl::ITelemetry& telemetry)
-      : Session(catalog_model, logger, telemetry) {}
+  RawGeneratorRuntime(const fl::Model& catalog_model, fl::ILogger& logger, fl::ITelemetry& telemetry)
+      : SessionRuntime(catalog_model, logger, telemetry, fl::ModelSessionLease{}) {}
 
   fl::SessionType Type() const override { return fl::SessionType::kChat; }
 
@@ -69,22 +149,110 @@ class RawGeneratorSession : public fl::Session {
   bool StoppedWithoutThrowing() const { return stopped_without_throwing_; }
 
  private:
-  void ProcessRequestImpl(const fl::Request& request, fl::Response& /*response*/) override {
-    ActiveGenerator active(*this, generator_);
-    stopped_without_throwing_ = !fl::TryGenerateNextToken(generator_, request);
+  void ProcessRequestImpl(const fl::OperationContext& operation, const fl::Request& /*request*/,
+                          fl::Response& /*response*/) override {
+    fl::ActiveGenerator active(operation, generator_);
+    stopped_without_throwing_ = !fl::TryGenerateNextToken(generator_, operation);
   }
 
   BlockingGenerator generator_;
   bool stopped_without_throwing_ = false;
 };
 
-TEST(OgaGeneratorCancellationTest, RuntimeErrorAfterRequestCancellationStopsGeneration) {
-  fl::Request request;
-  request.canceled.store(true);
-  ThrowingGenerator generator;
+/// Drives one operation to completion so the raw helper can be exercised against a real stop latch.
+class StoppedOperation {
+ public:
+  explicit StoppedOperation(fl::StopReason reason) {
+    state_ = std::make_shared<fl::OperationState>(std::weak_ptr<fl::SessionRuntime>{},
+                                                  std::weak_ptr<fl::RequestControl>{}, std::nullopt,
+                                                  std::chrono::milliseconds(0));
+    context_ = std::make_unique<fl::OperationContext>(state_);
+    state_->RequestStop(reason);
+  }
 
-  EXPECT_FALSE(fl::TryGenerateNextToken(generator, request));
+  const fl::OperationContext& Context() const { return *context_; }
+
+  /// Publish `generator` long enough for the stop to be delivered to it, exactly as a modality would.
+  void DeliverEngineCancel(fl::ICancellable& generator) {
+    fl::ActiveGenerator active(Context(), generator);
+  }
+
+ private:
+  std::shared_ptr<fl::OperationState> state_;
+  std::unique_ptr<fl::OperationContext> context_;
+};
+
+/// An operation that was never stopped.
+class RunningOperation {
+ public:
+  RunningOperation() {
+    state_ = std::make_shared<fl::OperationState>(std::weak_ptr<fl::SessionRuntime>{},
+                                                  std::weak_ptr<fl::RequestControl>{}, std::nullopt,
+                                                  std::chrono::milliseconds(0));
+    context_ = std::make_unique<fl::OperationContext>(state_);
+  }
+
+  const fl::OperationContext& Context() const { return *context_; }
+
+ private:
+  std::shared_ptr<fl::OperationState> state_;
+  std::unique_ptr<fl::OperationContext> context_;
+};
+
+TEST(OgaGeneratorCancellationTest, PreStoppedOperationDoesNotEnterGeneratorAfterDeliveredCancel) {
+  StoppedOperation operation(fl::StopReason::kExternalCancel);
+
+  // Registering after the stop delivers engine cancellation through a lease and outside every lock.
+  BlockingGenerator blocking;
+  operation.DeliverEngineCancel(blocking);
+
+  ThrowingGenerator generator;
+  generator.session_terminated = false;
+
+  EXPECT_TRUE(operation.Context().ShouldStop());
+  EXPECT_TRUE(operation.Context().EngineCancelDelivered());
+  EXPECT_FALSE(fl::TryGenerateNextToken(generator, operation.Context()));
+  EXPECT_EQ(generator.call_count, 0);
+}
+
+TEST(OgaGeneratorCancellationTest, PreStoppedOperationSkipsEveryRawOgaBoundary) {
+  StoppedOperation operation(fl::StopReason::kExternalCancel);
+  RawCallCounter generator;
+  DecodeCallCounter decoder;
+  int tensors = 0;
+  int token_count = 7;
+
+  EXPECT_FALSE(fl::TrySetGeneratorInputs(generator, tensors, operation.Context()));
+  EXPECT_FALSE(fl::TryGenerateNextToken(generator, operation.Context()));
+  EXPECT_FALSE(fl::TryGetNextTokens(generator, operation.Context()).has_value());
+  EXPECT_FALSE(fl::TryDecodeToken(decoder, int32_t{42}, operation.Context()).has_value());
+  EXPECT_FALSE(fl::TryIncrementTokenCount(token_count, operation.Context()));
+  EXPECT_TRUE(fl::IsGeneratorDoneCancellationSafe(generator, operation.Context()));
+
+  EXPECT_EQ(generator.set_inputs_count, 0);
+  EXPECT_EQ(generator.generate_count, 0);
+  EXPECT_EQ(generator.get_tokens_count, 0);
+  EXPECT_EQ(generator.is_done_count, 0);
+  EXPECT_EQ(decoder.decode_count, 0);
+  EXPECT_EQ(token_count, 7);
+}
+
+TEST(OgaGeneratorCancellationTest, StopRacingStartedCallSuppressesOnlyConfirmedTermination) {
+  RunningOperation operation;
+  StopThenThrowGenerator generator(operation.Context(), /*report_terminated=*/true);
+
+  EXPECT_FALSE(fl::TryGenerateNextToken(generator, operation.Context()));
   EXPECT_EQ(generator.call_count, 1);
+  EXPECT_TRUE(operation.Context().ShouldStop());
+}
+
+TEST(OgaGeneratorCancellationTest, UnrelatedErrorRacingStopIsRethrown) {
+  RunningOperation operation;
+  StopThenThrowGenerator generator(operation.Context(), /*report_terminated=*/false);
+
+  EXPECT_THROW(static_cast<void>(fl::TryGenerateNextToken(generator, operation.Context())), std::runtime_error);
+  EXPECT_EQ(generator.call_count, 1);
+  EXPECT_FALSE(operation.Context().EngineCancelDelivered());
 }
 
 TEST(OgaGeneratorCancellationTest, DeadlineTerminationIsTranslatedToTimeoutBySession) {
@@ -92,7 +260,9 @@ TEST(OgaGeneratorCancellationTest, DeadlineTerminationIsTranslatedToTimeoutBySes
   auto catalog_model =
       fl::Model::FromModelInfo(fl::ModelInfo{}, "", services.download_manager, services.model_load_manager);
   fl::TelemetryLogger telemetry{"test", fl::test::NullLog()};
-  RawGeneratorSession session(catalog_model, services.logger, telemetry);
+
+  auto runtime = fl::MakeSessionRuntime<RawGeneratorRuntime>(catalog_model, services.logger, telemetry);
+  fl::Session session(runtime);
 
   fl::Request request;
   request.SetTimeout(std::chrono::milliseconds(200));
@@ -105,22 +275,45 @@ TEST(OgaGeneratorCancellationTest, DeadlineTerminationIsTranslatedToTimeoutBySes
     EXPECT_EQ(ex.code(), FOUNDRY_LOCAL_ERROR_TIMEOUT);
   }
 
-  EXPECT_TRUE(session.StoppedWithoutThrowing());
+  EXPECT_TRUE(runtime->StoppedWithoutThrowing());
   EXPECT_TRUE(request.canceled.load());
   EXPECT_TRUE(request.timed_out.load());
 }
 
 TEST(OgaGeneratorCancellationTest, RuntimeErrorFromRunningRequestIsRethrownUnchanged) {
-  fl::Request request;
+  RunningOperation operation;
+
   ThrowingGenerator generator;
+  generator.session_terminated = true;  // irrelevant: nothing stopped this operation
   generator.message = "unrelated engine failure";
 
   try {
-    static_cast<void>(fl::TryGenerateNextToken(generator, request));
+    static_cast<void>(fl::TryGenerateNextToken(generator, operation.Context()));
     FAIL() << "Expected runtime_error";
   } catch (const std::runtime_error& ex) {
     EXPECT_STREQ(ex.what(), generator.message.c_str());
   }
+}
+
+TEST(OgaGeneratorCancellationTest, SealedOperationRejectsLaterStops) {
+  RunningOperation operation;
+
+  ASSERT_TRUE(operation.Context().TrySeal());
+  EXPECT_TRUE(operation.Context().IsSealed());
+
+  // Post-seal cancellation is a no-op: it must not latch, and must not be able to reach a generator.
+  EXPECT_FALSE(operation.Context().RequestStop(fl::StopReason::kExternalCancel));
+  EXPECT_FALSE(operation.Context().RequestStop(fl::StopReason::kTimeout));
+  EXPECT_FALSE(operation.Context().ShouldStop());
+  EXPECT_FALSE(operation.Context().EngineCancelDelivered());
+}
+
+TEST(OgaGeneratorCancellationTest, SealFailsOnceCancellationHasWon) {
+  StoppedOperation operation(fl::StopReason::kTimeout);
+
+  EXPECT_FALSE(operation.Context().TrySeal());
+  EXPECT_FALSE(operation.Context().IsSealed());
+  EXPECT_EQ(operation.Context().Reason(), fl::StopReason::kTimeout);
 }
 
 }  // namespace

--- a/sdk_v2/cpp/test/internal_api/operation_test.cc
+++ b/sdk_v2/cpp/test/internal_api/operation_test.cc
@@ -1,0 +1,449 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "inferencing/session/operation.h"
+
+#include "inferencing/session/operation_context.h"
+#include "inferencing/session/operation_state.h"
+#include "inferencing/session/session.h"
+#include "inferencing/session/session_runtime.h"
+#include "internal_api/test_helpers.h"
+#include "items/text_item.h"
+#include "model.h"
+#include "model_info.h"
+#include "telemetry/telemetry_logger.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <thread>
+
+namespace {
+
+using namespace std::chrono_literals;
+
+constexpr auto kDiagnosticTimeout = 5s;
+
+class CountingCancellable final : public fl::ICancellable {
+ public:
+  bool Cancel() noexcept override {
+    cancel_count_.fetch_add(1, std::memory_order_relaxed);
+
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      cancelled_ = true;
+    }
+
+    cancelled_cv_.notify_all();
+    return true;
+  }
+
+  int CancelCount() const noexcept {
+    return cancel_count_.load(std::memory_order_relaxed);
+  }
+
+  bool WaitForCancellation() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cancelled_cv_.wait_for(lock, kDiagnosticTimeout, [this] { return cancelled_; });
+  }
+
+ private:
+  std::atomic<int> cancel_count_{0};
+  std::mutex mutex_;
+  std::condition_variable cancelled_cv_;
+  bool cancelled_ = false;
+};
+
+class OperationRuntime final : public fl::SessionRuntime {
+ public:
+  enum class Behavior {
+    kComplete,
+    kBlockUntilCancelled,
+  };
+
+  OperationRuntime(const fl::Model& catalog_model, fl::ILogger& logger, fl::ITelemetry& telemetry,
+                   Behavior behavior)
+      : SessionRuntime(catalog_model, logger, telemetry, fl::ModelSessionLease{}), behavior_(behavior) {}
+
+  fl::SessionType Type() const override {
+    return fl::SessionType::kChat;
+  }
+
+  int ProcessCount() const noexcept {
+    return process_count_.load(std::memory_order_relaxed);
+  }
+
+  int GeneratorCancelCount() const noexcept {
+    return generator_.CancelCount();
+  }
+
+  bool WaitUntilRunning() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return running_cv_.wait_for(lock, kDiagnosticTimeout, [this] { return running_; });
+  }
+
+ private:
+  void ProcessRequestImpl(const fl::OperationContext& operation, const fl::Request& /*request*/,
+                          fl::Response& response) override {
+    process_count_.fetch_add(1, std::memory_order_relaxed);
+
+    if (behavior_ == Behavior::kComplete) {
+      fl::Response pending;
+      pending.items.push_back(std::make_unique<fl::TextItem>("completed"));
+      pending.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+
+      if (operation.TrySeal()) {
+        response.Swap(pending);
+      }
+
+      return;
+    }
+
+    {
+      fl::ActiveGenerator active(operation, generator_);
+
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        running_ = true;
+      }
+      running_cv_.notify_all();
+
+      if (!generator_.WaitForCancellation()) {
+        throw std::runtime_error("operation cancellation was not delivered");
+      }
+    }
+
+    fl::Response partial;
+    partial.items.push_back(std::make_unique<fl::TextItem>("partial"));
+    partial.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+    response.Swap(partial);
+  }
+
+  const Behavior behavior_;
+  std::atomic<int> process_count_{0};
+  CountingCancellable generator_;
+  std::mutex mutex_;
+  std::condition_variable running_cv_;
+  bool running_ = false;
+};
+
+class StopDeliveryGate {
+ public:
+  static void Pause(void* context) noexcept {
+    static_cast<StopDeliveryGate*>(context)->Pause();
+  }
+
+  bool WaitUntilPaused() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, kDiagnosticTimeout, [this] { return paused_; });
+  }
+
+  void Release() noexcept {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      released_ = true;
+    }
+
+    cv_.notify_all();
+  }
+
+ private:
+  void Pause() noexcept {
+    std::unique_lock<std::mutex> lock(mutex_);
+    paused_ = true;
+    cv_.notify_all();
+    cv_.wait(lock, [this] { return released_; });
+  }
+
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  bool paused_ = false;
+  bool released_ = false;
+};
+
+struct ControlledClock {
+  static std::chrono::steady_clock::time_point Now(void* context) noexcept {
+    auto& clock = *static_cast<ControlledClock*>(context);
+    clock.read_count.fetch_add(1, std::memory_order_relaxed);
+    return clock.now;
+  }
+
+  std::chrono::steady_clock::time_point now;
+  std::atomic<int> read_count{0};
+};
+
+class LinearizationClock {
+ public:
+  static std::chrono::steady_clock::time_point Now(void* context) noexcept {
+    return static_cast<LinearizationClock*>(context)->Read();
+  }
+
+  explicit LinearizationClock(std::chrono::steady_clock::time_point now) : now_(now) {}
+
+  bool WaitUntilReadStarted() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, kDiagnosticTimeout, [this] { return read_started_; });
+  }
+
+  void MarkCancelStarted() noexcept {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      cancel_started_ = true;
+    }
+
+    cv_.notify_all();
+  }
+
+  void MarkCancelCompleted() noexcept {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      cancel_completed_ = true;
+    }
+
+    cv_.notify_all();
+  }
+
+  bool CancelCompletedDuringRead() const noexcept {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return cancel_completed_during_read_;
+  }
+
+ private:
+  std::chrono::steady_clock::time_point Read() noexcept {
+    std::unique_lock<std::mutex> lock(mutex_);
+    read_started_ = true;
+    cv_.notify_all();
+
+    cv_.wait_for(lock, kDiagnosticTimeout, [this] { return cancel_started_; });
+
+    // Diagnostic timeout: while OperationState::mu_ is held by TrySeal, RequestStop cannot complete. If the
+    // clock were sampled before that lock, the cancellation would complete here and this test would fail.
+    cancel_completed_during_read_ =
+        cv_.wait_for(lock, 250ms, [this] { return cancel_completed_; });
+    return now_;
+  }
+
+  const std::chrono::steady_clock::time_point now_;
+  mutable std::mutex mutex_;
+  std::condition_variable cv_;
+  bool read_started_ = false;
+  bool cancel_started_ = false;
+  bool cancel_completed_ = false;
+  bool cancel_completed_during_read_ = false;
+};
+
+class OperationTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<OperationRuntime> MakeRuntime(OperationRuntime::Behavior behavior) {
+    return fl::MakeSessionRuntime<OperationRuntime>(catalog_model_, services_.logger, telemetry_, behavior);
+  }
+
+  fl::test::FakeServiceBindings services_;
+  fl::Model catalog_model_ =
+      fl::Model::FromModelInfo(fl::ModelInfo{}, "", services_.download_manager, services_.model_load_manager);
+  fl::TelemetryLogger telemetry_{"test", fl::test::NullLog()};
+};
+
+TEST_F(OperationTest, PreCancelledOperationSkipsRuntimeAndClearsReusedResponse) {
+  auto runtime = MakeRuntime(OperationRuntime::Behavior::kComplete);
+  fl::Session session(runtime);
+  fl::Request request;
+  auto operation = session.CreateOperation(request);
+
+  fl::Response response;
+  response.items.push_back(std::make_unique<fl::TextItem>("stale"));
+  response.finish_reason = FOUNDRY_LOCAL_FINISH_LENGTH;
+
+  operation->Cancel();
+  const auto outcome = operation->Process(response);
+
+  EXPECT_EQ(outcome, fl::OperationOutcome::kCancelled);
+  EXPECT_EQ(operation->Status(), fl::OperationStatus::kCancelled);
+  EXPECT_EQ(runtime->ProcessCount(), 0);
+  EXPECT_TRUE(response.items.empty());
+  EXPECT_EQ(response.finish_reason, FOUNDRY_LOCAL_FINISH_NONE);
+  EXPECT_TRUE(request.canceled.load());
+  EXPECT_FALSE(request.timed_out.load());
+}
+
+TEST_F(OperationTest, ActiveCancelStopsExactGeneratorAndClearsPartialResponse) {
+  auto runtime = MakeRuntime(OperationRuntime::Behavior::kBlockUntilCancelled);
+  fl::Session session(runtime);
+  fl::Request request;
+  auto operation = session.CreateOperation(request);
+
+  fl::Response response;
+  response.items.push_back(std::make_unique<fl::TextItem>("stale"));
+
+  fl::OperationOutcome outcome = fl::OperationOutcome::kCompleted;
+  std::exception_ptr process_error;
+  std::thread worker([&] {
+    try {
+      outcome = operation->Process(response);
+    } catch (...) {
+      process_error = std::current_exception();
+    }
+  });
+
+  const bool running = runtime->WaitUntilRunning();
+  operation->Cancel();
+  worker.join();
+
+  ASSERT_TRUE(running);
+  ASSERT_FALSE(process_error);
+  EXPECT_EQ(outcome, fl::OperationOutcome::kCancelled);
+  EXPECT_EQ(operation->Status(), fl::OperationStatus::kCancelled);
+  EXPECT_EQ(runtime->ProcessCount(), 1);
+  EXPECT_EQ(runtime->GeneratorCancelCount(), 1);
+  EXPECT_TRUE(response.items.empty());
+  EXPECT_EQ(response.finish_reason, FOUNDRY_LOCAL_FINISH_NONE);
+  EXPECT_TRUE(request.canceled.load());
+  EXPECT_FALSE(request.timed_out.load());
+}
+
+TEST_F(OperationTest, CompletedOperationReplacesStaleResponseWithCommittedCandidate) {
+  auto runtime = MakeRuntime(OperationRuntime::Behavior::kComplete);
+  fl::Session session(runtime);
+  fl::Request request;
+  auto operation = session.CreateOperation(request);
+
+  fl::Response response;
+  response.items.push_back(std::make_unique<fl::TextItem>("stale"));
+  response.finish_reason = FOUNDRY_LOCAL_FINISH_LENGTH;
+
+  const auto outcome = operation->Process(response);
+
+  ASSERT_EQ(outcome, fl::OperationOutcome::kCompleted);
+  ASSERT_EQ(response.items.size(), 1u);
+  ASSERT_EQ(response.items[0]->type, FOUNDRY_LOCAL_ITEM_TEXT);
+  EXPECT_EQ(static_cast<const fl::TextItem&>(*response.items[0]).text, "completed");
+  EXPECT_EQ(response.finish_reason, FOUNDRY_LOCAL_FINISH_STOP);
+  EXPECT_EQ(operation->Status(), fl::OperationStatus::kCompleted);
+  EXPECT_FALSE(request.canceled.load());
+}
+
+TEST(OperationStateTest, DeadlineAndSealUseOneFirstWinnerDecision) {
+  using Clock = std::chrono::steady_clock;
+
+  const auto deadline = Clock::time_point{} + 10s;
+  ControlledClock expired_clock{.now = deadline};
+  const fl::OperationState::TestHooks expired_hooks{
+      .now = &ControlledClock::Now,
+      .context = &expired_clock,
+  };
+  auto expired = std::make_shared<fl::OperationState>(
+      std::weak_ptr<fl::SessionRuntime>{}, std::weak_ptr<fl::RequestControl>{}, deadline, 10s, &expired_hooks);
+
+  EXPECT_FALSE(expired->TrySeal());
+  EXPECT_EQ(expired->Reason(), fl::StopReason::kTimeout);
+  EXPECT_EQ(expired->Status(), fl::OperationStatus::kTimedOut);
+  EXPECT_FALSE(expired->RequestStop(fl::StopReason::kExternalCancel));
+  EXPECT_EQ(expired_clock.read_count.load(std::memory_order_relaxed), 1);
+
+  ControlledClock pre_deadline_clock{.now = deadline - 1ms};
+  const fl::OperationState::TestHooks pre_deadline_hooks{
+      .now = &ControlledClock::Now,
+      .context = &pre_deadline_clock,
+  };
+  auto sealed = std::make_shared<fl::OperationState>(
+      std::weak_ptr<fl::SessionRuntime>{}, std::weak_ptr<fl::RequestControl>{}, deadline, 10s,
+      &pre_deadline_hooks);
+
+  EXPECT_TRUE(sealed->TrySeal());
+  EXPECT_TRUE(sealed->IsSealed());
+  EXPECT_EQ(sealed->Reason(), fl::StopReason::kNone);
+  EXPECT_FALSE(sealed->RequestStop(fl::StopReason::kTimeout));
+  EXPECT_EQ(pre_deadline_clock.read_count.load(std::memory_order_relaxed), 1);
+}
+
+TEST(OperationStateTest, ClockSampleHoldsLifecycleMutexAgainstConcurrentStop) {
+  using Clock = std::chrono::steady_clock;
+
+  const auto deadline = Clock::time_point{} + 10s;
+  LinearizationClock clock(deadline - 1ms);
+  const fl::OperationState::TestHooks hooks{
+      .now = &LinearizationClock::Now,
+      .context = &clock,
+  };
+  auto state = std::make_shared<fl::OperationState>(
+      std::weak_ptr<fl::SessionRuntime>{}, std::weak_ptr<fl::RequestControl>{}, deadline, 10s, &hooks);
+
+  bool seal_won = false;
+  std::thread sealer([&] {
+    seal_won = state->TrySeal();
+  });
+
+  const bool read_started = clock.WaitUntilReadStarted();
+  bool cancel_won = false;
+  std::thread canceller([&] {
+    clock.MarkCancelStarted();
+    cancel_won = state->RequestStop(fl::StopReason::kExternalCancel);
+    clock.MarkCancelCompleted();
+  });
+
+  sealer.join();
+  canceller.join();
+
+  ASSERT_TRUE(read_started);
+  EXPECT_FALSE(clock.CancelCompletedDuringRead());
+  EXPECT_TRUE(seal_won);
+  EXPECT_FALSE(cancel_won);
+  EXPECT_TRUE(state->IsSealed());
+  EXPECT_EQ(state->Reason(), fl::StopReason::kNone);
+}
+
+TEST(OperationStateTest, RegistrationRacingStoppedSnapshotIsCancelledExactlyOnce) {
+  StopDeliveryGate gate;
+  const fl::OperationState::TestHooks hooks{
+      .before_generator_drain = &StopDeliveryGate::Pause,
+      .context = &gate,
+  };
+  auto state = std::make_shared<fl::OperationState>(
+      std::weak_ptr<fl::SessionRuntime>{}, std::weak_ptr<fl::RequestControl>{}, std::nullopt, 0ms, &hooks);
+  fl::OperationContext operation(state);
+
+  bool stop_won = false;
+  std::thread stopper([&] {
+    stop_won = state->RequestStop(fl::StopReason::kExternalCancel);
+  });
+
+  const bool paused = gate.WaitUntilPaused();
+  if (!paused) {
+    gate.Release();
+    stopper.join();
+    FAIL() << "stop delivery did not reach the deterministic gate";
+    return;
+  }
+
+  CountingCancellable generator;
+  auto active = std::make_unique<fl::ActiveGenerator>(operation, generator);
+  EXPECT_EQ(generator.CancelCount(), 1);
+
+  gate.Release();
+  stopper.join();
+
+  EXPECT_TRUE(stop_won);
+  EXPECT_EQ(generator.CancelCount(), 1);
+  active.reset();
+}
+
+TEST(OperationStateTest, RepeatedStopCancelsPublishedGeneratorAtMostOnce) {
+  auto state = std::make_shared<fl::OperationState>(
+      std::weak_ptr<fl::SessionRuntime>{}, std::weak_ptr<fl::RequestControl>{}, std::nullopt, 0ms);
+  fl::OperationContext operation(state);
+  CountingCancellable generator;
+  fl::ActiveGenerator active(operation, generator);
+
+  EXPECT_TRUE(state->RequestStop(fl::StopReason::kExternalCancel));
+  EXPECT_FALSE(state->RequestStop(fl::StopReason::kTimeout));
+  EXPECT_EQ(generator.CancelCount(), 1);
+}
+
+}  // namespace

--- a/sdk_v2/cpp/test/internal_api/session_manager_test.cc
+++ b/sdk_v2/cpp/test/internal_api/session_manager_test.cc
@@ -6,8 +6,10 @@
 #include "inferencing/session/session_registration.h"
 #include "inferencing/generative/chat/chat_session.h"
 #include "inferencing/model_load_manager.h"
+#include "inferencing/session/session.h"
 #include "ep_detection/ep_detector.h"
 #include "exception.h"
+#include "inferencing/session/session_runtime.h"
 #include "logger.h"
 #include "model.h"
 #include "internal_api/test_helpers.h"
@@ -323,25 +325,24 @@ TEST_F(SessionManagerTest, CheckedOutSessionNotAffectedByCheckIn) {
 
 namespace {
 
-/// Test-only Session that blocks inside ProcessRequestImpl until its request's cancel flag is
-/// observed. Lets a unit test verify SessionManager::CancelAll() propagates cancellation to every
-/// registered session without loading a model. Polls the atomic exactly like the real generation
-/// loop, with a safety deadline so a broken Cancel() fails the test instead of hanging the suite.
-class BlockingCancelSession : public Session {
+/// Test-only runtime that blocks until its operation is cancelled. This exercises the production
+/// per-operation stop authority without loading a model.
+class BlockingCancelRuntime final : public SessionRuntime {
  public:
-  BlockingCancelSession(const Model& model, ILogger& logger, ITelemetry& telemetry)
-      : Session(model, logger, telemetry) {}
+  BlockingCancelRuntime(const fl::Model& model, fl::ILogger& logger, fl::ITelemetry& telemetry)
+      : SessionRuntime(model, logger, telemetry, ModelSessionLease{}) {}
 
   SessionType Type() const override { return SessionType::kChat; }
 
   bool InFlight() const { return in_flight_.load(std::memory_order_acquire); }
 
- protected:
-  void ProcessRequestImpl(const Request& request, Response& /*response*/) override {
+ private:
+  void ProcessRequestImpl(const OperationContext& operation, const Request& /*request*/,
+                          Response& /*response*/) override {
     in_flight_.store(true, std::memory_order_release);
 
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-    while (!request.canceled.load(std::memory_order_relaxed)) {
+    while (!operation.ShouldStop()) {
       if (std::chrono::steady_clock::now() >= deadline) {
         return;  // safety net: a broken Cancel() must not hang the test suite
       }
@@ -350,7 +351,6 @@ class BlockingCancelSession : public Session {
     }
   }
 
- private:
   std::atomic<bool> in_flight_{false};
 };
 
@@ -377,16 +377,17 @@ TEST(SessionManagerCancelTest, CancelAllCancelsInFlightRequestsOnEverySession) {
   TelemetryLogger telemetry{"test", fl::test::NullLog()};
   SessionManager mgr(fl::test::NullLog());
 
-  BlockingCancelSession s1(catalog_model, fl::test::NullLog(), telemetry);
-  BlockingCancelSession s2(catalog_model, fl::test::NullLog(), telemetry);
+  auto runtime1 = MakeSessionRuntime<BlockingCancelRuntime>(catalog_model, fl::test::NullLog(), telemetry);
+  auto runtime2 = MakeSessionRuntime<BlockingCancelRuntime>(catalog_model, fl::test::NullLog(), telemetry);
+  Session s1(runtime1);
+  Session s2(runtime2);
   SessionRegistration r1(mgr, s1);
   SessionRegistration r2(mgr, s2);
 
   Request req1;
   Request req2;
 
-  // Drive each session's blocking ProcessRequest on its own worker so both requests are in-flight
-  // (published in the cancellation state) at the same time — exercising "every registered session".
+  // Drive each runtime on its own worker so both operations are in-flight at the same time.
   auto f1 = std::async(std::launch::async, [&] {
     Response resp;
     s1.ProcessRequest(req1, resp);
@@ -396,7 +397,7 @@ TEST(SessionManagerCancelTest, CancelAllCancelsInFlightRequestsOnEverySession) {
     s2.ProcessRequest(req2, resp);
   });
 
-  ASSERT_TRUE(WaitUntil([&] { return s1.InFlight() && s2.InFlight(); }, std::chrono::seconds(2)))
+  ASSERT_TRUE(WaitUntil([&] { return runtime1->InFlight() && runtime2->InFlight(); }, std::chrono::seconds(2)))
       << "worker requests never became in-flight";
 
   mgr.CancelAll();
@@ -410,17 +411,18 @@ TEST(SessionManagerCancelTest, CancelAllCancelsInFlightRequestsOnEverySession) {
 
 TEST(SessionManagerCancelTest, RequestAdmittedAfterCancelIsStampedCanceledAndRejected) {
   // Models the late-admission window: a session is registered (its streaming thread exists) but the
-  // request hasn't reached ProcessRequest when the shutdown sweep runs. Cancel()'s per-request loop
-  // can't see this request yet, so the terminal latch must stamp and reject it at admission.
+  // request has not created an operation when the shutdown sweep runs, so the terminal runtime must
+  // stamp and reject it at admission.
   fl::test::FakeServiceBindings svc;
   Model catalog_model = Model::FromModelInfo(ModelInfo{}, "", svc.download_manager, svc.model_load_manager);
   TelemetryLogger telemetry{"test", fl::test::NullLog()};
   SessionManager mgr(fl::test::NullLog());
 
-  BlockingCancelSession s(catalog_model, fl::test::NullLog(), telemetry);
+  auto runtime = MakeSessionRuntime<BlockingCancelRuntime>(catalog_model, fl::test::NullLog(), telemetry);
+  Session s(runtime);
   SessionRegistration r(mgr, s);
 
-  // Cancel while no request is in-flight; the per-request cancel loop has nothing to flip.
+  // Cancel while no operation exists yet.
   mgr.CancelAll();
 
   Request req;


### PR DESCRIPTION
## Scope

Follow-up to #994. This contains the larger per-operation cancellation runtime that was removed from #994 to keep the original fix focused and reviewable.

It addresses the deferred concurrency/lifetime findings around request epochs, per-operation deadlines, generator ownership, session destruction, and concurrent embeddings cancellation.

This PR is intentionally draft and must not block #994.