### PR TITLE
Add audio input support to Responses API

### DIFF
--- a/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.cc
@@ -11,6 +11,7 @@
 #include "inferencing/generative/toolcalling/tool_call_context.h"
 #include "inferencing/generative/toolcalling/tool_call_stream_accumulator.h"
 #include "inferencing/generative/toolcalling/tool_call_utils.h"
+#include "items/audio_item.h"
 #include "items/image_item.h"
 #include "items/text_item.h"
 #include "items/tool_result_item.h"
@@ -414,31 +415,33 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
              "At least one MESSAGE item with non-empty content is required in the request");
   }
 
-  // Vision input detection.
+  // Media input detection.
   //
-  // Image input is only allowed on the first turn of a session. After that:
-  //   - AppendMessages (continuous decoding) has no image-aware path; image
+  // Media input is only allowed on the first turn of a session. After that:
+  //   - AppendMessages (continuous decoding) has no media-aware path; media
   //     parts in subsequent turns would be silently dropped.
   //   - Conversation history can't replay image bytes through the chat
   //     template, so we can't even rebuild from scratch with prior images.
   // The simplest correct behaviour is to require a fresh session for every
-  // vision request. Text follow-ups within the same session are fine — the
-  // model has already produced a textual description that lives in history.
+  // media request. Text follow-ups within the same session are fine.
   std::vector<const ImageItem*> images;
+  std::vector<const AudioItem*> audios;
   for (const auto& msg : new_messages) {
     for (const auto& part : msg.content) {
       if (part.view && part.view->type == FOUNDRY_LOCAL_ITEM_IMAGE) {
         images.push_back(static_cast<const ImageItem*>(part.view));
+      } else if (part.view && part.view->type == FOUNDRY_LOCAL_ITEM_AUDIO) {
+        audios.push_back(static_cast<const AudioItem*>(part.view));
       }
     }
   }
 
-  const bool vision_turn = !images.empty();
+  const bool media_turn = !images.empty() || !audios.empty();
 
-  if (vision_turn && !history_.empty()) {
+  if (media_turn && !history_.empty()) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
-             "image input is only allowed on the first turn of a session; "
-             "create a new ChatSession to send images");
+             "image or audio input is only allowed on the first turn of a session; "
+             "create a new ChatSession to send media");
   }
 
   // Merge session-level and per-request options once for this turn.
@@ -483,15 +486,15 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
     all_messages.insert(all_messages.end(), new_messages.begin(), new_messages.end());
 
     std::unique_ptr<OnnxChatGenerator> generator;
-    if (vision_turn) {
-      // Vision is single-shot: the generator is dropped after the turn (see
+    if (media_turn) {
+      // Media is single-shot: the generator is dropped after the turn (see
       // CommitTurn cleanup below) because AppendMessages can't extend a
       // sequence whose state includes image-derived tokens. Sizing the KV
       // cache to the model's full context window would needlessly allocate
       // gigabytes (262k tokens × 28 layers × 8 heads × 128 dims for
       // qwen3-vl-2b ≈ 120 GB). Bound it to prompt + max_output_tokens.
-      generator = OnnxChatGenerator::CreateWithImages(all_messages, effective_options, Model(), images, tool_ctx,
-                                                      /*use_full_context*/ false);
+      generator = OnnxChatGenerator::CreateWithMedia(all_messages, effective_options, Model(), images, audios,
+                         tool_ctx, /*use_full_context*/ false);
     } else {
       generator = OnnxChatGenerator::Create(all_messages, effective_options, Model(), tool_ctx,
                                             /*use_full_context*/ true);
@@ -628,11 +631,11 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
 
     CommitTurn(std::move(new_messages), response, pre_turn_token_count, total_tokens);
 
-    // After a vision turn, drop the cached generator so any text follow-up
-    // rebuilds from history. AppendMessages cannot extend a vision-decoded
+    // After a media turn, drop the cached generator so any text follow-up
+    // rebuilds from history. AppendMessages cannot extend a media-decoded
     // sequence; trying to do so would silently feed text into a state that
-    // includes image-derived tokens.
-    if (vision_turn) {
+    // includes media-derived tokens.
+    if (media_turn) {
       cached_generator_.reset();
       cached_tool_ctx_ = {};
     }

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #include "inferencing/generative/chat/onnx_chat_generator.h"
 #include "exception.h"
+#include "items/audio_item.h"
 #include "items/image_item.h"
 #include "items/message_item.h"
 #include "items/text_item.h"
@@ -166,12 +167,12 @@ void OnnxChatGenerator::RewindTo(int token_count) {
 }
 
 // ---------------------------------------------------------------------------
-// Vision helpers (mirror upstream C# OnnxChatGenerator)
+// Media helpers
 // ---------------------------------------------------------------------------
 
-std::string OnnxChatGenerator::TransformMessagesForVision(const std::vector<MessageItem>& messages) {
+std::string OnnxChatGenerator::TransformMessagesForMedia(const std::vector<MessageItem>& messages) {
   // Find the index of the last user message so we can rewrite only that one
-  // into the structured `[{"type":"image"},{"type":"text","text":...}]` form.
+  // into structured media markers followed by its text content.
   // Other messages are emitted in plain `{"role","content"}` form so the chat
   // template renders them the same way it does for text-only requests.
   size_t last_user_idx = messages.size();
@@ -189,12 +190,19 @@ std::string OnnxChatGenerator::TransformMessagesForVision(const std::vector<Mess
     entry["role"] = Utils::RoleToString(msg.role);
 
     if (i == last_user_idx) {
-      // Concatenate the message's text parts (REASONING parts and non-text parts skipped by the helper); image
-      // bytes are processed separately by OgaMultiModalProcessor::ProcessImages.
-      entry["content"] = nlohmann::json::array({
-          nlohmann::json{{"type", "image"}},
-          nlohmann::json{{"type", "text"}, {"text", RenderMessageForPrompt(msg)}},
-      });
+      auto content = nlohmann::json::array();
+      for (const auto& part : msg.content) {
+        if (!part.view) {
+          continue;
+        }
+        if (part.view->type == FOUNDRY_LOCAL_ITEM_IMAGE) {
+          content.push_back(nlohmann::json{{"type", "image"}});
+        } else if (part.view->type == FOUNDRY_LOCAL_ITEM_AUDIO) {
+          content.push_back(nlohmann::json{{"type", "audio"}});
+        }
+      }
+      content.push_back(nlohmann::json{{"type", "text"}, {"text", RenderMessageForPrompt(msg)}});
+      entry["content"] = std::move(content);
     } else {
       // Non-final message: render visible text parts only via the canonical helper.
       entry["content"] = RenderMessageForPrompt(msg);
@@ -215,22 +223,22 @@ std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::Create(const std::vector<M
                                                              GenAIModelInstance& model,
                                                              const ToolCallContext& tool_ctx,
                                                              bool use_full_context) {
-  return CreateImpl(messages, options, model, tool_ctx, use_full_context, /*images=*/{});
+  return CreateImpl(messages, options, model, tool_ctx, use_full_context, /*images=*/{}, /*audios=*/{});
 }
 
-std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateWithImages(
+std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateWithMedia(
     const std::vector<MessageItem>& messages,
     const SearchOptions& options,
     GenAIModelInstance& model,
     const std::vector<const ImageItem*>& images,
+    const std::vector<const AudioItem*>& audios,
     const ToolCallContext& tool_ctx,
     bool use_full_context) {
-  if (images.empty()) {
+  if (images.empty() && audios.empty()) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-             "CreateWithImages requires at least one image; use Create for text-only requests");
+             "CreateWithMedia requires at least one image or audio input");
   }
-
-  return CreateImpl(messages, options, model, tool_ctx, use_full_context, images);
+  return CreateImpl(messages, options, model, tool_ctx, use_full_context, images, audios);
 }
 
 std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateImpl(const std::vector<MessageItem>& messages,
@@ -238,22 +246,23 @@ std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateImpl(const std::vect
                                                                  GenAIModelInstance& model,
                                                                  const ToolCallContext& tool_ctx,
                                                                  bool use_full_context,
-                                                                 const std::vector<const ImageItem*>& images) {
+                                                                 const std::vector<const ImageItem*>& images,
+                                                                 const std::vector<const AudioItem*>& audios) {
   if (messages.empty()) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "messages must not be empty");
   }
 
-  const bool vision_branch = !images.empty();
+  const bool media_branch = !images.empty() || !audios.empty();
 
-  if (vision_branch) {
+  if (media_branch) {
     if (!model.IsMultiModal()) {
       FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-               "image input requires a multimodal model");
+               "image or audio input requires a multimodal model");
     }
 
     if (model.GetProcessor() == nullptr) {
       FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-               "model has no multimodal processor available for image input");
+               "model has no multimodal processor available for media input");
     }
 
     // Match upstream's single-image limit. Easy to relax once the wider
@@ -265,11 +274,10 @@ std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateImpl(const std::vect
   }
 
   // 1. Build the chat prompt using the model's template.
-  //    Vision: rewrite the last user message to insert the model's image
-  //    sentinel before the user text.
+  //    Media: rewrite the last user message to insert media sentinels.
   std::string prompt;
-  if (vision_branch) {
-    std::string messages_json = TransformMessagesForVision(messages);
+  if (media_branch) {
+    std::string messages_json = TransformMessagesForMedia(messages);
     const char* tools_ptr = tool_ctx.tools_json.empty() ? nullptr : tool_ctx.tools_json.c_str();
     prompt = model.Tokenizer().ApplyChatTemplate(messages_json.c_str(), tools_ptr, /*add_generation_prompt=*/true);
   } else {
@@ -278,32 +286,71 @@ std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateImpl(const std::vect
 
   // 2. Token budgeting.
   //    Text path: encode the prompt up front so we know its token count.
-  //    Vision path: defer; OgaGenerator::SetInputs will derive input_ids from
-  //    the named tensors, and we read TokenCount() back after the call.
+  //    Media path: process inputs first and read the expanded input_ids shape.
   std::unique_ptr<OgaSequences> sequences;
   int input_token_count = 0;
 
-  if (!vision_branch) {
+  if (!media_branch) {
     sequences = EncodePrompt(prompt, model);
     input_token_count = static_cast<int>(sequences->SequenceCount(0));
-  } else {
-    // Approximate budget for ApplySearchOptions: encode the prompt once with
-    // the text tokenizer to get a token count. The actual prompt fed to the
-    // generator comes from ProcessImages and may be slightly longer due to
-    // image-token expansion, but this is the best estimate we have for
-    // max_length budgeting and matches upstream's pattern of reading
-    // TokenCount() after SetInputs for the authoritative count.
-    auto approx = EncodePrompt(prompt, model);
-    input_token_count = static_cast<int>(approx->SequenceCount(0));
+  }
+
+  // Process media before sizing the generator so max_length includes the
+  // exact token expansion produced by the multimodal processor.
+  std::unique_ptr<OgaNamedTensors> named_tensors;
+  if (media_branch) {
+    std::vector<std::vector<std::uint8_t>> image_bytes;
+    image_bytes.reserve(images.size());
+    std::vector<const void*> buffers;
+    buffers.reserve(images.size());
+    std::vector<size_t> sizes;
+    sizes.reserve(images.size());
+
+    for (const auto* img : images) {
+      if (img == nullptr) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "image entry must not be null");
+      }
+
+      image_bytes.push_back(img->ReadBytes());
+      buffers.push_back(image_bytes.back().data());
+      sizes.push_back(image_bytes.back().size());
+    }
+
+    std::vector<const void*> audio_buffers;
+    audio_buffers.reserve(audios.size());
+    std::vector<size_t> audio_sizes;
+    audio_sizes.reserve(audios.size());
+    for (const auto* audio : audios) {
+      if (audio == nullptr || audio->data == nullptr || audio->data_size == 0) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "audio entry must contain bytes");
+      }
+      audio_buffers.push_back(audio->data);
+      audio_sizes.push_back(audio->data_size);
+    }
+
+    auto oga_images = images.empty() ? nullptr : OgaImages::Load(buffers.data(), sizes.data(), buffers.size());
+    auto oga_audios = audios.empty() ? nullptr : OgaAudios::Load(audio_buffers.data(), audio_sizes.data(), audio_buffers.size());
+    if (oga_images && oga_audios) {
+      named_tensors = model.GetProcessor()->ProcessImagesAndAudios(prompt.c_str(), oga_images.get(), oga_audios.get());
+    } else if (oga_images) {
+      named_tensors = model.GetProcessor()->ProcessImages(prompt.c_str(), oga_images.get());
+    } else {
+      named_tensors = model.GetProcessor()->ProcessAudios(prompt.c_str(), oga_audios.get());
+    }
+    auto input_ids = named_tensors->Get("input_ids");
+    auto input_shape = input_ids->Shape();
+    if (input_shape.empty() || input_shape.back() <= 0) {
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "multimodal processor returned invalid input_ids");
+    }
+    input_token_count = static_cast<int>(input_shape.back());
   }
 
   // 3. Create GeneratorParams from the model
   auto gen_params = OgaGeneratorParams::Create(model.GetOgaModel());
 
   // 4. Apply search options (temperature, top_p, max_length, etc.) and validate token budget.
-  //    Default output budget mirrors C# OnnxChatGenerator: 3072 for vision requests
-  //    (image tokens push the prompt much higher), 2048 for text.
-  int default_max_output = vision_branch ? 3072 : 2048;
+  //    Media inputs use a larger default because preprocessing expands them into tokens.
+  int default_max_output = media_branch ? 3072 : 2048;
   ApplySearchOptions(options, input_token_count, model.GetGenAIConfig(), *gen_params, model.EP(),
                      use_full_context, default_max_output);
 
@@ -348,39 +395,15 @@ std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateImpl(const std::vect
 
   // 6. Create the Generator and feed it the prompt.
   //    Text path: append the encoded token sequences.
-  //    Vision path: process images via OgaMultiModalProcessor and feed the
+  //    Media path: process inputs via OgaMultiModalProcessor and feed the
   //    resulting named tensors via SetInputs (which extracts input_ids and
   //    appends them internally — do NOT also call AppendTokenSequences).
   std::unique_ptr<OgaGenerator> generator;
-  std::unique_ptr<OgaNamedTensors> named_tensors;
   try {
     generator = OgaGenerator::Create(model.GetOgaModel(), *gen_params);
 
-    if (vision_branch) {
-      // Materialise raw image bytes and pointer/size arrays for OgaImages::Load.
-      std::vector<std::vector<std::uint8_t>> image_bytes;
-      image_bytes.reserve(images.size());
-      std::vector<const void*> buffers;
-      buffers.reserve(images.size());
-      std::vector<size_t> sizes;
-      sizes.reserve(images.size());
-
-      for (const auto* img : images) {
-        if (img == nullptr) {
-          FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "image entry must not be null");
-        }
-
-        image_bytes.push_back(img->ReadBytes());
-        buffers.push_back(image_bytes.back().data());
-        sizes.push_back(image_bytes.back().size());
-      }
-
-      auto oga_images = OgaImages::Load(buffers.data(), sizes.data(), buffers.size());
-      named_tensors = model.GetProcessor()->ProcessImages(prompt.c_str(), oga_images.get());
+    if (media_branch) {
       generator->SetInputs(*named_tensors);
-
-      // Authoritative prompt token count after image-token expansion.
-      input_token_count = static_cast<int>(generator->GetSequenceCount(0));
     } else {
       generator->AppendTokenSequences(*sequences);
     }

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
@@ -306,38 +306,45 @@ std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateImpl(const std::vect
   // exact token expansion produced by the multimodal processor.
   std::unique_ptr<OgaNamedTensors> named_tensors;
   if (media_branch) {
-    std::vector<std::vector<std::uint8_t>> image_bytes;
-    image_bytes.reserve(images.size());
-    std::vector<const void*> buffers;
-    buffers.reserve(images.size());
-    std::vector<size_t> sizes;
-    sizes.reserve(images.size());
+    std::unique_ptr<OgaImages> oga_images;
+    if (!images.empty()) {
+      std::vector<std::vector<std::uint8_t>> image_bytes;
+      image_bytes.reserve(images.size());
+      std::vector<const void*> buffers;
+      buffers.reserve(images.size());
+      std::vector<size_t> sizes;
+      sizes.reserve(images.size());
 
-    for (const auto* img : images) {
-      if (img == nullptr) {
-        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "image entry must not be null");
+      for (const auto* img : images) {
+        if (img == nullptr) {
+          FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "image entry must not be null");
+        }
+
+        image_bytes.push_back(img->ReadBytes());
+        buffers.push_back(image_bytes.back().data());
+        sizes.push_back(image_bytes.back().size());
       }
 
-      image_bytes.push_back(img->ReadBytes());
-      buffers.push_back(image_bytes.back().data());
-      sizes.push_back(image_bytes.back().size());
+      oga_images = OgaImages::Load(buffers.data(), sizes.data(), buffers.size());
     }
 
-    std::vector<const void*> audio_buffers;
-    audio_buffers.reserve(audios.size());
-    std::vector<size_t> audio_sizes;
-    audio_sizes.reserve(audios.size());
-    for (const auto* audio : audios) {
-      if (audio == nullptr || audio->data == nullptr || audio->data_size == 0) {
-        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "audio entry must contain bytes");
+    std::unique_ptr<OgaAudios> oga_audios;
+    if (!audios.empty()) {
+      std::vector<const void*> audio_buffers;
+      audio_buffers.reserve(audios.size());
+      std::vector<size_t> audio_sizes;
+      audio_sizes.reserve(audios.size());
+      for (const auto* audio : audios) {
+        if (audio == nullptr || audio->data == nullptr || audio->data_size == 0) {
+          FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "audio entry must contain bytes");
+        }
+        audio_buffers.push_back(audio->data);
+        audio_sizes.push_back(audio->data_size);
       }
-      audio_buffers.push_back(audio->data);
-      audio_sizes.push_back(audio->data_size);
+
+      oga_audios = OgaAudios::Load(audio_buffers.data(), audio_sizes.data(), audio_buffers.size());
     }
 
-    auto oga_images = images.empty() ? nullptr : OgaImages::Load(buffers.data(), sizes.data(), buffers.size());
-    auto oga_audios =
-        audios.empty() ? nullptr : OgaAudios::Load(audio_buffers.data(), audio_sizes.data(), audio_buffers.size());
     if (oga_images && oga_audios) {
       named_tensors = model.GetProcessor()->ProcessImagesAndAudios(prompt.c_str(), oga_images.get(), oga_audios.get());
     } else if (oga_images) {

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
@@ -204,6 +204,13 @@ std::string OnnxChatGenerator::TransformMessagesForMedia(const std::vector<Messa
       content.push_back(nlohmann::json{{"type", "text"}, {"text", RenderMessageForPrompt(msg)}});
       entry["content"] = std::move(content);
     } else {
+      for (const auto& part : msg.content) {
+        if (part.view &&
+            (part.view->type == FOUNDRY_LOCAL_ITEM_IMAGE || part.view->type == FOUNDRY_LOCAL_ITEM_AUDIO)) {
+          FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+                   "media input must belong to the final user message");
+        }
+      }
       // Non-final message: render visible text parts only via the canonical helper.
       entry["content"] = RenderMessageForPrompt(msg);
     }
@@ -329,7 +336,8 @@ std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateImpl(const std::vect
     }
 
     auto oga_images = images.empty() ? nullptr : OgaImages::Load(buffers.data(), sizes.data(), buffers.size());
-    auto oga_audios = audios.empty() ? nullptr : OgaAudios::Load(audio_buffers.data(), audio_sizes.data(), audio_buffers.size());
+    auto oga_audios =
+        audios.empty() ? nullptr : OgaAudios::Load(audio_buffers.data(), audio_sizes.data(), audio_buffers.size());
     if (oga_images && oga_audios) {
       named_tensors = model.GetProcessor()->ProcessImagesAndAudios(prompt.c_str(), oga_images.get(), oga_audios.get());
     } else if (oga_images) {

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.h
@@ -99,9 +99,9 @@ class OnnxChatGenerator : public ChatGenerator {
                     int prompt_token_count,
                     std::unique_ptr<OgaNamedTensors> named_tensors = nullptr);
 
-    // Shared implementation for text and media creation paths. Empty image and
-    // audio lists select text; either media list selects multimodal processing.
-  // both public entry points share search-options validation, guidance setup,
+  // Shared implementation for text and media creation paths. Empty image and
+  // audio lists select text; either media list selects multimodal processing.
+  // Both public entry points share search-options validation, guidance setup,
   // and generator construction.
   static std::unique_ptr<OnnxChatGenerator> CreateImpl(const std::vector<MessageItem>& messages,
                                                        const SearchOptions& options,

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.h
@@ -7,6 +7,7 @@
 #include "inferencing/generative/chat/search_options.h"
 #include "inferencing/generative/toolcalling/tool_call_context.h"
 #include "inferencing/generative/genai_model_instance.h"
+#include "items/audio_item.h"
 #include "items/image_item.h"
 
 #include <atomic>
@@ -68,26 +69,13 @@ class OnnxChatGenerator : public ChatGenerator {
                                                    const ToolCallContext& tool_ctx = {},
                                                    bool use_full_context = false);
 
-  /// Factory: create a vision-enabled chat generator.
-  ///
-  /// Processes `images` via the model's OgaMultiModalProcessor and feeds the
-  /// resulting named tensors into OgaGenerator::SetInputs (in place of the
-  /// usual encoded-prompt path). The last user message in `messages` is
-  /// rewritten to `[{"type":"image"},{"type":"text","text":...}]` so the chat
-  /// template inserts the model's image sentinel tokens.
-  ///
-  /// Requires `model.IsMultiModal()`. `images` must be non-empty.
-  /// Continuous decoding (AppendMessages) has no image-aware path; callers
-  /// must always create a fresh generator for a vision turn.
-  ///
-  /// @throws fl::Exception (FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT) on a
-  ///         non-multimodal model, empty/oversize image list, or unreadable
-  ///         image bytes.
-  static std::unique_ptr<OnnxChatGenerator> CreateWithImages(
+  /// Factory: create a multimodal chat generator with image and/or audio inputs.
+  static std::unique_ptr<OnnxChatGenerator> CreateWithMedia(
       const std::vector<MessageItem>& messages,
       const SearchOptions& options,
       GenAIModelInstance& model,
       const std::vector<const ImageItem*>& images,
+      const std::vector<const AudioItem*>& audios,
       const ToolCallContext& tool_ctx = {},
       bool use_full_context = false);
 
@@ -100,8 +88,7 @@ class OnnxChatGenerator : public ChatGenerator {
   /// chat template inserts the appropriate vision sentinel tokens. Other
   /// messages are emitted in their plain `{"role","content"}` form.
   ///
-  /// Mirrors upstream C# OnnxChatGenerator.TransformMessagesForVision.
-  static std::string TransformMessagesForVision(const std::vector<MessageItem>& messages);
+  static std::string TransformMessagesForMedia(const std::vector<MessageItem>& messages);
 
  private:
   OnnxChatGenerator(std::unique_ptr<OgaGeneratorParams> gen_params,
@@ -112,8 +99,8 @@ class OnnxChatGenerator : public ChatGenerator {
                     int prompt_token_count,
                     std::unique_ptr<OgaNamedTensors> named_tensors = nullptr);
 
-  // Shared implementation for both Create (text) and CreateWithImages (vision).
-  // `images` empty → text path; non-empty → vision path. Centralised here so
+    // Shared implementation for text and media creation paths. Empty image and
+    // audio lists select text; either media list selects multimodal processing.
   // both public entry points share search-options validation, guidance setup,
   // and generator construction.
   static std::unique_ptr<OnnxChatGenerator> CreateImpl(const std::vector<MessageItem>& messages,
@@ -121,13 +108,14 @@ class OnnxChatGenerator : public ChatGenerator {
                                                        GenAIModelInstance& model,
                                                        const ToolCallContext& tool_ctx,
                                                        bool use_full_context,
-                                                       const std::vector<const ImageItem*>& images);
+                                                       const std::vector<const ImageItem*>& images,
+                                                       const std::vector<const AudioItem*>& audios);
 
   std::unique_ptr<OgaGeneratorParams> gen_params_;
   std::unique_ptr<OgaGenerator> generator_;
   std::unique_ptr<OgaTokenizerStream> stream_;
   std::unique_ptr<OgaTokenizerStream> stream_with_special_;  // for tool call token detection
-  // Holds the named tensors produced by OgaMultiModalProcessor::ProcessImages
+  // Holds the named tensors produced by OgaMultiModalProcessor media processing
   // for the lifetime of the generator. Generator retains shared_ptr<Tensor>
   // copies internally, but we keep the wrapper alive for symmetry with
   // upstream C# and to guarantee defensive lifetime safety.

--- a/sdk_v2/cpp/src/inferencing/generative/openresponses/response_converter.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/openresponses/response_converter.cc
@@ -59,6 +59,7 @@ static_assert(sizeof(ResponseObject) == 832,
 }  // namespace fl
 
 #include "exception.h"
+#include "items/audio_item.h"
 #include "items/image_item.h"
 #include "items/message_item.h"
 #include "items/text_item.h"
@@ -290,6 +291,29 @@ std::unique_ptr<ImageItem> MakeImageItemFromInputImage(const InputImageContent& 
            "input_image content requires a non-empty image_url, image_data, or file_id");
 }
 
+std::unique_ptr<AudioItem> MakeAudioItemFromInputAudio(const InputAudioContent& c) {
+  if (c.data.empty()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "input_audio data must not be empty");
+  }
+  if (c.format.empty()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "input_audio format must not be empty");
+  }
+
+  std::vector<std::uint8_t> bytes;
+  try {
+    bytes = Azure::Core::Convert::Base64Decode(c.data);
+  } catch (const std::exception& e) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+             std::string("input_audio has invalid base64 payload: ") + e.what());
+  }
+
+  if (bytes.empty()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "input_audio decoded to zero bytes");
+  }
+
+  return std::make_unique<AudioItem>(std::move(bytes), c.format);
+}
+
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -303,10 +327,7 @@ static void AddTypedInputItems(Request& request,
       auto i = std::make_unique<ToolResultItem>(fc_result->call_id, fc_result->output);
       request.AddOwnedItem(std::move(i));
     } else if (auto* msg = std::get_if<InputMessage>(&input_item)) {
-      // Build typed parts from the message's content array. Text and image
-      // parts are forwarded; other content variants (file, audio) are
-      // rejected at the converter so we fail fast rather than silently
-      // dropping content.
+      // Build typed parts from the message's content array.
       std::vector<std::unique_ptr<Item>> parts;
       bool has_text = false;
       for (const auto& c : msg->content) {
@@ -317,9 +338,11 @@ static void AddTypedInputItems(Request& request,
           }
         } else if (auto* ic = std::get_if<InputImageContent>(&c)) {
           parts.push_back(MakeImageItemFromInputImage(*ic));
+        } else if (auto* ac = std::get_if<InputAudioContent>(&c)) {
+          parts.push_back(MakeAudioItemFromInputAudio(*ac));
         } else {
           FL_THROW(FOUNDRY_LOCAL_ERROR_NOT_IMPLEMENTED,
-                   "input message content type not supported (only input_text and input_image)");
+                   "input message content type not supported (only input_text, input_image, and input_audio)");
         }
       }
 

--- a/sdk_v2/cpp/src/model.cc
+++ b/sdk_v2/cpp/src/model.cc
@@ -430,6 +430,7 @@ const StaticIOCache& VisionLanguageChatIO() {
     c.input_items.push_back(Item::Create(FOUNDRY_LOCAL_ITEM_MESSAGE));
     c.input_items.push_back(std::make_unique<TextItem>("", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
     c.input_items.push_back(Item::Create(FOUNDRY_LOCAL_ITEM_IMAGE));
+    c.input_items.push_back(Item::Create(FOUNDRY_LOCAL_ITEM_AUDIO));
     c.output_items.push_back(Item::Create(FOUNDRY_LOCAL_ITEM_MESSAGE));
     c.output_items.push_back(std::make_unique<TextItem>("", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
 

--- a/sdk_v2/cpp/test/internal_api/chat/onnx_chat_generator_vision_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat/onnx_chat_generator_vision_test.cc
@@ -143,3 +143,11 @@ TEST(OnnxChatGeneratorMedia, TransformIncludesImageAndAudioMarkers) {
   EXPECT_EQ(json[0]["content"][1]["type"], "audio");
   EXPECT_EQ(json[0]["content"][2]["text"], "describe both");
 }
+
+TEST(OnnxChatGeneratorMedia, TransformRejectsMediaOutsideFinalUserMessage) {
+  std::vector<MessageItem> messages;
+  messages.push_back(MakeAudioMessage(FOUNDRY_LOCAL_ROLE_USER, "transcribe this"));
+  messages.push_back(MakeTextMessage(FOUNDRY_LOCAL_ROLE_USER, "then summarize it"));
+
+  EXPECT_THROW(OnnxChatGenerator::TransformMessagesForMedia(messages), fl::Exception);
+}

--- a/sdk_v2/cpp/test/internal_api/chat/onnx_chat_generator_vision_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat/onnx_chat_generator_vision_test.cc
@@ -3,13 +3,14 @@
 //
 // Unit tests for OnnxChatGenerator's vision-input message rewriting.
 //
-// Covers `TransformMessagesForVision` — the only static helper exposed for
+// Covers `TransformMessagesForMedia` — the only static helper exposed for
 // testability without loading a model. Image-byte extraction is covered by
 // ImageItemTest (item_test.cc); model-bound vision behaviour is exercised by
 // the integration tests.
 
 #include "inferencing/generative/chat/onnx_chat_generator.h"
 
+#include "items/audio_item.h"
 #include "items/image_item.h"
 #include "items/message_item.h"
 #include "items/text_item.h"
@@ -42,10 +43,28 @@ MessageItem MakeImageMessage(flMessageRole role, std::string text) {
   return MessageItem(role, std::move(parts));
 }
 
+MessageItem MakeAudioMessage(flMessageRole role, std::string text) {
+  std::vector<std::unique_ptr<Item>> parts;
+  static const std::uint8_t kFakeAudio[] = {0x52, 0x49, 0x46, 0x46};
+  parts.emplace_back(std::make_unique<AudioItem>(kFakeAudio, sizeof(kFakeAudio), "wav"));
+  parts.emplace_back(std::make_unique<TextItem>(std::move(text)));
+  return MessageItem(role, std::move(parts));
+}
+
+MessageItem MakeImageAudioMessage(flMessageRole role, std::string text) {
+  std::vector<std::unique_ptr<Item>> parts;
+  static const std::uint8_t kFakeImage[] = {0x89};
+  static const std::uint8_t kFakeAudio[] = {0x52, 0x49, 0x46, 0x46};
+  parts.emplace_back(std::make_unique<ImageItem>(kFakeImage, sizeof(kFakeImage), "image/png"));
+  parts.emplace_back(std::make_unique<AudioItem>(kFakeAudio, sizeof(kFakeAudio), "wav"));
+  parts.emplace_back(std::make_unique<TextItem>(std::move(text)));
+  return MessageItem(role, std::move(parts));
+}
+
 }  // namespace
 
 // ---------------------------------------------------------------------------
-// TransformMessagesForVision
+// TransformMessagesForMedia
 // ---------------------------------------------------------------------------
 
 TEST(OnnxChatGeneratorVision, TransformRewritesLastUserAsStructuredContent) {
@@ -53,7 +72,7 @@ TEST(OnnxChatGeneratorVision, TransformRewritesLastUserAsStructuredContent) {
   messages.push_back(MakeTextMessage(FOUNDRY_LOCAL_ROLE_SYSTEM, "you are helpful"));
   messages.push_back(MakeImageMessage(FOUNDRY_LOCAL_ROLE_USER, "describe the image"));
 
-  std::string json_str = OnnxChatGenerator::TransformMessagesForVision(messages);
+  std::string json_str = OnnxChatGenerator::TransformMessagesForMedia(messages);
   auto json = nlohmann::json::parse(json_str);
 
   ASSERT_TRUE(json.is_array());
@@ -78,7 +97,7 @@ TEST(OnnxChatGeneratorVision, TransformPreservesPriorTextOnlyMessages) {
   messages.push_back(MakeTextMessage(FOUNDRY_LOCAL_ROLE_ASSISTANT, "hello"));
   messages.push_back(MakeImageMessage(FOUNDRY_LOCAL_ROLE_USER, "what is this"));
 
-  auto json = nlohmann::json::parse(OnnxChatGenerator::TransformMessagesForVision(messages));
+  auto json = nlohmann::json::parse(OnnxChatGenerator::TransformMessagesForMedia(messages));
 
   ASSERT_EQ(json.size(), 3u);
   EXPECT_EQ(json[0]["content"], "hi");
@@ -94,10 +113,33 @@ TEST(OnnxChatGeneratorVision, TransformOnlyRewritesFinalUserMessage) {
   messages.push_back(MakeTextMessage(FOUNDRY_LOCAL_ROLE_ASSISTANT, "ok"));
   messages.push_back(MakeImageMessage(FOUNDRY_LOCAL_ROLE_USER, "second"));
 
-  auto json = nlohmann::json::parse(OnnxChatGenerator::TransformMessagesForVision(messages));
+  auto json = nlohmann::json::parse(OnnxChatGenerator::TransformMessagesForMedia(messages));
 
   ASSERT_EQ(json.size(), 3u);
   EXPECT_TRUE(json[0]["content"].is_string());
   EXPECT_EQ(json[0]["content"], "first");
   EXPECT_TRUE(json[2]["content"].is_array());
+}
+
+TEST(OnnxChatGeneratorMedia, TransformIncludesAudioMarker) {
+  std::vector<MessageItem> messages;
+  messages.push_back(MakeAudioMessage(FOUNDRY_LOCAL_ROLE_USER, "transcribe this"));
+
+  auto json = nlohmann::json::parse(OnnxChatGenerator::TransformMessagesForMedia(messages));
+
+  ASSERT_EQ(json[0]["content"].size(), 2u);
+  EXPECT_EQ(json[0]["content"][0]["type"], "audio");
+  EXPECT_EQ(json[0]["content"][1]["text"], "transcribe this");
+}
+
+TEST(OnnxChatGeneratorMedia, TransformIncludesImageAndAudioMarkers) {
+  std::vector<MessageItem> messages;
+  messages.push_back(MakeImageAudioMessage(FOUNDRY_LOCAL_ROLE_USER, "describe both"));
+
+  auto json = nlohmann::json::parse(OnnxChatGenerator::TransformMessagesForMedia(messages));
+
+  ASSERT_EQ(json[0]["content"].size(), 3u);
+  EXPECT_EQ(json[0]["content"][0]["type"], "image");
+  EXPECT_EQ(json[0]["content"][1]["type"], "audio");
+  EXPECT_EQ(json[0]["content"][2]["text"], "describe both");
 }

--- a/sdk_v2/cpp/test/internal_api/model_io_info_test.cc
+++ b/sdk_v2/cpp/test/internal_api/model_io_info_test.cc
@@ -60,11 +60,12 @@ TEST(ModelIOInfoTest, VisionLanguageChat_ReturnsImageInput) {
   auto model = MakeModelWithTask("vision-language-chat");
   auto io = model.GetInputOutputInfo();
 
-  ASSERT_EQ(io.num_inputs, 3u);
+  ASSERT_EQ(io.num_inputs, 4u);
   EXPECT_EQ(io.inputs[0]->type, FOUNDRY_LOCAL_ITEM_MESSAGE);
   EXPECT_EQ(io.inputs[1]->type, FOUNDRY_LOCAL_ITEM_TEXT);
   EXPECT_EQ(static_cast<const TextItem*>(io.inputs[1])->text_type, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON);
   EXPECT_EQ(io.inputs[2]->type, FOUNDRY_LOCAL_ITEM_IMAGE);
+  EXPECT_EQ(io.inputs[3]->type, FOUNDRY_LOCAL_ITEM_AUDIO);
 }
 
 TEST(ModelIOInfoTest, VisionLanguageChat_ReturnsChatOutputs) {

--- a/sdk_v2/cpp/test/internal_api/response_converter_test.cc
+++ b/sdk_v2/cpp/test/internal_api/response_converter_test.cc
@@ -11,6 +11,7 @@
 
 #include <string>
 
+#include "items/audio_item.h"
 #include "items/image_item.h"
 #include "items/message_item.h"
 #include "items/text_item.h"
@@ -362,6 +363,51 @@ TEST(ResponseConverterTest, ToSessionRequest_InputImage_DataUrl_DecodesToImageIt
   EXPECT_EQ(img->format, "image/png");
   EXPECT_EQ(img->data_size, kSamplePngDecodedSize);
   EXPECT_NE(img->data, nullptr);
+}
+
+TEST(ResponseConverterTest, ToSessionRequest_InputAudio_DecodesToAudioItem) {
+  ResponseCreateParams params;
+  params.model = "test-model";
+
+  InputMessage msg;
+  msg.role = "user";
+  InputTextContent text_part;
+  text_part.text = "Transcribe this audio.";
+  msg.content.push_back(text_part);
+  InputAudioContent audio_part;
+  audio_part.data = "AQIDBA==";
+  audio_part.format = "wav";
+  msg.content.push_back(audio_part);
+  params.input = std::vector<InputItem>{msg};
+
+  auto request = ToSessionRequest(params);
+
+  ASSERT_EQ(request.items.size(), 1u);
+  auto* message = dynamic_cast<MessageItem*>(request.items[0]);
+  ASSERT_NE(message, nullptr);
+  ASSERT_EQ(message->content.size(), 2u);
+  ASSERT_EQ(message->content[1].view->type, FOUNDRY_LOCAL_ITEM_AUDIO);
+  const auto* audio = static_cast<const AudioItem*>(message->content[1].view);
+  EXPECT_EQ(audio->format, "wav");
+  ASSERT_EQ(audio->data_size, 4u);
+  const auto* bytes = static_cast<const std::uint8_t*>(audio->data);
+  EXPECT_EQ(bytes[0], 1u);
+  EXPECT_EQ(bytes[3], 4u);
+}
+
+TEST(ResponseConverterTest, ToSessionRequest_InputAudio_RejectsInvalidBase64) {
+  ResponseCreateParams params;
+  params.model = "test-model";
+
+  InputMessage msg;
+  msg.role = "user";
+  InputAudioContent audio_part;
+  audio_part.data = "not-base64!";
+  audio_part.format = "wav";
+  msg.content.push_back(audio_part);
+  params.input = std::vector<InputItem>{msg};
+
+  EXPECT_THROW(ToSessionRequest(params), fl::Exception);
 }
 
 TEST(ResponseConverterTest, ToSessionRequest_InputImage_ImageData_DecodesWithMediaType) {

--- a/sdk_v2/cpp/test/internal_api/response_converter_test.cc
+++ b/sdk_v2/cpp/test/internal_api/response_converter_test.cc
@@ -407,7 +407,50 @@ TEST(ResponseConverterTest, ToSessionRequest_InputAudio_RejectsInvalidBase64) {
   msg.content.push_back(audio_part);
   params.input = std::vector<InputItem>{msg};
 
-  EXPECT_THROW(ToSessionRequest(params), fl::Exception);
+  try {
+    ToSessionRequest(params);
+    FAIL() << "Expected invalid base64 audio data to be rejected";
+  } catch (const fl::Exception& e) {
+    EXPECT_EQ(e.code(), FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT);
+  }
+}
+
+TEST(ResponseConverterTest, ToSessionRequest_InputAudio_RejectsEmptyData) {
+  ResponseCreateParams params;
+  params.model = "test-model";
+
+  InputMessage msg;
+  msg.role = "user";
+  InputAudioContent audio_part;
+  audio_part.format = "wav";
+  msg.content.push_back(audio_part);
+  params.input = std::vector<InputItem>{msg};
+
+  try {
+    ToSessionRequest(params);
+    FAIL() << "Expected empty audio data to be rejected";
+  } catch (const fl::Exception& e) {
+    EXPECT_EQ(e.code(), FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT);
+  }
+}
+
+TEST(ResponseConverterTest, ToSessionRequest_InputAudio_RejectsEmptyFormat) {
+  ResponseCreateParams params;
+  params.model = "test-model";
+
+  InputMessage msg;
+  msg.role = "user";
+  InputAudioContent audio_part;
+  audio_part.data = "AQIDBA==";
+  msg.content.push_back(audio_part);
+  params.input = std::vector<InputItem>{msg};
+
+  try {
+    ToSessionRequest(params);
+    FAIL() << "Expected empty audio format to be rejected";
+  } catch (const fl::Exception& e) {
+    EXPECT_EQ(e.code(), FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT);
+  }
 }
 
 TEST(ResponseConverterTest, ToSessionRequest_InputImage_ImageData_DecodesWithMediaType) {


### PR DESCRIPTION
# Add audio input support to Responses API

## Summary

Extend the SDK v2 Responses API multimodal pipeline to support audio alongside text and images.

## Changes

- Decode base64 `input_audio` payloads into owned `AudioItem` instances.
- Reject empty formats, empty payloads, and invalid base64.
- Detect audio content during chat-session processing.
- Generalize vision processing into a shared media path.
- Add `<|audio|>` markers to multimodal prompts.
- Route requests through:
  - `ProcessImages` for images
  - `ProcessAudios` for audio
  - `ProcessImagesAndAudios` for combined media
- Calculate the token budget from processed `input_ids`.
- Apply existing first-turn and cache restrictions to all media.
- Preserve text-only and image-only behavior.

## Motivation

The Responses schema already parsed `input_audio`, and the runtime already provided `AudioItem` and ORT GenAI audio-processing APIs. However, the Responses converter rejected audio before it reached the model.

Media expansion also happened after generator sizing, which could produce an insufficient `max_length`.