### PR TITLE
Limit model blob downloads to three hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,7 @@ Please report issues or suggest improvements in the [GitHub Issues](https://gith
 
 ### Can inference be cancelled?
 
-Streaming inference supports cooperative cancellation. Non-streaming inference cannot currently be cancelled after
-processing starts and runs to completion.
+Streaming inference supports cooperative cancellation. Non-streaming inference cannot currently be cancelled after processing starts and runs to completion.
 
 ### Is Foundry Local a web server and CLI tool?
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ Please report issues or suggest improvements in the [GitHub Issues](https://gith
 
 ## ❔ Frequently asked questions
 
+### Can inference be cancelled?
+
+Streaming inference supports cooperative cancellation. Non-streaming inference cannot currently be cancelled after
+processing starts and runs to completion.
+
 ### Is Foundry Local a web server and CLI tool?
 
 No. Foundry Local is an **end-to-end local AI solution** that your application ships with. It handles model acquisition, hardware acceleration, and inference inside your app process through the SDK. The optional web server and CLI are available for development workflows, but the core product is the local AI runtime and SDK that you integrate directly into your application.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Please report issues or suggest improvements in the [GitHub Issues](https://gith
 
 ### Can inference be cancelled?
 
-Streaming inference supports cooperative cancellation. Non-streaming inference cannot currently be cancelled after processing starts and runs to completion.
+Inference cancellation is cooperative. Low-level requests can be cancelled with `Request.Cancel()`, while streaming APIs provide language-specific cancellation mechanisms. Cancellation may not take effect until the current generation step completes, and inference requests do not currently have a built-in timeout.
 
 ### Is Foundry Local a web server and CLI tool?
 

--- a/sdk_v2/cpp/src/download/blob_downloader.cc
+++ b/sdk_v2/cpp/src/download/blob_downloader.cc
@@ -181,7 +181,8 @@ void AzureBlobDownloader::DownloadBlob(const std::string& sas_uri,
 
     // Single shared Azure context for the whole blob; calling Cancel() on it
     // propagates into every in-flight chunk read.
-    Azure::Core::Context azure_ctx;
+    auto azure_ctx = Azure::Core::Context{}.WithDeadline(
+        Azure::DateTime(std::chrono::system_clock::now() + std::chrono::hours{3}));
     // Internal cancel flag flipped by the orchestrator on first chunk failure
     // or by external cancellation; checked by workers between iterations.
     std::atomic<bool> internal_cancel{false};
@@ -409,7 +410,11 @@ void AzureBlobDownloader::DownloadBlob(const std::string& sas_uri,
     // All chunks done — sidecar is no longer needed.
     BlobDownloadState::DeleteState(local_path, logger_);
   } catch (const Azure::Core::OperationCancelledException&) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_OPERATION_CANCELLED, "download cancelled");
+    if (cancelled && cancelled->load(std::memory_order_relaxed)) {
+      FL_THROW(FOUNDRY_LOCAL_ERROR_OPERATION_CANCELLED, "download cancelled");
+    }
+
+    FL_THROW(FOUNDRY_LOCAL_ERROR_NETWORK, "model download timed out after 3 hours");
   } catch (const Azure::Core::RequestFailedException& e) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_NETWORK,
              std::string("failed to download blob '") + blob_name + "': " + e.what());

--- a/sdk_v2/cpp/test/internal_api/download_test.cc
+++ b/sdk_v2/cpp/test/internal_api/download_test.cc
@@ -21,7 +21,6 @@
 #include "test_helpers.h"
 #include "util/path_safety.h"
 #include "util/region_fallback.h"
-#include <azure/core/context.hpp>
 #include <foundry_local/foundry_local_c.h>
 #include <nlohmann/json.hpp>
 #include <gtest/gtest.h>
@@ -1543,7 +1542,6 @@ namespace {
 class FakeChunkAzureDownloader : public AzureBlobDownloader {
  public:
   int64_t blob_size = 0;
-  std::function<void()> get_blob_size_hook;
 
   /// Per-call hook. Receives the chunk offset and size plus a `sink` callback
   /// that forwards bytes to the file writer. Allowed to:
@@ -1568,13 +1566,7 @@ class FakeChunkAzureDownloader : public AzureBlobDownloader {
   FakeChunkAzureDownloader() : AzureBlobDownloader(fl::test::NullLog()) {}
 
  protected:
-  int64_t GetBlobSize(ChunkContext& /*ctx*/) override {
-    if (get_blob_size_hook) {
-      get_blob_size_hook();
-    }
-
-    return blob_size;
-  }
+  int64_t GetBlobSize(ChunkContext& /*ctx*/) override { return blob_size; }
 
   void DownloadChunkStreaming(ChunkContext& ctx, int64_t offset, int64_t size,
                               std::vector<uint8_t>& scratch,
@@ -1605,38 +1597,6 @@ class FakeChunkAzureDownloader : public AzureBlobDownloader {
 };
 
 }  // namespace
-
-TEST(AzureBlobDownloaderTimeoutTest, DeadlineCancellationWithoutExternalCancellationBecomesNetworkError) {
-  auto tmpdir = TempPath::CreateTempDir();
-  FakeChunkAzureDownloader d;
-  d.get_blob_size_hook = []() {
-    throw Azure::Core::OperationCancelledException("deadline exceeded");
-  };
-
-  try {
-    d.DownloadBlob("", "blob", (tmpdir.path() / "blob.bin").string(), 1);
-    FAIL() << "expected fl::Exception";
-  } catch (const fl::Exception& e) {
-    EXPECT_EQ(e.code(), FOUNDRY_LOCAL_ERROR_NETWORK);
-    EXPECT_NE(std::string(e.what()).find("model download timed out after 3 hours"), std::string::npos);
-  }
-}
-
-TEST(AzureBlobDownloaderTimeoutTest, DeadlineCancellationWithExternalCancellationRemainsCancelled) {
-  auto tmpdir = TempPath::CreateTempDir();
-  FakeChunkAzureDownloader d;
-  d.get_blob_size_hook = []() {
-    throw Azure::Core::OperationCancelledException("deadline exceeded");
-  };
-  std::atomic<bool> cancelled{true};
-
-  try {
-    d.DownloadBlob("", "blob", (tmpdir.path() / "blob.bin").string(), 1, nullptr, &cancelled);
-    FAIL() << "expected fl::Exception";
-  } catch (const fl::Exception& e) {
-    EXPECT_EQ(e.code(), FOUNDRY_LOCAL_ERROR_OPERATION_CANCELLED);
-  }
-}
 
 TEST(AzureBlobDownloaderResumeTest, SkipsChunksAlreadyMarkedCompleteInSidecar) {
   auto tmpdir = TempPath::CreateTempDir();

--- a/sdk_v2/cpp/test/internal_api/download_test.cc
+++ b/sdk_v2/cpp/test/internal_api/download_test.cc
@@ -21,6 +21,7 @@
 #include "test_helpers.h"
 #include "util/path_safety.h"
 #include "util/region_fallback.h"
+#include <azure/core/context.hpp>
 #include <foundry_local/foundry_local_c.h>
 #include <nlohmann/json.hpp>
 #include <gtest/gtest.h>
@@ -1542,6 +1543,7 @@ namespace {
 class FakeChunkAzureDownloader : public AzureBlobDownloader {
  public:
   int64_t blob_size = 0;
+  std::function<void()> get_blob_size_hook;
 
   /// Per-call hook. Receives the chunk offset and size plus a `sink` callback
   /// that forwards bytes to the file writer. Allowed to:
@@ -1566,7 +1568,13 @@ class FakeChunkAzureDownloader : public AzureBlobDownloader {
   FakeChunkAzureDownloader() : AzureBlobDownloader(fl::test::NullLog()) {}
 
  protected:
-  int64_t GetBlobSize(ChunkContext& /*ctx*/) override { return blob_size; }
+  int64_t GetBlobSize(ChunkContext& /*ctx*/) override {
+    if (get_blob_size_hook) {
+      get_blob_size_hook();
+    }
+
+    return blob_size;
+  }
 
   void DownloadChunkStreaming(ChunkContext& ctx, int64_t offset, int64_t size,
                               std::vector<uint8_t>& scratch,
@@ -1597,6 +1605,38 @@ class FakeChunkAzureDownloader : public AzureBlobDownloader {
 };
 
 }  // namespace
+
+TEST(AzureBlobDownloaderTimeoutTest, DeadlineCancellationWithoutExternalCancellationBecomesNetworkError) {
+  auto tmpdir = TempPath::CreateTempDir();
+  FakeChunkAzureDownloader d;
+  d.get_blob_size_hook = []() {
+    throw Azure::Core::OperationCancelledException("deadline exceeded");
+  };
+
+  try {
+    d.DownloadBlob("", "blob", (tmpdir.path() / "blob.bin").string(), 1);
+    FAIL() << "expected fl::Exception";
+  } catch (const fl::Exception& e) {
+    EXPECT_EQ(e.code(), FOUNDRY_LOCAL_ERROR_NETWORK);
+    EXPECT_NE(std::string(e.what()).find("model download timed out after 3 hours"), std::string::npos);
+  }
+}
+
+TEST(AzureBlobDownloaderTimeoutTest, DeadlineCancellationWithExternalCancellationRemainsCancelled) {
+  auto tmpdir = TempPath::CreateTempDir();
+  FakeChunkAzureDownloader d;
+  d.get_blob_size_hook = []() {
+    throw Azure::Core::OperationCancelledException("deadline exceeded");
+  };
+  std::atomic<bool> cancelled{true};
+
+  try {
+    d.DownloadBlob("", "blob", (tmpdir.path() / "blob.bin").string(), 1, nullptr, &cancelled);
+    FAIL() << "expected fl::Exception";
+  } catch (const fl::Exception& e) {
+    EXPECT_EQ(e.code(), FOUNDRY_LOCAL_ERROR_OPERATION_CANCELLED);
+  }
+}
 
 TEST(AzureBlobDownloaderResumeTest, SkipsChunksAlreadyMarkedCompleteInSidecar) {
   auto tmpdir = TempPath::CreateTempDir();

--- a/sdk_v2/cs/README.md
+++ b/sdk_v2/cs/README.md
@@ -12,7 +12,7 @@ The Foundry Local C# SDK provides a .NET interface for running AI models locally
 - **Model variants** — select specific hardware/quantization variants per model alias
 - **Optional web service** — start an OpenAI-compatible REST endpoint (`/v1/chat_completions`, `/v1/models`)
 - **WinML acceleration** — built-in Windows hardware acceleration with automatic EP download
-- **Full async/await** — every operation supports `CancellationToken` and async patterns
+- **Async APIs** — idiomatic async/await support across the SDK
 - **IDisposable** — deterministic cleanup of native resources
 
 ## Installation


### PR DESCRIPTION
## Summary

- Add a fixed three-hour deadline to each Azure blob transfer used by `Model.Download`.
- Preserve explicit progress-callback cancellation as `OPERATION_CANCELLED`; report deadline expiry as a network timeout.
- Briefly document that streaming cancellation is cooperative and non-streaming inference runs to completion.
- Remove the overbroad C# claim that every operation supports `CancellationToken`.

## Validation

- Compiled `blob_downloader.cc` directly with MSVC.
- `git diff --check` passes.