### PR TITLE
Fix models FastPass accessibility failures

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -19,6 +19,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
+		"test:a11y": "node --test test/accessibility.test.mjs",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",

--- a/www/src/app.css
+++ b/www/src/app.css
@@ -290,6 +290,36 @@ html {
 
 /* Smooth transitions for interactive elements */
 @layer components {
+	.skip-link {
+		position: fixed;
+		top: 1rem;
+		left: 1rem;
+		z-index: 100;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		white-space: nowrap;
+		clip: rect(0, 0, 0, 0);
+		clip-path: inset(50%);
+		border: 0;
+	}
+
+	.skip-link:focus-visible {
+		width: auto;
+		height: auto;
+		padding: 0.5rem 1rem;
+		margin: 0;
+		overflow: visible;
+		color: hsl(var(--primary-foreground));
+		background: hsl(var(--primary));
+		clip: auto;
+		clip-path: none;
+		border-radius: 0.25rem;
+		box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+	}
+
 	.transition-smooth {
 		transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
 	}

--- a/www/src/lib/components/home/nav.svelte
+++ b/www/src/lib/components/home/nav.svelte
@@ -8,6 +8,7 @@
 	import SocialMedia from '../social-media.svelte';
 	import DownloadDropdown from '../download-dropdown.svelte';
 	import LogoTransition from '$lib/components/logo-transition.svelte';
+	import SkipLink from '$lib/components/skip-link.svelte';
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 
@@ -33,12 +34,7 @@
 	});
 </script>
 
-<a
-	href="#main-content"
-	class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-primary focus:px-4 focus:py-2 focus:text-white focus:shadow-lg"
->
-	Skip to main content
-</a>
+<SkipLink />
 <header
 	class="sticky top-0 z-50 w-full border-b bg-white/80 backdrop-blur-md transition-all duration-300 dark:bg-black/80"
 >

--- a/www/src/lib/components/skip-link.svelte
+++ b/www/src/lib/components/skip-link.svelte
@@ -1,0 +1,1 @@
+<a href="#main-content" class="skip-link">Skip to main content</a>

--- a/www/src/routes/models/components/ModelCard.svelte
+++ b/www/src/routes/models/components/ModelCard.svelte
@@ -87,17 +87,14 @@
 
 <div use:animate={{ delay: 0, duration: 600, animation: 'fade-in', once: true }} class="flex">
 	<Card.Root
-		class="border-border/40 hover:border-primary/50 focus:ring-primary relative z-0 flex flex-1 cursor-pointer flex-col transition-all duration-300 focus-within:z-20 hover:z-20 focus:ring-2 focus:ring-offset-2 focus:outline-none"
-		onclick={() => onCardClick(model)}
-		onkeydown={(e) => {
-			if (e.key === 'Enter' || e.key === ' ') {
-				e.preventDefault();
-				onCardClick(model);
-			}
-		}}
-		role="button"
-		tabindex="0"
+		class="border-border/40 hover:border-primary/50 relative z-0 flex flex-1 cursor-pointer flex-col transition-all duration-300 focus-within:z-20 hover:z-20"
 	>
+		<button
+			type="button"
+			class="model-card-details focus-visible:ring-primary absolute inset-0 z-10 cursor-pointer rounded-xl bg-transparent focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+			onclick={() => onCardClick(model)}
+			aria-label={`View details for ${model.displayName}`}
+		></button>
 		<Card.Header class="pb-3">
 			<Card.Title class="line-clamp-1 text-lg">
 				{model.displayName}
@@ -149,7 +146,7 @@
 							target="_blank"
 							rel="noopener noreferrer"
 							onclick={(e) => e.stopPropagation()}
-							class="inline-block"
+							class="relative z-20 inline-block"
 							aria-label={`View ${model.license} license (opens in new tab)`}
 						>
 							<Badge
@@ -203,7 +200,7 @@
 								target="_blank"
 								rel="noopener noreferrer"
 								onclick={(e) => e.stopPropagation()}
-								class="inline-flex items-center gap-1.5 text-xs font-medium text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 transition-colors"
+								class="relative z-20 inline-flex items-center gap-1.5 text-xs font-medium text-violet-600 transition-colors hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-300"
 								aria-label="View SDK Documentation (opens in new tab)"
 							>
 								<svg class="size-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -234,7 +231,7 @@
 											e.stopPropagation();
 											onCopyCommand(genericModelName);
 										}}
-										class="border-primary text-primary hover:bg-primary/10 group relative h-8 w-full justify-start gap-2 overflow-hidden border-2 px-3 text-xs font-semibold"
+										class="border-primary text-primary hover:bg-primary/10 group relative z-20 h-8 w-full justify-start gap-2 overflow-hidden border-2 px-3 text-xs font-semibold"
 									>
 										{#if copiedModelId === `run-${genericModelName}`}
 											<!-- Success State -->
@@ -285,7 +282,7 @@
 													e.stopPropagation();
 													onCopyCommand(variant.name);
 												}}
-												class="h-7 w-full justify-start gap-1.5 px-2.5 text-xs"
+												class="relative z-20 h-7 w-full justify-start gap-1.5 px-2.5 text-xs"
 											>
 												{#if copiedModelId === `run-${variant.name}`}
 													<Check class="size-4 shrink-0 text-green-500" />

--- a/www/test/accessibility.test.mjs
+++ b/www/test/accessibility.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const readSource = (path) => readFileSync(new URL(path, import.meta.url), 'utf8');
+
+function getOpeningTag(source, tagName) {
+	const start = source.indexOf(`<${tagName}`);
+	assert.notEqual(start, -1, `Expected <${tagName}>`);
+
+	let braceDepth = 0;
+	let quote = null;
+	for (let index = start; index < source.length; index += 1) {
+		const character = source[index];
+		const previous = source[index - 1];
+
+		if (quote !== null) {
+			if (character === quote && previous !== '\\') quote = null;
+			continue;
+		}
+		if (character === '"' || character === "'" || character === '`') {
+			quote = character;
+		} else if (character === '{') {
+			braceDepth += 1;
+		} else if (character === '}') {
+			braceDepth -= 1;
+		} else if (character === '>' && braceDepth === 0) {
+			return { start, end: index + 1, source: source.slice(start, index + 1) };
+		}
+	}
+
+	throw new Error(`Unterminated <${tagName}>`);
+}
+
+function getCssRule(source, selector) {
+	const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const match = source.match(new RegExp(`${escapedSelector}\\s*\\{([^}]+)\\}`));
+	assert.ok(match, `Expected CSS rule for ${selector}`);
+	return match[1];
+}
+
+test('ModelCard uses sibling controls instead of nested interactive descendants', () => {
+	const modelCard = readSource('../src/routes/models/components/ModelCard.svelte');
+	const cardComponent = readSource('../src/lib/components/ui/card/card.svelte');
+	const cardRoot = getOpeningTag(modelCard, 'Card.Root');
+
+	assert.match(cardComponent, /<div\b/);
+	assert.doesNotMatch(cardRoot.source, /\b(?:onclick|onkeydown|role|tabindex)=/);
+
+	const detailsMarker = 'class="model-card-details ';
+	const detailsClass = modelCard.indexOf(detailsMarker, cardRoot.end);
+	assert.notEqual(detailsClass, -1);
+	const detailsStart = modelCard.lastIndexOf('<button', detailsClass);
+	const detailsOpen = getOpeningTag(modelCard.slice(detailsStart), 'button');
+	const detailsEnd = modelCard.indexOf('</button>', detailsStart) + '</button>'.length;
+	const detailsButton = modelCard.slice(detailsStart, detailsEnd);
+
+	assert.match(detailsOpen.source, /type="button"/);
+	assert.match(detailsOpen.source, /\bz-10\b/);
+	assert.match(detailsOpen.source, /onclick=\{\(\) => onCardClick\(model\)\}/);
+	assert.match(detailsOpen.source, /aria-label=\{`View details for \$\{model\.displayName\}`\}/);
+	assert.doesNotMatch(detailsButton.slice(detailsOpen.end), /<(?:a|button|Button)\b/);
+	assert.match(modelCard.slice(cardRoot.end, detailsStart), /^\s*$/);
+
+	const cardHeader = modelCard.indexOf('<Card.Header', detailsEnd);
+	assert.notEqual(cardHeader, -1);
+	assert.match(modelCard.slice(detailsEnd, cardHeader), /^\s*$/);
+	assert.match(modelCard.slice(cardHeader), /<a\b/);
+	assert.match(modelCard.slice(cardHeader), /<Button\b/);
+
+	const foregroundActions =
+		modelCard.match(/<(?:a|Button)\b[\s\S]*?\bclass="[^"]*\bz-20\b[^"]*"/g) ?? [];
+	assert.equal(foregroundActions.length, 4);
+});
+
+test('shared skip link is hidden until keyboard focus and targets both main landmarks', () => {
+	const skipLink = readSource('../src/lib/components/skip-link.svelte');
+	const nav = readSource('../src/lib/components/home/nav.svelte');
+	const homePage = readSource('../src/routes/+page.svelte');
+	const modelsPage = readSource('../src/routes/models/+page.svelte');
+	const styles = readSource('../src/app.css');
+
+	assert.match(skipLink, /<a href="#main-content" class="skip-link">Skip to main content<\/a>/);
+	assert.match(nav, /import SkipLink from '\$lib\/components\/skip-link\.svelte';/);
+	assert.match(nav, /<SkipLink \/>/);
+	assert.match(homePage, /<main id="main-content">/);
+	assert.match(modelsPage, /<main id="main-content"(?:\s|>)/);
+
+	const hiddenRule = getCssRule(styles, '.skip-link');
+	assert.match(hiddenRule, /position:\s*fixed/);
+	assert.match(hiddenRule, /top:\s*1rem/);
+	assert.match(hiddenRule, /left:\s*1rem/);
+	assert.match(hiddenRule, /z-index:\s*100/);
+	assert.match(hiddenRule, /width:\s*1px/);
+	assert.match(hiddenRule, /height:\s*1px/);
+	assert.match(hiddenRule, /overflow:\s*hidden/);
+	assert.match(hiddenRule, /clip-path:\s*inset\(50%\)/);
+
+	const focusRule = getCssRule(styles, '.skip-link:focus-visible');
+	assert.match(focusRule, /width:\s*auto/);
+	assert.match(focusRule, /height:\s*auto/);
+	assert.match(focusRule, /overflow:\s*visible/);
+	assert.match(focusRule, /clip-path:\s*none/);
+});


### PR DESCRIPTION
## Summary
- replace the interactive `ModelCard` ancestor with a semantic full-card details button that is a sibling of license, documentation, and copy controls
- move the shared skip link outside the animated navigation and reveal it at a fixed in-viewport position on keyboard focus
- add focused regression coverage for card control structure, skip-link focus styling, and both `#main-content` targets

## Official evidence
Accessibility Insights for Web v2.47.0 reported 47 `nested-interactive` failures on production `https://foundrylocal.ai/models`, all from `ModelCard`, plus a failed focus indicator because `Skip to main content` remained entirely offscreen at `y=-5871`.

Native report: `foundrylocal-accessibility-insights-official/evidence/models/models-official-fastpass-report.html` (187,670 bytes; completed 2026-08-20T00:17:09.254Z).

Production `/` was already clean (0 failed, 0 incomplete, 31 passed); the shared fix preserves its `#main-content` target.

## Validation
- `npm run test:a11y` — 2/2 passed
- `npm run build` — passed
- built-preview DOM on `/models` — 47 cards, 0 nested interactive descendants
- real Chromium Tab traversal on `/models` and `/` — skip link became `:focus-visible` at `(16, 16)`, sized `178.625 × 41.594`, and targeted the existing `main#main-content`
- new-file Prettier checks and `git diff --check` — passed

Repository-wide `npm run lint` remains red on 136 pre-existing formatting files, and `npm run check` remains red on 16 pre-existing errors in 13 untouched UI primitive files. The changed source has no `svelte-check` diagnostics. The official extension was not available in the isolated headless preview profile, so the runtime evidence above is preview evidence rather than an official FastPass rerun.

A production Accessibility Insights FastPass rerun is required after deployment before closing 97172.