### PR TITLE
[SDK V2] Fix some Rust SDK gaps and align language bindings for parity (Rust, C#, JS, Python)

### DIFF
--- a/.pipelines/v2/templates/steps-build-rust.yml
+++ b/.pipelines/v2/templates/steps-build-rust.yml
@@ -16,7 +16,8 @@
 #      the crate, so both unit and integration tests resolve the native by that
 #      baked path.
 #   3. Stamp the crate version from the shared `version-info` artifact.
-#   4. `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build`, and — when
+#   4. `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build`, a doc-lint
+#      (`RUSTDOCFLAGS=-D warnings cargo doc` + `cargo test --doc`), and — when
 #      `runTests` — `cargo test --lib` (unit) followed by the `tests/`
 #      integration suite (serialised: the native core enforces a single manager
 #      per process).
@@ -244,6 +245,26 @@ steps:
         $ErrorActionPreference = 'Stop'
         cargo build --all-targets
         if ($LASTEXITCODE -ne 0) { throw "cargo build failed" }
+    env:
+      FOUNDRY_LOCAL_NATIVE_BIN_DIR: $(flNativeDir)
+
+  - task: PowerShell@2
+    displayName: 'cargo doc (doc-lint, -D warnings)'
+    inputs:
+      targetType: inline
+      pwsh: true
+      workingDirectory: '$(Build.SourcesDirectory)/sdk_v2/rust'
+      script: |
+        $ErrorActionPreference = 'Stop'
+        # Fail on broken intra-doc links / doc warnings so the `///` comments
+        # (the source of truth behind docs/api.md and docs.rs) can't silently
+        # rot. Documentation-only; needs no native library.
+        $env:RUSTDOCFLAGS = '-D warnings'
+        cargo doc --no-deps
+        if ($LASTEXITCODE -ne 0) { throw "cargo doc (doc-lint) failed" }
+        # Compile-check the ```rust examples embedded in doc comments.
+        cargo test --doc
+        if ($LASTEXITCODE -ne 0) { throw "cargo test --doc failed" }
     env:
       FOUNDRY_LOCAL_NATIVE_BIN_DIR: $(flNativeDir)
 

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -10,12 +10,6 @@ repository = "https://github.com/microsoft/Foundry-Local"
 documentation = "https://github.com/microsoft/Foundry-Local/blob/main/sdk/rust/docs/api.md"
 include = ["src/**", "build.rs", "Cargo.toml", "README.md", "LICENSE.txt", "deps_versions.json", "deps_versions_winml.json"]
 
-# docs.rs builds the documentation in an offline sandbox. The build script skips
-# native acquisition when DOCS_RS is set (see build.rs), so the hosted docs build
-# without the native library. Pin a single deterministic target.
-[package.metadata.docs.rs]
-default-target = "x86_64-unknown-linux-gnu"
-
 [features]
 default = []
 winml = []

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -10,6 +10,12 @@ repository = "https://github.com/microsoft/Foundry-Local"
 documentation = "https://github.com/microsoft/Foundry-Local/blob/main/sdk/rust/docs/api.md"
 include = ["src/**", "build.rs", "Cargo.toml", "README.md", "LICENSE.txt", "deps_versions.json", "deps_versions_winml.json"]
 
+# docs.rs builds the documentation in an offline sandbox. The build script skips
+# native acquisition when DOCS_RS is set (see build.rs), so the hosted docs build
+# without the native library. Pin a single deterministic target.
+[package.metadata.docs.rs]
+default-target = "x86_64-unknown-linux-gnu"
+
 [features]
 default = []
 winml = []

--- a/sdk/rust/build.rs
+++ b/sdk/rust/build.rs
@@ -444,14 +444,6 @@ fn main() {
     println!("cargo:rerun-if-env-changed=FOUNDRY_LOCAL_WINDOWS_AI_MACHINELEARNING_VERSION");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_WINML");
 
-    // docs.rs builds the documentation in an offline sandbox and only needs the
-    // crate to type-check — `cargo doc` never links or runs the native library.
-    // Skip native acquisition there; otherwise the unconditional NuGet download
-    // below fails with no network and the hosted docs build fails.
-    if env::var_os("DOCS_RS").is_some() {
-        return;
-    }
-
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
 
     let rid = match get_rid() {

--- a/sdk/rust/build.rs
+++ b/sdk/rust/build.rs
@@ -444,6 +444,14 @@ fn main() {
     println!("cargo:rerun-if-env-changed=FOUNDRY_LOCAL_WINDOWS_AI_MACHINELEARNING_VERSION");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_WINML");
 
+    // docs.rs builds the documentation in an offline sandbox and only needs the
+    // crate to type-check — `cargo doc` never links or runs the native library.
+    // Skip native acquisition there; otherwise the unconditional NuGet download
+    // below fails with no network and the hosted docs build fails.
+    if env::var_os("DOCS_RS").is_some() {
+        return;
+    }
+
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
 
     let rid = match get_rid() {

--- a/sdk_v2/cs/src/AudioSession.cs
+++ b/sdk_v2/cs/src/AudioSession.cs
@@ -19,13 +19,24 @@ public sealed class AudioSession : Session
     /// </summary>
     /// <param name="model">A loaded model whose task is "automatic-speech-recognition".</param>
     /// <exception cref="ArgumentException">If the model's task is not automatic-speech-recognition.</exception>
-    public AudioSession(IModel model) : base(model)
+    public AudioSession(IModel model) : base(ValidateTask(model))
     {
+    }
+
+    // Validate the model's task BEFORE the base Session constructor runs. The base
+    // constructor calls into native to create the session; checking first surfaces a
+    // wrong-task model as an ArgumentException rather than a native error, and keeps
+    // validation consistent across the typed sessions.
+    private static IModel ValidateTask(IModel model)
+    {
+        Detail.Throw.IfNull(model);
         if (model.Info.Task != "automatic-speech-recognition")
         {
             throw new ArgumentException(
                 $"AudioSession requires a model with task 'automatic-speech-recognition', but got '{model.Info.Task}'.",
                 nameof(model));
         }
+
+        return model;
     }
 }

--- a/sdk_v2/cs/src/Catalog.cs
+++ b/sdk_v2/cs/src/Catalog.cs
@@ -60,6 +60,17 @@ internal sealed class Catalog : ICatalog
             "Error getting loaded models.", _logger, ct).ConfigureAwait(false);
     }
 
+    public async Task<List<IModel>> GetModelVersionsAsync(string modelAlias, string? modelName = null, int maxVersions = 50, CancellationToken? ct = null)
+    {
+        return await Utils.CallWithExceptionHandlingAsync(
+            () =>
+            {
+                using var list = _nativeCatalog.GetModelVersions(modelAlias, modelName, maxVersions);
+                return list.Models.Select(m => (IModel)new Model(m, _logger)).ToList();
+            },
+            $"Error getting model versions for alias '{modelAlias}'.", _logger, ct).ConfigureAwait(false);
+    }
+
     public async Task<IModel?> GetModelAsync(string modelAlias, CancellationToken? ct = null)
     {
         return await Utils.CallWithExceptionHandlingAsync(

--- a/sdk_v2/cs/src/ChatSession.cs
+++ b/sdk_v2/cs/src/ChatSession.cs
@@ -25,14 +25,25 @@ public sealed class ChatSession : Session
     /// </summary>
     /// <param name="model">A loaded model whose task is "chat-completion" or "vision-language-chat".</param>
     /// <exception cref="ArgumentException">If the model's task is not a supported chat task.</exception>
-    public ChatSession(IModel model) : base(model)
+    public ChatSession(IModel model) : base(ValidateTask(model))
     {
+    }
+
+    // Validate the model's task BEFORE the base Session constructor runs. The base
+    // constructor calls into native to create the session; checking first surfaces a
+    // wrong-task model as an ArgumentException rather than a native error, and keeps
+    // validation consistent across the typed sessions.
+    private static IModel ValidateTask(IModel model)
+    {
+        Detail.Throw.IfNull(model);
         if (model.Info.Task != "chat-completion" && model.Info.Task != "vision-language-chat")
         {
             throw new ArgumentException(
                 $"ChatSession requires a model with task 'chat-completion' or 'vision-language-chat', but got '{model.Info.Task}'.",
                 nameof(model));
         }
+
+        return model;
     }
 
     /// <summary>

--- a/sdk_v2/cs/src/Detail/FoundryLocalApi.cs
+++ b/sdk_v2/cs/src/Detail/FoundryLocalApi.cs
@@ -469,6 +469,31 @@ public sealed class Catalog
         Api.CheckStatus(status);
         return new ModelList(ptr);
     }
+
+    public ModelList GetModelVersions(string modelAlias, string? modelName, int maxVersions)
+    {
+        var aliasPtr = Utf8.StringToCoTaskMem(modelAlias);
+        var modelNamePtr = Utf8.StringToCoTaskMem(modelName);
+
+        try
+        {
+            var status = Api.Catalog.GetModelVersions(Ptr, aliasPtr, modelNamePtr, maxVersions, out var ptr);
+            Api.CheckStatus(status);
+            return new ModelList(ptr);
+        }
+        finally
+        {
+            if (aliasPtr != IntPtr.Zero)
+            {
+                Marshal.FreeCoTaskMem(aliasPtr);
+            }
+
+            if (modelNamePtr != IntPtr.Zero)
+            {
+                Marshal.FreeCoTaskMem(modelNamePtr);
+            }
+        }
+    }
 }
 
 // ===================================================================

--- a/sdk_v2/cs/src/Detail/FoundryLocalApi.cs
+++ b/sdk_v2/cs/src/Detail/FoundryLocalApi.cs
@@ -109,7 +109,9 @@ internal static class Api
             throw new OperationCanceledException(msg);
         }
 
-        throw new Microsoft.AI.Foundry.Local.FoundryLocalException(msg);
+        // FoundryLocalErrorCode mirrors the native FlErrorCode ABI 1:1 (same names and values), so a direct
+        // cast is safe; an unknown/future numeric code still round-trips through the cast.
+        throw new Microsoft.AI.Foundry.Local.FoundryLocalException(msg, (FoundryLocalErrorCode)code);
     }
 
     /// <summary>

--- a/sdk_v2/cs/src/EmbeddingsSession.cs
+++ b/sdk_v2/cs/src/EmbeddingsSession.cs
@@ -26,10 +26,9 @@ public sealed class EmbeddingsSession : Session
     }
 
     // Validate the model's task BEFORE the base Session constructor runs. The base
-    // constructor calls into native and requires the model to already be loaded; if
-    // a caller passes the wrong-task model (e.g. a chat model) we want to surface
-    // ArgumentException regardless of whether that model has been loaded yet, so
-    // the wrong-task contract isn't accidentally gated on load state.
+    // constructor calls into native to create the session; checking first surfaces a
+    // wrong-task model as an ArgumentException rather than a native error, and keeps
+    // validation consistent across the typed sessions.
     private static IModel ValidateTask(IModel model)
     {
         Detail.Throw.IfNull(model);

--- a/sdk_v2/cs/src/FoundryLocalErrorCode.cs
+++ b/sdk_v2/cs/src/FoundryLocalErrorCode.cs
@@ -1,0 +1,36 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright company="Microsoft">
+//   Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Microsoft.AI.Foundry.Local;
+
+/// <summary>
+/// Stable error codes reported by the native Foundry Local runtime. These mirror the native ABI error codes
+/// 1:1 (same names and numeric values) and are surfaced on <see cref="FoundryLocalException.ErrorCode"/> so
+/// callers can inspect the underlying cause of a native failure without depending on internal interop types.
+/// </summary>
+public enum FoundryLocalErrorCode
+{
+    /// <summary>No error.</summary>
+    Ok = 0,
+
+    /// <summary>The requested operation is not implemented.</summary>
+    NotImplemented = 1,
+
+    /// <summary>An internal error occurred in the native runtime.</summary>
+    Internal = 2,
+
+    /// <summary>An argument passed to the native runtime was invalid.</summary>
+    InvalidArgument = 3,
+
+    /// <summary>The API was used incorrectly (e.g. invalid call sequence or state).</summary>
+    InvalidUsage = 4,
+
+    /// <summary>The operation was cancelled.</summary>
+    OperationCancelled = 5,
+
+    /// <summary>A network error occurred.</summary>
+    Network = 6,
+}

--- a/sdk_v2/cs/src/FoundryLocalException.cs
+++ b/sdk_v2/cs/src/FoundryLocalException.cs
@@ -16,6 +16,11 @@ public class FoundryLocalException : Exception
     {
     }
 
+    public FoundryLocalException(string message, FoundryLocalErrorCode errorCode) : base(message)
+    {
+        ErrorCode = errorCode;
+    }
+
     public FoundryLocalException(string message, Exception innerException) : base(message, innerException)
     {
     }
@@ -32,4 +37,10 @@ public class FoundryLocalException : Exception
         Debug.Assert(logger != null);
         logger!.LogError(innerException, message);
     }
+
+    /// <summary>
+    /// Gets the native error code associated with this failure, or <c>null</c> for SDK-side failures that
+    /// have no corresponding native error code.
+    /// </summary>
+    public FoundryLocalErrorCode? ErrorCode { get; }
 }

--- a/sdk_v2/cs/src/ICatalog.cs
+++ b/sdk_v2/cs/src/ICatalog.cs
@@ -54,6 +54,16 @@ public interface ICatalog
     Task<List<IModel>> GetLoadedModelsAsync(CancellationToken? ct = null);
 
     /// <summary>
+    /// Get the set of available versions for a model alias, optionally filtered by variant name.
+    /// </summary>
+    /// <param name="modelAlias">Model alias.</param>
+    /// <param name="modelName">Optional exact variant name filter; null matches all variants.</param>
+    /// <param name="maxVersions">Maximum number of versions to return per variant name. Use 0 or a negative value to return all versions.</param>
+    /// <param name="ct">Optional CancellationToken.</param>
+    /// <returns>Available model versions matching the alias and variant filter.</returns>
+    Task<List<IModel>> GetModelVersionsAsync(string modelAlias, string? modelName = null, int maxVersions = 50, CancellationToken? ct = null);
+
+    /// <summary>
     /// Get the latest version of a model.
     /// This is used to check if a newer version of a model is available in the catalog for download.
     /// </summary>

--- a/sdk_v2/cs/test/FoundryLocal.Tests/CatalogTests.cs
+++ b/sdk_v2/cs/test/FoundryLocal.Tests/CatalogTests.cs
@@ -74,7 +74,15 @@ internal sealed class CatalogTests
         await Assert.That(versions.Count).IsGreaterThanOrEqualTo(2);
 
         var capped = await catalog.GetModelVersionsAsync(modelWithVariants.Alias, maxVersions: 1);
-        await Assert.That(capped.Count).IsLessThanOrEqualTo(1);
+
+        // maxVersions caps the number of versions returned *per model name*, not the total
+        // result count. An alias with several distinct model names can therefore return one
+        // entry per name, so assert the cap per name rather than on the overall count.
+        var perName = capped.GroupBy(v => v.Info.Name);
+        foreach (var group in perName)
+        {
+            await Assert.That(group.Count()).IsLessThanOrEqualTo(1);
+        }
     }
 
     [Test]

--- a/sdk_v2/cs/test/FoundryLocal.Tests/CatalogTests.cs
+++ b/sdk_v2/cs/test/FoundryLocal.Tests/CatalogTests.cs
@@ -56,6 +56,28 @@ internal sealed class CatalogTests
     }
 
     [Test]
+    public async Task GetModelVersionsAsync_ReturnsVersions_AndCapsResults()
+    {
+        var catalog = await FoundryLocalManager.Instance.GetCatalogAsync();
+
+        var models = await catalog.ListModelsAsync();
+        var modelWithVariants = models.FirstOrDefault(m => m.Variants.Count > 1);
+
+        if (modelWithVariants == null)
+        {
+            Skip.Test("No multi-version model in the catalog.");
+            return;
+        }
+
+        var versions = await catalog.GetModelVersionsAsync(modelWithVariants.Alias);
+        await Assert.That(versions).IsNotNull();
+        await Assert.That(versions.Count).IsGreaterThanOrEqualTo(2);
+
+        var capped = await catalog.GetModelVersionsAsync(modelWithVariants.Alias, maxVersions: 1);
+        await Assert.That(capped.Count).IsLessThanOrEqualTo(1);
+    }
+
+    [Test]
     public async Task ListModelsAsync_HonorsCancelledToken()
     {
         var catalog = await FoundryLocalManager.Instance.GetCatalogAsync();

--- a/sdk_v2/cs/test/FoundryLocal.Tests/FoundryLocalExceptionTests.cs
+++ b/sdk_v2/cs/test/FoundryLocal.Tests/FoundryLocalExceptionTests.cs
@@ -1,0 +1,34 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright company="Microsoft">
+//   Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Microsoft.AI.Foundry.Local.Tests;
+
+using System.Threading.Tasks;
+
+/// <summary>
+/// Tests for <see cref="FoundryLocalException"/> error-code surfacing. These require neither the native
+/// library nor a downloaded model.
+/// </summary>
+internal sealed class FoundryLocalExceptionTests
+{
+    [Test]
+    public async Task Constructor_WithErrorCode_SetsErrorCodeAndMessage()
+    {
+        var ex = new FoundryLocalException("boom", FoundryLocalErrorCode.InvalidUsage);
+
+        await Assert.That(ex.ErrorCode).IsEqualTo(FoundryLocalErrorCode.InvalidUsage);
+        await Assert.That(ex.Message).IsEqualTo("boom");
+    }
+
+    [Test]
+    public async Task Constructor_MessageOnly_LeavesErrorCodeNull()
+    {
+        var ex = new FoundryLocalException("x");
+
+        await Assert.That(ex.ErrorCode).IsNull();
+        await Assert.That(ex.Message).IsEqualTo("x");
+    }
+}

--- a/sdk_v2/js/native/src/catalog.cc
+++ b/sdk_v2/js/native/src/catalog.cc
@@ -81,6 +81,7 @@ Napi::Function Catalog::Init(Napi::Env env) {
           InstanceMethod("getModels", &Catalog::GetModels),
           InstanceMethod("getCachedModels", &Catalog::GetCachedModels),
           InstanceMethod("getLoadedModels", &Catalog::GetLoadedModels),
+          InstanceMethod("getModelVersions", &Catalog::GetModelVersions),
           InstanceMethod("getModel", &Catalog::GetModel),
           InstanceMethod("getModelVariant", &Catalog::GetModelVariant),
           InstanceMethod("getLatestVersion", &Catalog::GetLatestVersion),
@@ -141,6 +142,41 @@ Napi::Value Catalog::GetLoadedModels(const Napi::CallbackInfo& info) {
   Napi::ObjectReference mgr = CloneManager(manager_);
   return CallChecked<Napi::Value>(env, [&]() -> Napi::Value {
     return WrapModelList(env, impl_->GetLoadedModels(), std::move(mgr));
+  });
+}
+
+Napi::Value Catalog::GetModelVersions(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsString()) {
+    Napi::TypeError::New(env, "getModelVersions(modelAlias: string, modelName?: string | null, maxVersions?: number)")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  std::string model_alias = info[0].As<Napi::String>();
+  std::string variant_name;
+  if (info.Length() >= 2 && !info[1].IsNull() && !info[1].IsUndefined()) {
+    if (!info[1].IsString()) {
+      Napi::TypeError::New(env, "getModelVersions: modelName must be a string, null, or undefined")
+          .ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+    variant_name = info[1].As<Napi::String>();
+  }
+
+  int max_versions = 50;
+  if (info.Length() >= 3 && !info[2].IsUndefined()) {
+    if (!info[2].IsNumber()) {
+      Napi::TypeError::New(env, "getModelVersions: maxVersions must be a number")
+          .ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+    max_versions = static_cast<int>(info[2].As<Napi::Number>().Int32Value());
+  }
+
+  Napi::ObjectReference mgr = CloneManager(manager_);
+  return CallChecked<Napi::Value>(env, [&]() -> Napi::Value {
+    return WrapModelList(env, impl_->GetModelVersions(model_alias, variant_name, max_versions), std::move(mgr));
   });
 }
 

--- a/sdk_v2/js/native/src/catalog.cc
+++ b/sdk_v2/js/native/src/catalog.cc
@@ -5,6 +5,7 @@
 #include "addon_data.h"
 #include "errors.h"
 #include "model.h"
+#include "promise_worker.h"
 
 #include <foundry_local/foundry_local_cpp.h>
 
@@ -174,10 +175,23 @@ Napi::Value Catalog::GetModelVersions(const Napi::CallbackInfo& info) {
     max_versions = static_cast<int>(info[2].As<Napi::Number>().Int32Value());
   }
 
-  Napi::ObjectReference mgr = CloneManager(manager_);
-  return CallChecked<Napi::Value>(env, [&]() -> Napi::Value {
-    return WrapModelList(env, impl_->GetModelVersions(model_alias, variant_name, max_versions), std::move(mgr));
-  });
+  // GetModelVersions performs a fresh network FetchModelVersions query on every
+  // call, so it must NOT run on the JS thread. Argument parsing/validation above
+  // stays on the JS thread; only the network fetch is dispatched to the libuv
+  // worker. The Manager is pinned two ways: `owner` keeps it (and the ICatalog*
+  // it owns) alive across the worker, and `manager_pin` is a JS-thread-only
+  // clone the resolver uses to build the Model handles.
+  auto* impl = impl_;
+  auto manager_pin = std::make_shared<Napi::ObjectReference>(CloneManager(manager_));
+  return PromiseWorker<foundry_local::ModelList>::Run(
+      env,
+      [impl, model_alias, variant_name, max_versions]() -> foundry_local::ModelList {
+        return impl->GetModelVersions(model_alias, variant_name, max_versions);
+      },
+      [manager_pin](Napi::Env env, foundry_local::ModelList& ml) -> Napi::Value {
+        return WrapModelList(env, std::move(ml), CloneManager(*manager_pin));
+      },
+      CloneManager(manager_));
 }
 
 // ── Single-model lookups ─────────────────────────────────────────────────────

--- a/sdk_v2/js/native/src/catalog.h
+++ b/sdk_v2/js/native/src/catalog.h
@@ -37,6 +37,7 @@ class Catalog : public Napi::ObjectWrap<Catalog> {
   Napi::Value GetModels(const Napi::CallbackInfo& info);
   Napi::Value GetCachedModels(const Napi::CallbackInfo& info);
   Napi::Value GetLoadedModels(const Napi::CallbackInfo& info);
+  Napi::Value GetModelVersions(const Napi::CallbackInfo& info);
   Napi::Value GetModel(const Napi::CallbackInfo& info);
   Napi::Value GetModelVariant(const Napi::CallbackInfo& info);
   Napi::Value GetLatestVersion(const Napi::CallbackInfo& info);

--- a/sdk_v2/js/src/catalog.ts
+++ b/sdk_v2/js/src/catalog.ts
@@ -89,7 +89,19 @@ export class Catalog {
     if (typeof modelAlias !== "string" || modelAlias.trim() === "") {
       throw new Error("Model alias must be a non-empty string.");
     }
-    return wrapAll(this.#native.getModelVersions(modelAlias, modelName ?? null, maxVersions));
+    // The native parameter is int32_t; N-API's Int32Value() silently coerces
+    // fractions, NaN, Infinity, and out-of-range values into a different cap.
+    // Reject them here (matching Rust's i32::MAX rejection) so callers get a
+    // clear error rather than a surprising truncated result. Negatives/0 are
+    // valid ("no cap") but must still fit i32.
+    if (
+      !Number.isInteger(maxVersions) ||
+      maxVersions < -(2 ** 31) ||
+      maxVersions > 2 ** 31 - 1
+    ) {
+      throw new TypeError("maxVersions must be an integer within the 32-bit range.");
+    }
+    return wrapAll(await this.#native.getModelVersions(modelAlias, modelName ?? null, maxVersions));
   }
 }
 

--- a/sdk_v2/js/src/catalog.ts
+++ b/sdk_v2/js/src/catalog.ts
@@ -80,6 +80,17 @@ export class Catalog {
     }
     return wrapNativeModel(n);
   }
+
+  /**
+   * Get all versions of a model alias, optionally narrowed to a single variant name. `maxVersions`
+   * defaults to 50 and acts as a per-variant cap; pass 0 or a negative value for no cap.
+   */
+  async getModelVersions(modelAlias: string, modelName?: string, maxVersions = 50): Promise<IModel[]> {
+    if (typeof modelAlias !== "string" || modelAlias.trim() === "") {
+      throw new Error("Model alias must be a non-empty string.");
+    }
+    return wrapAll(this.#native.getModelVersions(modelAlias, modelName ?? null, maxVersions));
+  }
 }
 
 /** @internal — used by `FoundryLocalManager` to wrap a native catalog. */

--- a/sdk_v2/js/src/detail/native.ts
+++ b/sdk_v2/js/src/detail/native.ts
@@ -104,7 +104,7 @@ export interface NativeCatalog {
   getModel(alias: string): NativeModel | undefined;
   getModelVariant(modelId: string): NativeModel | undefined;
   getLatestVersion(model: NativeModel): NativeModel | undefined;
-  getModelVersions(modelAlias: string, modelName: string | null, maxVersions: number): NativeModel[];
+  getModelVersions(modelAlias: string, modelName: string | null, maxVersions: number): Promise<NativeModel[]>;
 }
 
 // ── Inference surface ───────────────────────────────────────────────────────

--- a/sdk_v2/js/src/detail/native.ts
+++ b/sdk_v2/js/src/detail/native.ts
@@ -104,6 +104,7 @@ export interface NativeCatalog {
   getModel(alias: string): NativeModel | undefined;
   getModelVariant(modelId: string): NativeModel | undefined;
   getLatestVersion(model: NativeModel): NativeModel | undefined;
+  getModelVersions(modelAlias: string, modelName: string | null, maxVersions: number): NativeModel[];
 }
 
 // ── Inference surface ───────────────────────────────────────────────────────

--- a/sdk_v2/js/src/session.ts
+++ b/sdk_v2/js/src/session.ts
@@ -58,6 +58,15 @@ function modelToNativeChatSession(model: IModel): NativeChatSession {
   if (!(model instanceof Model)) {
     throw new TypeError("ChatSession: expected a Model as the first argument");
   }
+  // Validate the task BEFORE constructing the native session so a wrong-task model
+  // surfaces a `TypeError` here rather than a native `FoundryLocalError`, consistently
+  // with the C# and Python bindings.
+  const task = model.info.task;
+  if (task !== "chat-completion" && task !== "vision-language-chat") {
+    throw new TypeError(
+      `ChatSession requires a model with task 'chat-completion' or 'vision-language-chat', but got '${task ?? "(unset)"}'.`,
+    );
+  }
   const nativeModel = unwrapNativeModel(model);
   return new (getAddon().ChatSession)(nativeModel);
 }
@@ -66,11 +75,9 @@ function modelToNativeEmbeddingsSession(model: IModel): NativeEmbeddingsSession 
   if (!(model instanceof Model)) {
     throw new TypeError("EmbeddingsSession: expected a Model as the first argument");
   }
-  // Validate task in JS BEFORE constructing the native session. Matches the
-  // C# (`ValidateTask`) and Python (`__init__` precheck) conventions: a
-  // wrong-task model surfaces a `TypeError` rather than a native
-  // `FoundryLocalError`, and the check works whether or not the model has
-  // been loaded yet (the native ctor would fail later either way).
+  // Validate the task BEFORE constructing the native session so a wrong-task model
+  // surfaces a `TypeError` here rather than a native `FoundryLocalError`, consistently
+  // with the C# and Python bindings.
   const task = model.info.task;
   if (task !== "embeddings") {
     throw new TypeError(`EmbeddingsSession requires a model with task 'embeddings', but got '${task ?? "(unset)"}'.`);

--- a/sdk_v2/js/test/catalog.test.ts
+++ b/sdk_v2/js/test/catalog.test.ts
@@ -141,7 +141,8 @@ describeIfBuilt("Catalog (cache-only)", () => {
         expect(modelAlias).toBe("phi-4-mini-instruct");
         expect(modelName).toBeNull();
         expect(maxVersions).toBe(1);
-        return [fakeNativeModel];
+        // The real native path resolves a Promise; mirror that here.
+        return Promise.resolve([fakeNativeModel]);
       },
     };
 
@@ -154,4 +155,70 @@ describeIfBuilt("Catalog (cache-only)", () => {
     }
     expect(versions[0]?.info.id).toBe("phi-4-mini-instruct-generic-cpu:2");
   });
+});
+
+// Pure argument-validation: runs regardless of native build state because the
+// checks happen on the JS thread before the native call is ever queued.
+describe("Catalog.getModelVersions maxVersions validation", () => {
+  // A fake whose getModelVersions must never be reached for invalid inputs.
+  function makeGuardedCatalog(): Catalog {
+    const fakeNativeCatalog: NativeCatalog = {
+      getName: () => "TestCatalog",
+      getModels: () => [],
+      getCachedModels: () => [],
+      getLoadedModels: () => [],
+      getModel: () => undefined,
+      getModelVariant: () => undefined,
+      getLatestVersion: () => undefined,
+      getModelVersions: () => {
+        throw new Error("native getModelVersions must not be called for invalid maxVersions");
+      },
+    };
+    return wrapNativeCatalog(fakeNativeCatalog);
+  }
+
+  const invalidCases: ReadonlyArray<readonly [string, number]> = [
+    ["a fraction", 1.5],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["-Infinity", Number.NEGATIVE_INFINITY],
+    ["above int32 max", 2 ** 31],
+    ["below int32 min", -(2 ** 31) - 1],
+  ];
+
+  for (const [label, value] of invalidCases) {
+    it(`rejects ${label} (${value})`, async () => {
+      const catalog = makeGuardedCatalog();
+      await expect(catalog.getModelVersions("phi-4-mini-instruct", undefined, value)).rejects.toThrow(
+        /maxVersions must be an integer within the 32-bit range/,
+      );
+    });
+  }
+
+  const validCases: ReadonlyArray<readonly [string, number]> = [
+    ["int32 max", 2 ** 31 - 1],
+    ["int32 min", -(2 ** 31)],
+    ["zero (no cap)", 0],
+    ["negative (no cap)", -5],
+  ];
+
+  for (const [label, value] of validCases) {
+    it(`accepts ${label} (${value})`, async () => {
+      const fakeNativeCatalog: NativeCatalog = {
+        getName: () => "TestCatalog",
+        getModels: () => [],
+        getCachedModels: () => [],
+        getLoadedModels: () => [],
+        getModel: () => undefined,
+        getModelVariant: () => undefined,
+        getLatestVersion: () => undefined,
+        getModelVersions: (_alias, _name, maxVersions) => {
+          expect(maxVersions).toBe(value);
+          return Promise.resolve([]);
+        },
+      };
+      const catalog = wrapNativeCatalog(fakeNativeCatalog);
+      await expect(catalog.getModelVersions("phi-4-mini-instruct", undefined, value)).resolves.toEqual([]);
+    });
+  }
 });

--- a/sdk_v2/js/test/catalog.test.ts
+++ b/sdk_v2/js/test/catalog.test.ts
@@ -2,7 +2,9 @@
 // helper so this file constructs exactly one Manager + cache directory.
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import type { NativeCatalog, NativeModel, NativeModelInfo } from "../src/detail/native.js";
 import type { Catalog } from "../src/catalog.js";
+import { wrapNativeCatalog } from "../src/catalog.js";
 import { Model } from "../src/model.js";
 
 import {
@@ -97,5 +99,59 @@ describeIfBuilt("Catalog (cache-only)", () => {
   it("getLoadedModels returns an empty array (nothing loaded)", async () => {
     const loaded = await catalog.getLoadedModels();
     expect(loaded).toEqual([]);
+  });
+
+  it("getModelVersions returns versions for a known alias and respects maxVersions", async () => {
+    const nativeModelInfo: NativeModelInfo = {
+      id: "phi-4-mini-instruct-generic-cpu:2",
+      name: "phi-4-mini-instruct-generic-cpu",
+      version: 2,
+      alias: "phi-4-mini-instruct",
+      uri: "azureml://registries/azureml/models/phi-4-mini-instruct-generic-cpu/versions/2",
+      deviceType: "CPU",
+      providerType: "FoundryLocal",
+      modelType: "ONNX",
+      task: "chat-completion",
+      publisher: "Microsoft",
+      displayName: "Phi-4 Mini Instruct",
+      createdAtUnix: 1713800000,
+      isTestModel: false,
+    };
+    const fakeNativeModel: NativeModel = {
+      getInfo: () => nativeModelInfo,
+      isCached: () => true,
+      isLoaded: () => false,
+      getPath: () => "",
+      getVariants: () => [],
+      selectVariant: () => {},
+      load: async () => {},
+      unload: async () => {},
+      download: async () => {},
+      removeFromCache: () => {},
+    };
+    const fakeNativeCatalog: NativeCatalog = {
+      getName: () => "TestCatalog",
+      getModels: () => [],
+      getCachedModels: () => [],
+      getLoadedModels: () => [],
+      getModel: () => undefined,
+      getModelVariant: () => undefined,
+      getLatestVersion: () => undefined,
+      getModelVersions: (modelAlias, modelName, maxVersions) => {
+        expect(modelAlias).toBe("phi-4-mini-instruct");
+        expect(modelName).toBeNull();
+        expect(maxVersions).toBe(1);
+        return [fakeNativeModel];
+      },
+    };
+
+    const localCatalog = wrapNativeCatalog(fakeNativeCatalog);
+    const versions = await localCatalog.getModelVersions("phi-4-mini-instruct", undefined, 1);
+    expect(versions).toHaveLength(1);
+    for (const model of versions) {
+      expect(model).toBeInstanceOf(Model);
+      expect(model.info.alias).toBe("phi-4-mini-instruct");
+    }
+    expect(versions[0]?.info.id).toBe("phi-4-mini-instruct-generic-cpu:2");
   });
 });

--- a/sdk_v2/python/src/foundry_local_sdk/catalog.py
+++ b/sdk_v2/python/src/foundry_local_sdk/catalog.py
@@ -148,3 +148,39 @@ class Catalog:
         ml_out = ffi.new("flModelList**")
         api.check_status(api.catalog.GetLoadedModels(self._ptr, ml_out))
         return _consume_model_list(ml_out[0], api, ffi, parent=self)
+
+    def get_model_versions(
+        self,
+        model_alias: str,
+        model_name: str | None = None,
+        max_versions: int = 50,
+    ) -> list[IModel]:
+        """Get all versions of a model alias.
+
+        Args:
+            model_alias: Model alias. Must be non-empty.
+            model_name: Optional variant name; ``None`` or an empty string returns every
+                variant for the alias.
+            max_versions: Select the latest ``X`` versions per variant name. Defaults to
+                50, matching the web service contract. Pass ``0`` or a negative value for
+                no per-variant cap.
+
+        Returns:
+            One ``IModel`` instance per matching model variant.
+        """
+        from foundry_local_sdk._native.api import api, ffi
+
+        alias_bytes = model_alias.encode("utf-8")
+        model_name_ptr = ffi.NULL if model_name is None else model_name.encode("utf-8")
+
+        ml_out = ffi.new("flModelList**")
+        api.check_status(
+            api.catalog.GetModelVersions(
+                self._ptr,
+                alias_bytes,
+                model_name_ptr,
+                max_versions,
+                ml_out,
+            )
+        )
+        return _consume_model_list(ml_out[0], api, ffi, parent=self)

--- a/sdk_v2/python/test/integration/test_catalog.py
+++ b/sdk_v2/python/test/integration/test_catalog.py
@@ -80,8 +80,15 @@ class TestCatalogShape:
         capped = manager.catalog.get_model_versions(alias, max_versions=1)
 
         assert len(versions) >= 1
-        assert len(capped) <= 1
         assert len(capped) <= len(versions)
+
+        # max_versions caps versions *per model name*, not the total result count. An alias
+        # with several distinct model names can return one entry per name, so assert the cap
+        # per name rather than on the overall length.
+        counts_by_name: dict[str, int] = {}
+        for v in capped:
+            counts_by_name[v.info.name] = counts_by_name.get(v.info.name, 0) + 1
+        assert all(count <= 1 for count in counts_by_name.values())
 
     def test_get_latest_version_returns_model_for_multi_variant_model(self, manager):
         models = manager.catalog.list_models()

--- a/sdk_v2/python/test/integration/test_catalog.py
+++ b/sdk_v2/python/test/integration/test_catalog.py
@@ -58,6 +58,31 @@ class TestCatalogShape:
     def test_get_model_variant_unknown_id_returns_none(self, manager):
         assert manager.catalog.get_model_variant("not-a-real-id") is None
 
+    def test_get_model_versions_returns_versions_for_alias(self, manager):
+        models = manager.catalog.list_models()
+        if not models:
+            pytest.skip("Catalog is empty.")
+
+        alias = next((m.alias for m in models if len(m.variants) > 1), models[0].alias)
+        versions = manager.catalog.get_model_versions(alias)
+
+        assert versions
+        assert all(isinstance(v, IModel) for v in versions)
+        assert all(v.alias == alias for v in versions)
+
+    def test_get_model_versions_respects_max_versions_cap(self, manager):
+        models = manager.catalog.list_models()
+        if not models:
+            pytest.skip("Catalog is empty.")
+
+        alias = next((m.alias for m in models if len(m.variants) > 1), models[0].alias)
+        versions = manager.catalog.get_model_versions(alias)
+        capped = manager.catalog.get_model_versions(alias, max_versions=1)
+
+        assert len(versions) >= 1
+        assert len(capped) <= 1
+        assert len(capped) <= len(versions)
+
     def test_get_latest_version_returns_model_for_multi_variant_model(self, manager):
         models = manager.catalog.list_models()
         if not models:

--- a/sdk_v2/rust/Cargo.toml
+++ b/sdk_v2/rust/Cargo.toml
@@ -10,6 +10,14 @@ repository = "https://github.com/microsoft/Foundry-Local"
 documentation = "https://github.com/microsoft/Foundry-Local/blob/main/sdk_v2/rust/docs/api.md"
 include = ["src/**", "build.rs", "Cargo.toml", "README.md", "LICENSE.txt", "deps_versions.json"]
 
+# docs.rs builds the documentation in an offline sandbox. The build script skips
+# native acquisition when DOCS_RS is set (see build.rs), so the hosted docs build
+# without the native library once the crate is published. Pin a deterministic
+# target. Until then, the hand-maintained docs/api.md is the reference (see
+# GENERATE-DOCS.md).
+[package.metadata.docs.rs]
+default-target = "x86_64-unknown-linux-gnu"
+
 [features]
 default = []
 nightly = []

--- a/sdk_v2/rust/GENERATE-DOCS.md
+++ b/sdk_v2/rust/GENERATE-DOCS.md
@@ -1,41 +1,71 @@
 # Generating API Reference Docs
 
-The Rust SDK uses `cargo doc` to generate API documentation from `///` doc comments in the source code.
+There are two API references for the Rust SDK:
 
-## Viewing Docs Locally
+1. **`cargo doc` (HTML) — canonical.** Generated directly from the `///` doc
+   comments in `src/`. Always in sync with the source.
+2. **`docs/api.md` (markdown) — hand-maintained stopgap.** A committed snapshot
+   of the public API, kept until the crate is published to crates.io / docs.rs.
+   It is **not** auto-generated — update it by hand when the public API changes.
 
-To generate and open the API docs in your browser:
+## Generate & view the HTML locally
 
 ```bash
 cd sdk_v2/rust
 cargo doc --no-deps --open
 ```
 
-This generates HTML documentation at `target/doc/foundry_local_sdk/index.html`.
+This builds HTML at `target/doc/foundry_local_sdk/index.html` and opens it. To
+include internal/private items while working on the SDK:
 
-## Public API Surface
+```bash
+cargo doc --no-deps --document-private-items --open
+```
 
-The SDK re-exports all public types from the crate root. Key modules:
+## Check for broken docs (CI)
 
-| Module / Type | Description |
+Doc comments can rot — a renamed type breaks an intra-doc `[link]`, or an example
+stops compiling. Treat doc warnings as errors to catch this:
+
+```bash
+# Broken intra-doc links, missing-doc warnings, etc.
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+
+# Compile-check the ```rust examples in doc comments
+cargo test --doc
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:RUSTDOCFLAGS = "-D warnings"; cargo doc --no-deps
+```
+
+## Maintaining `docs/api.md`
+
+`docs/api.md` is updated manually. When you add, remove, or change the signature
+of a public item, update the corresponding row/section in `api.md` in the same
+change. rustdoc has no first-party markdown output, so there is no command that
+regenerates this file — treat the `///` doc comments as the source of truth and
+mirror the public surface into `api.md`.
+
+Once the crate is published, [docs.rs](https://docs.rs/foundry-local-sdk) will
+host the `cargo doc` output for every release (the build script skips native
+acquisition under `DOCS_RS`; see `build.rs`), and `api.md` can be retired in
+favour of that link.
+
+## Public API surface
+
+The SDK re-exports its public types from the crate root. Key entry points:
+
+| Type | Description |
 |---|---|
 | `FoundryLocalManager` | Entry point — SDK initialisation, web service lifecycle |
-| `FoundryLocalConfig` | Configuration (app name, log level, service endpoint) |
-| `Catalog` | Model discovery and lookup |
-| `Model` | Grouped model (alias → best variant) |
-| `DownloadBuilder` | Builder for model downloads (progress, cancellation) |
-| `ChatClient` | OpenAI-compatible chat completions (sync + streaming) |
-| `AudioClient` | OpenAI-compatible audio transcription (sync + streaming) |
-| `CreateChatCompletionResponse` | Typed chat completion response (from `async-openai`) |
-| `CreateChatCompletionStreamResponse` | Typed streaming chat chunk (from `async-openai`) |
-| `AudioTranscriptionResponse` | Typed audio transcription response |
-| `FoundryLocalError` | Error enum with variants for all failure modes |
+| `FoundryLocalConfig` | Configuration (app name, log level, catalog, service endpoint) |
+| `Catalog` | Model discovery, lookup, and version queries |
+| `Model` | Grouped model (alias → best variant) — download, load, unload |
+| `Session` / `ChatSession` / `EmbeddingsSession` / `AudioSession` | Inference sessions |
+| `ChatClient` / `AudioClient` | OpenAI-compatible clients (sync + streaming) |
+| `FoundryLocalError` / `NativeErrorCode` | Error enum and stable native error codes |
 
-## Notes
 
-- Unlike the C# and JS SDKs which commit generated markdown docs, Rust's convention is to generate HTML docs on demand with `cargo doc`.
-- Once the crate is published to crates.io, docs will be automatically hosted at [docs.rs](https://docs.rs).
-- Use `--document-private-items` to include internal/private API in the generated docs:
-  ```bash
-  cargo doc --no-deps --document-private-items --open
-  ```

--- a/sdk_v2/rust/build.rs
+++ b/sdk_v2/rust/build.rs
@@ -315,6 +315,15 @@ fn main() {
     println!("cargo:rerun-if-env-changed=FOUNDRY_LOCAL_NATIVE_BIN_DIR");
     println!("cargo:rerun-if-env-changed=FOUNDRY_LOCAL_RUNTIME_VERSION");
 
+    // docs.rs builds run in an offline sandbox and only need the crate to
+    // type-check — `cargo doc` never links or runs the native library. Skip all
+    // native acquisition there so documentation always builds regardless of the
+    // native-dependency env vars. (This crate's default path is already a no-op,
+    // but the guard makes docs builds robust and self-documenting.)
+    if env::var_os("DOCS_RS").is_some() {
+        return;
+    }
+
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap_or_default());
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
 

--- a/sdk_v2/rust/docs/api.md
+++ b/sdk_v2/rust/docs/api.md
@@ -1,6 +1,7 @@
 # Foundry Local Rust SDK — Public API Reference
 
-> Auto-generated from `sdk_v2/rust/src` source files.
+> Reference for the public API in `sdk_v2/rust/src`. Maintained by hand until the
+> crate is published; see [GENERATE-DOCS.md](../GENERATE-DOCS.md).
 
 ## Table of Contents
 
@@ -49,6 +50,7 @@
   - [Parameter](#parameter)
 - [Error Handling](#error-handling)
   - [FoundryLocalError](#foundrylocalerror)
+  - [NativeErrorCode](#nativeerrorcode)
 - [Re-exported OpenAI Types](#re-exported-openai-types)
 
 ---
@@ -91,6 +93,9 @@ pub struct FoundryLocalConfig { /* private fields */ }
 | `log_level` | `fn log_level(self, level: LogLevel) -> Self` | Set the log level. |
 | `web_service_urls` | `fn web_service_urls(self, urls: impl Into<String>) -> Self` | Set the web-service listen URLs. |
 | `service_endpoint` | `fn service_endpoint(self, endpoint: impl Into<String>) -> Self` | Set an external service endpoint URL. |
+| `catalog_url` | `fn catalog_url(self, url: impl Into<String>) -> Self` | Add a catalog source URL (no filter override). May be called multiple times. |
+| `catalog_url_with_filter` | `fn catalog_url_with_filter(self, url: impl Into<String>, filter_override: impl Into<String>) -> Self` | Add a catalog source URL with a filter override. |
+| `catalog_region` | `fn catalog_region(self, region: impl Into<String>) -> Self` | Set the Azure region used by the catalog service. |
 | `library_path` | `fn library_path(self, path: impl Into<String>) -> Self` | Override the path to the native core library. |
 | `additional_setting` | `fn additional_setting(self, key: impl Into<String>, value: impl Into<String>) -> Self` | Add a key-value pair to additional settings. |
 | `logger` | `fn logger(self, logger: impl Logger + 'static) -> Self` | Provide an application logger (stub — not yet wired into native core). |
@@ -150,6 +155,7 @@ pub struct Catalog { /* private fields */ }
 | `get_model_variant` | `async fn get_model_variant(&self, id: &str) -> Result<Arc<Model>, FoundryLocalError>` | Look up a variant by unique id. |
 | `get_cached_models` | `async fn get_cached_models(&self) -> Result<Vec<Arc<Model>>, FoundryLocalError>` | Return only variants cached on disk. |
 | `get_loaded_models` | `async fn get_loaded_models(&self) -> Result<Vec<Arc<Model>>, FoundryLocalError>` | Return model variants currently loaded in memory. |
+| `get_model_versions` | `async fn get_model_versions(&self, model_alias: &str, model_name: Option<&str>, max_versions: u32) -> Result<Vec<Arc<Model>>, FoundryLocalError>` | Return all versions for an alias, optionally filtered to a single model name. `max_versions` caps the results per model name; `0` returns all. |
 
 ---
 
@@ -422,7 +428,7 @@ impl Deref for ChatSession { type Target = Session; }
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `new` | `async fn new(model: &Model) -> Result<ChatSession, FoundryLocalError>` | Open a chat session on a loaded model. |
+| `new` | `async fn new(model: &Model) -> Result<ChatSession, FoundryLocalError>` | Open a chat session on a loaded model. Returns `Validation` if the model's task is not `chat-completion` or `vision-language-chat`. |
 | `add_tool_definition` | `async fn add_tool_definition(&self, definition: ToolDefinition) -> Result<(), FoundryLocalError>` | Register a tool for the lifetime of the session. |
 | `remove_tool_definition` | `async fn remove_tool_definition(&self, name: impl Into<String>) -> Result<bool, FoundryLocalError>` | Remove a tool by name; returns whether one was removed. |
 | `turn_count` | `fn turn_count(&self) -> usize` | The number of completed conversation turns. |
@@ -441,7 +447,7 @@ impl Deref for EmbeddingsSession { type Target = Session; }
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `new` | `async fn new(model: &Model) -> Result<EmbeddingsSession, FoundryLocalError>` | Open an embeddings session on a loaded model. |
+| `new` | `async fn new(model: &Model) -> Result<EmbeddingsSession, FoundryLocalError>` | Open an embeddings session on a loaded model. Returns `Validation` if the model's task is not `embeddings`. |
 | `embed` | `async fn embed(&self, input: impl Into<String>) -> Result<Vec<f32>, FoundryLocalError>` | Embed a single text input. |
 | `embed_batch` | `async fn embed_batch(&self, inputs: Vec<String>) -> Result<Vec<Vec<f32>>, FoundryLocalError>` | Embed a batch of inputs, one vector per input (in order). |
 | `into_session` | `fn into_session(self) -> Session` | Consume this handle, yielding the base session. |
@@ -458,7 +464,7 @@ impl Deref for AudioSession { type Target = Session; }
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `new` | `async fn new(model: &Model) -> Result<AudioSession, FoundryLocalError>` | Open an audio session on a loaded model. |
+| `new` | `async fn new(model: &Model) -> Result<AudioSession, FoundryLocalError>` | Open an audio session on a loaded model. Returns `Validation` if the model's task is not `automatic-speech-recognition`. |
 | `transcribe` | `async fn transcribe(&self, audio: Item) -> Result<String, FoundryLocalError>` | Transcribe a single audio item, returning the recognized text. |
 | `into_session` | `fn into_session(self) -> Session` | Consume this handle, yielding the base session. |
 
@@ -477,7 +483,7 @@ pub struct ItemQueue { /* private fields */ }
 | Method | Signature | Description |
 |--------|-----------|-------------|
 | `push` | `fn push(&self, item: &Item) -> Result<(), FoundryLocalError>` | Push an item, transferring a native copy into the queue. |
-| `try_pop` | `fn try_pop(&self) -> Option<Item>` | Pop the next item, or `None` if currently empty. |
+| `try_pop` | `fn try_pop(&self) -> Result<Option<Item>, FoundryLocalError>` | Pop the next item (`Ok(None)` if currently empty), or `Err` if converting the native item fails. |
 | `len` | `fn len(&self) -> usize` | Number of items currently buffered. |
 | `is_empty` | `fn is_empty(&self) -> bool` | Whether the queue currently holds no items. |
 | `mark_finished` | `fn mark_finished(&self)` | Signal that no more items will be pushed. |
@@ -497,6 +503,10 @@ impl Stream for ItemStream {
     type Item = Result<Item, FoundryLocalError>;
 }
 ```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `response` | `async fn response(&mut self) -> Result<Response, FoundryLocalError>` | Await the terminal [`Response`](#response) (finish reason, usage, final items). May be called after draining the item stream or instead of draining it; the terminal response can be taken only once. |
 
 ### Item
 
@@ -812,6 +822,9 @@ pub struct Parameter {
 
 ```rust
 pub enum FoundryLocalError {
+    /// The native core library returned an error. Carries a stable code.
+    Native { code: NativeErrorCode, message: String },
+
     /// The native core library could not be loaded.
     LibraryLoad { reason: String },
 
@@ -841,7 +854,31 @@ pub enum FoundryLocalError {
 }
 ```
 
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `native_code` | `fn native_code(&self) -> Option<NativeErrorCode>` | The stable native error code for a `Native` error, else `None`. |
+| `native_message` | `fn native_message(&self) -> Option<&str>` | The native error message for a `Native` error, else `None`. |
+
 Implements: `Display`, `Error`, `From<serde_json::Error>`, `From<std::io::Error>`, `From<reqwest::Error>`
+
+#### NativeErrorCode
+
+Stable error codes reported by the native Foundry Local library. Surfaced via
+[`FoundryLocalError::native_code`](#foundrylocalerror) so callers can branch on a
+failure without matching message strings.
+
+```rust
+pub enum NativeErrorCode {
+    Ok,
+    NotImplemented,
+    Internal,
+    InvalidArgument,
+    InvalidUsage,
+    OperationCancelled,
+    Network,
+    Unknown(i32),
+}
+```
 
 > **Note:** The `Result<T>` type alias (`std::result::Result<T, FoundryLocalError>`) is defined
 > in `error.rs` for internal SDK use but is **not** re-exported from the crate root.

--- a/sdk_v2/rust/docs/parity-review.md
+++ b/sdk_v2/rust/docs/parity-review.md
@@ -48,11 +48,17 @@ without matching error strings.
 This is a deliberate departure from the v1 Rust SDK, which had no native
 error-code concept and mapped native failures onto categorical variants
 (`CommandExecution`, `Validation`, `ModelOperation`, `Internal`) by inspecting
-message strings. The v2 variant is instead consistent with the other v2 bindings,
-which all surface a stable native error code (C# `FlErrorCode`, JavaScript
-`FlErrorCode`, Python's error code). The categorical variants remain in the enum
-for SDK-side (non-native) failures such as invalid configuration and input
-validation.
+message strings. The categorical variants remain in the v2 enum for SDK-side
+(non-native) failures such as invalid configuration and input validation.
+
+All v2 bindings surface the stable native code so callers can branch on it
+without string matching: Rust via `FoundryLocalError::Native { code, .. }`,
+JavaScript by tagging errors with a numeric `code` (and
+`name === "FoundryLocalError"`), Python via
+`FoundryLocalException(message, error_code=...)`, and C# via a nullable
+`FoundryLocalException.ErrorCode` (a public `FoundryLocalErrorCode` enum; `null`
+for SDK-side failures that have no native code). C# continues to translate the
+cancellation code to `OperationCanceledException` as is idiomatic on .NET.
 
 ## Conversion failures are propagated, not swallowed
 

--- a/sdk_v2/rust/docs/parity-review.md
+++ b/sdk_v2/rust/docs/parity-review.md
@@ -1,0 +1,72 @@
+# SDK V2 binding parity — design notes
+
+This document records the non-obvious design decisions behind the SDK V2 Rust
+binding and its alignment with the C#, JavaScript, and Python bindings. It is an
+architecture-decision record, not a changelog: it captures the *why* that is not
+evident from the code, so the reasoning survives after the originating pull
+request is out of view. For the list of what changed, see the PR history.
+
+## Typed-session task validation lives in every binding by design
+
+`ChatSession`, `EmbeddingsSession`, and `AudioSession` each validate the model's
+task at construction — C# throws `ArgumentException`, Python raises `ValueError`,
+JavaScript throws `TypeError`, and Rust returns `FoundryLocalError::Validation`.
+This looks redundant with native validation, but it is not, and it must not be
+"cleaned up" by deferring solely to native.
+
+There is a single native entry point, `Session_Create(model)`, which dispatches
+the concrete session type from the model's task. However, it first requires the
+model to already be loaded and throws `FOUNDRY_LOCAL_ERROR_INVALID_USAGE`
+("model must be loaded before creating a session") *before* it ever inspects the
+task. So natively:
+
+- A wrong-task model that has **not** been loaded fails with a generic
+  "not loaded" error, not a task-mismatch error.
+- The task-dispatch `FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT` only surfaces for a
+  *wholly unrecognized* task.
+
+The model's task, by contrast, is catalog metadata available **without** loading.
+Validating it in the binding surfaces a precise, task-specific error regardless
+of load state, and keeps that error identical whether or not the model happens to
+be loaded. Moving the check exclusively to native would require deferring the
+model-load requirement inside `Session_Create` — a larger change with its own
+complications — so the binding-level check is the intended design.
+
+Compatibility is additionally enforced at use time as a backstop: unsupported
+input items and type-specific operations (for example `UndoTurns` on a non-chat
+session) fail with `FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT` /
+`FOUNDRY_LOCAL_ERROR_INVALID_USAGE`.
+
+## Native error identity diverges deliberately from the v1 Rust SDK
+
+The v2 Rust binding exposes a `FoundryLocalError::Native { code, message }`
+variant carrying a `NativeErrorCode`, queryable via `native_code()` /
+`native_message()`, so callers can distinguish cancellation, network failures,
+invalid arguments, invalid usage, unsupported operations, and internal failures
+without matching error strings.
+
+This is a deliberate departure from the v1 Rust SDK, which had no native
+error-code concept and mapped native failures onto categorical variants
+(`CommandExecution`, `Validation`, `ModelOperation`, `Internal`) by inspecting
+message strings. The v2 variant is instead consistent with the other v2 bindings,
+which all surface a stable native error code (C# `FlErrorCode`, JavaScript
+`FlErrorCode`, Python's error code). The categorical variants remain in the enum
+for SDK-side (non-native) failures such as invalid configuration and input
+validation.
+
+## Conversion failures are propagated, not swallowed
+
+Native item conversion returns `Result<Item>` rather than using `None` for both
+an absent item and a conversion failure. An unknown item kind generally means the
+Rust binding is older than the native ABI; reporting a successful but truncated
+response would silently hide data loss, so conversion failures propagate through
+response getters, streaming callbacks, item queues, and usage retrieval instead.
+
+## The Rust FFI vtables are maintained by hand
+
+The Rust FFI vtables in `src/detail/ffi.rs` mirror the C ABI function-pointer
+tables in `foundry_local_c.h` and are maintained manually. Slot order must match
+the header exactly. Any newly appended native function must be added to the Rust
+vtable in the same change; a mismatch shifts every subsequent slot and corrupts
+dispatch. Consider generating or mechanically checking these tables to prevent
+future drift.

--- a/sdk_v2/rust/src/catalog.rs
+++ b/sdk_v2/rust/src/catalog.rs
@@ -145,6 +145,37 @@ impl Catalog {
         .await
     }
 
+    /// Return catalog versions for an alias, optionally narrowed to one model name.
+    ///
+    /// `max_versions` limits the results per model name; `0` returns all versions.
+    pub async fn get_model_versions(
+        &self,
+        model_alias: &str,
+        model_name: Option<&str>,
+        max_versions: u32,
+    ) -> Result<Vec<Arc<Model>>> {
+        if model_alias.trim().is_empty() {
+            return Err(FoundryLocalError::Validation {
+                reason: "Model alias must be a non-empty string".into(),
+            });
+        }
+        let max_versions =
+            i32::try_from(max_versions).map_err(|_| FoundryLocalError::Validation {
+                reason: "max_versions must not exceed i32::MAX".into(),
+            })?;
+        let native = self.native.clone();
+        let model_alias = model_alias.to_owned();
+        let model_name = model_name.map(str::to_owned);
+        spawn_blocking(move || {
+            native
+                .get_model_versions(&model_alias, model_name.as_deref(), max_versions)?
+                .into_iter()
+                .map(|m| Model::from_variant(&native.api, m).map(Arc::new))
+                .collect()
+        })
+        .await
+    }
+
     /// Resolve the latest catalog version for the provided model or variant.
     pub async fn get_latest_version(&self, model_or_model_variant: &Model) -> Result<Arc<Model>> {
         let native = self.native.clone();

--- a/sdk_v2/rust/src/configuration.rs
+++ b/sdk_v2/rust/src/configuration.rs
@@ -57,6 +57,8 @@ pub struct FoundryLocalConfig {
     model_cache_dir: Option<String>,
     logs_dir: Option<String>,
     log_level: Option<LogLevel>,
+    catalog_urls: Vec<(String, Option<String>)>,
+    catalog_region: Option<String>,
     web_service_urls: Option<String>,
     service_endpoint: Option<String>,
     library_path: Option<String>,
@@ -72,6 +74,8 @@ impl fmt::Debug for FoundryLocalConfig {
             .field("model_cache_dir", &self.model_cache_dir)
             .field("logs_dir", &self.logs_dir)
             .field("log_level", &self.log_level)
+            .field("catalog_urls", &self.catalog_urls)
+            .field("catalog_region", &self.catalog_region)
             .field("web_service_urls", &self.web_service_urls)
             .field("service_endpoint", &self.service_endpoint)
             .field("library_path", &self.library_path)
@@ -120,6 +124,37 @@ impl FoundryLocalConfig {
     /// Set the log level.
     pub fn log_level(mut self, level: LogLevel) -> Self {
         self.log_level = Some(level);
+        self
+    }
+
+    /// Add a catalog URL.
+    ///
+    /// Call this method multiple times to configure multiple catalogs. Catalogs
+    /// retain insertion order, which determines their priority. Use
+    /// [`catalog_url_with_filter`](Self::catalog_url_with_filter) to attach a
+    /// per-catalog filter override.
+    pub fn catalog_url(mut self, url: impl Into<String>) -> Self {
+        self.catalog_urls.push((url.into(), None));
+        self
+    }
+
+    /// Add a catalog URL with a per-catalog filter override.
+    ///
+    /// Behaves like [`catalog_url`](Self::catalog_url) but also records a filter
+    /// override that is applied to this catalog only.
+    pub fn catalog_url_with_filter(
+        mut self,
+        url: impl Into<String>,
+        filter_override: impl Into<String>,
+    ) -> Self {
+        self.catalog_urls
+            .push((url.into(), Some(filter_override.into())));
+        self
+    }
+
+    /// Set the Azure region used by the catalog service.
+    pub fn catalog_region(mut self, region: impl Into<String>) -> Self {
+        self.catalog_region = Some(region.into());
         self
     }
 
@@ -209,6 +244,18 @@ impl FoundryLocalConfig {
         if let Some(level) = self.log_level {
             api.check(unsafe { (c.SetDefaultLogLevel)(cfg.ptr, level.as_native()) })?;
         }
+        for (url, filter_override) in &self.catalog_urls {
+            let url = to_cstring(url)?;
+            let filter_override = filter_override.as_deref().map(to_cstring).transpose()?;
+            let filter_override_ptr = filter_override
+                .as_ref()
+                .map_or(std::ptr::null(), |filter| filter.as_ptr());
+            api.check(unsafe { (c.AddCatalogUrl)(cfg.ptr, url.as_ptr(), filter_override_ptr) })?;
+        }
+        if let Some(region) = &self.catalog_region {
+            let region = to_cstring(region)?;
+            api.check(unsafe { (c.SetCatalogRegion)(cfg.ptr, region.as_ptr()) })?;
+        }
         if let Some(urls) = &self.web_service_urls {
             for url in urls.split(',').map(str::trim).filter(|u| !u.is_empty()) {
                 let s = to_cstring(url)?;
@@ -258,5 +305,39 @@ impl Drop for NativeConfig {
             unsafe { (self.api.config_api().Configuration_Release)(self.ptr) };
             self.ptr = std::ptr::null_mut();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_builder_preserves_urls_filters_and_priority() {
+        let config = FoundryLocalConfig::new("test")
+            .catalog_url("https://first.example/catalog")
+            .catalog_url_with_filter("https://second.example/catalog", "device=cpu");
+
+        assert_eq!(
+            config.catalog_urls,
+            vec![
+                ("https://first.example/catalog".into(), None),
+                (
+                    "https://second.example/catalog".into(),
+                    Some("device=cpu".into())
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn catalog_region_is_optional_and_set_by_builder() {
+        assert_eq!(FoundryLocalConfig::new("test").catalog_region, None);
+        assert_eq!(
+            FoundryLocalConfig::new("test")
+                .catalog_region("australiaeast")
+                .catalog_region,
+            Some("australiaeast".into())
+        );
     }
 }

--- a/sdk_v2/rust/src/detail/api.rs
+++ b/sdk_v2/rust/src/detail/api.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use libloading::Library;
 
 use super::ffi::*;
-use crate::error::{FoundryLocalError, Result};
+use crate::error::{FoundryLocalError, NativeErrorCode, Result};
 
 // ── Library file names ───────────────────────────────────────────────────────
 
@@ -62,22 +62,18 @@ pub(crate) unsafe fn cstr_to_string(ptr: *const c_char) -> Option<String> {
 }
 
 fn map_error(code: flErrorCode, message: String) -> FoundryLocalError {
-    match code {
-        FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT | FOUNDRY_LOCAL_ERROR_INVALID_USAGE => {
-            FoundryLocalError::Validation { reason: message }
-        }
-        FOUNDRY_LOCAL_ERROR_INTERNAL | FOUNDRY_LOCAL_ERROR_NOT_IMPLEMENTED => {
-            FoundryLocalError::Internal { reason: message }
-        }
-        FOUNDRY_LOCAL_ERROR_OPERATION_CANCELLED => FoundryLocalError::CommandExecution {
-            reason: if message.is_empty() {
-                "Operation cancelled".into()
-            } else {
-                message
-            },
-        },
-        _ => FoundryLocalError::CommandExecution { reason: message },
-    }
+    let code = match code {
+        FOUNDRY_LOCAL_OK => NativeErrorCode::Ok,
+        FOUNDRY_LOCAL_ERROR_NOT_IMPLEMENTED => NativeErrorCode::NotImplemented,
+        FOUNDRY_LOCAL_ERROR_INTERNAL => NativeErrorCode::Internal,
+        FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT => NativeErrorCode::InvalidArgument,
+        FOUNDRY_LOCAL_ERROR_INVALID_USAGE => NativeErrorCode::InvalidUsage,
+        FOUNDRY_LOCAL_ERROR_OPERATION_CANCELLED => NativeErrorCode::OperationCancelled,
+        FOUNDRY_LOCAL_ERROR_NETWORK => NativeErrorCode::Network,
+        _ => NativeErrorCode::Unknown(code),
+    };
+
+    FoundryLocalError::Native { code, message }
 }
 
 // ── Api ──────────────────────────────────────────────────────────────────────
@@ -440,4 +436,52 @@ fn resolve_library_path(library_path: Option<&str>) -> Result<(PathBuf, Option<P
 
     // 5. Fall back to the bare library name (system loader search path).
     Ok((PathBuf::from(LIB_FILE), None))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_error_preserves_all_native_codes_and_messages() {
+        let cases = [
+            (FOUNDRY_LOCAL_OK, NativeErrorCode::Ok),
+            (
+                FOUNDRY_LOCAL_ERROR_NOT_IMPLEMENTED,
+                NativeErrorCode::NotImplemented,
+            ),
+            (FOUNDRY_LOCAL_ERROR_INTERNAL, NativeErrorCode::Internal),
+            (
+                FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+                NativeErrorCode::InvalidArgument,
+            ),
+            (
+                FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
+                NativeErrorCode::InvalidUsage,
+            ),
+            (
+                FOUNDRY_LOCAL_ERROR_OPERATION_CANCELLED,
+                NativeErrorCode::OperationCancelled,
+            ),
+            (FOUNDRY_LOCAL_ERROR_NETWORK, NativeErrorCode::Network),
+            (i32::MAX, NativeErrorCode::Unknown(i32::MAX)),
+        ];
+
+        for (raw_code, expected_code) in cases {
+            let error = map_error(raw_code, "native message".into());
+            assert_eq!(error.native_code(), Some(expected_code));
+            assert_eq!(error.native_message(), Some("native message"));
+        }
+    }
+
+    #[test]
+    fn map_error_preserves_empty_native_message() {
+        let error = map_error(FOUNDRY_LOCAL_ERROR_OPERATION_CANCELLED, String::new());
+
+        assert_eq!(
+            error.native_code(),
+            Some(NativeErrorCode::OperationCancelled)
+        );
+        assert_eq!(error.native_message(), Some(""));
+    }
 }

--- a/sdk_v2/rust/src/detail/ffi.rs
+++ b/sdk_v2/rust/src/detail/ffi.rs
@@ -678,6 +678,13 @@ pub struct flCatalogApiVtable {
         catalog: *const flCatalog,
         out_models: *mut *mut flModelList,
     ) -> flStatusPtr,
+    pub GetModelVersions: unsafe extern "system" fn(
+        catalog: *const flCatalog,
+        model_alias: *const c_char,
+        model_name: *const c_char,
+        max_versions: i32,
+        out_models: *mut *mut flModelList,
+    ) -> flStatusPtr,
 }
 
 /// Model API table (`flModelApi`).

--- a/sdk_v2/rust/src/detail/items.rs
+++ b/sdk_v2/rust/src/detail/items.rs
@@ -211,25 +211,23 @@ pub(crate) fn make_bytes_item(
 ///
 /// # Safety
 /// `item` must be null or a valid item pointer alive for the duration of this call.
-pub(crate) unsafe fn read_text_item(api: &Api, item: *const flItem) -> Option<String> {
+/// Returns `Ok(None)` for a null or non-TEXT item so callers can fall through to
+/// another item type, and `Err` when the native getter itself fails so a genuine
+/// read failure is propagated rather than silently dropped.
+pub(crate) unsafe fn read_text_item(api: &Api, item: *const flItem) -> Result<Option<String>> {
     if item.is_null() {
-        return None;
+        return Ok(None);
     }
     if (api.item_api().GetType)(item) != FOUNDRY_LOCAL_ITEM_TEXT {
-        return None;
+        return Ok(None);
     }
     let mut data = flTextData {
         version: FOUNDRY_LOCAL_API_VERSION,
         text: ptr::null::<c_char>(),
         r#type: FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT,
     };
-    if api
-        .check((api.item_api().GetText)(item, &mut data))
-        .is_err()
-    {
-        return None;
-    }
-    cstr_to_string(data.text)
+    api.check((api.item_api().GetText)(item, &mut data))?;
+    Ok(cstr_to_string(data.text))
 }
 
 /// Text + timing read from a SPEECH_SEGMENT item (output-only).
@@ -287,13 +285,19 @@ pub(crate) unsafe fn read_speech_segment(
 }
 
 /// Read the concatenated transcript of a SPEECH_RESULT item (output-only).
-/// Returns `None` for null/other items.
+///
+/// Returns `Ok(None)` for a null or non-SPEECH_RESULT item so callers can fall
+/// through to another item type, and `Err` when the native getter fails so a
+/// genuine read failure is propagated rather than silently dropped.
 ///
 /// # Safety
 /// `item` must be null or a valid item pointer alive for the duration of this call.
-pub(crate) unsafe fn read_speech_result_text(api: &Api, item: *const flItem) -> Option<String> {
+pub(crate) unsafe fn read_speech_result_text(
+    api: &Api,
+    item: *const flItem,
+) -> Result<Option<String>> {
     if item.is_null() || (api.item_api().GetType)(item) != FOUNDRY_LOCAL_ITEM_SPEECH_RESULT {
-        return None;
+        return Ok(None);
     }
     let mut data = flSpeechResultData {
         version: FOUNDRY_LOCAL_API_VERSION,
@@ -303,13 +307,8 @@ pub(crate) unsafe fn read_speech_result_text(api: &Api, item: *const flItem) -> 
         segments: ptr::null::<*const flItem>(),
         segments_count: 0,
     };
-    if api
-        .check((api.item_api().GetSpeechResult)(item, &mut data))
-        .is_err()
-    {
-        return None;
-    }
-    cstr_to_string(data.text)
+    api.check((api.item_api().GetSpeechResult)(item, &mut data))?;
+    Ok(cstr_to_string(data.text))
 }
 
 // ── Additional native item builders (image / tensor / message / tool) ─────────

--- a/sdk_v2/rust/src/detail/items.rs
+++ b/sdk_v2/rust/src/detail/items.rs
@@ -682,21 +682,21 @@ fn tensor_byte_len(data_type: TensorDataType, shape: &[i64]) -> Option<usize> {
 }
 
 /// Read a TEXT item into an owned [`Item::Text`] (preserving its [`TextKind`]).
-unsafe fn read_text_full(api: &Api, item: *const flItem) -> Option<Item> {
+unsafe fn read_text_full(api: &Api, item: *const flItem) -> Result<Item> {
     let mut data = flTextData {
         version: FOUNDRY_LOCAL_API_VERSION,
         text: ptr::null::<c_char>(),
         r#type: FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT,
     };
-    api.check((api.item_api().GetText)(item, &mut data)).ok()?;
-    Some(Item::Text {
+    api.check((api.item_api().GetText)(item, &mut data))?;
+    Ok(Item::Text {
         text: cstr_to_string(data.text).unwrap_or_default(),
         kind: TextKind::from_native(data.r#type),
     })
 }
 
 /// Read a BYTES item into an owned [`Item::Bytes`].
-unsafe fn read_bytes_full(api: &Api, item: *const flItem) -> Option<Item> {
+unsafe fn read_bytes_full(api: &Api, item: *const flItem) -> Result<Item> {
     let mut data = flBytesData {
         version: FOUNDRY_LOCAL_API_VERSION,
         item_type: FOUNDRY_LOCAL_ITEM_BYTES,
@@ -706,12 +706,12 @@ unsafe fn read_bytes_full(api: &Api, item: *const flItem) -> Option<Item> {
         deleter: None,
         deleter_user_data: ptr::null_mut(),
     };
-    api.check((api.item_api().GetBytes)(item, &mut data)).ok()?;
-    Some(Item::Bytes(copy_bytes(data.data, data.data_size)))
+    api.check((api.item_api().GetBytes)(item, &mut data))?;
+    Ok(Item::Bytes(copy_bytes(data.data, data.data_size)))
 }
 
 /// Read a TENSOR item into an owned [`Item::Tensor`].
-unsafe fn read_tensor_full(api: &Api, item: *const flItem) -> Option<Item> {
+unsafe fn read_tensor_full(api: &Api, item: *const flItem) -> Result<Item> {
     let mut data = flTensorData {
         version: FOUNDRY_LOCAL_API_VERSION,
         data_type: FOUNDRY_LOCAL_TENSOR_UNDEFINED,
@@ -722,8 +722,7 @@ unsafe fn read_tensor_full(api: &Api, item: *const flItem) -> Option<Item> {
         deleter: None,
         deleter_user_data: ptr::null_mut(),
     };
-    api.check((api.item_api().GetTensor)(item, &mut data))
-        .ok()?;
+    api.check((api.item_api().GetTensor)(item, &mut data))?;
     let shape: Vec<i64> = if data.shape.is_null() || data.rank == 0 {
         Vec::new()
     } else {
@@ -734,7 +733,7 @@ unsafe fn read_tensor_full(api: &Api, item: *const flItem) -> Option<Item> {
         Some(len) => copy_bytes(data.data, len),
         None => Vec::new(),
     };
-    Some(Item::Tensor(Tensor {
+    Ok(Item::Tensor(Tensor {
         data_type,
         shape,
         data: bytes,
@@ -742,7 +741,7 @@ unsafe fn read_tensor_full(api: &Api, item: *const flItem) -> Option<Item> {
 }
 
 /// Read an IMAGE item into an owned [`Item::Image`].
-unsafe fn read_image_full(api: &Api, item: *const flItem) -> Option<Item> {
+unsafe fn read_image_full(api: &Api, item: *const flItem) -> Result<Item> {
     let mut data = flImageData {
         version: FOUNDRY_LOCAL_API_VERSION,
         data: ptr::null(),
@@ -753,7 +752,7 @@ unsafe fn read_image_full(api: &Api, item: *const flItem) -> Option<Item> {
         deleter: None,
         deleter_user_data: ptr::null_mut(),
     };
-    api.check((api.item_api().GetImage)(item, &mut data)).ok()?;
+    api.check((api.item_api().GetImage)(item, &mut data))?;
     let source = if !data.data.is_null() && data.data_size > 0 {
         MediaSource::Data(copy_bytes(data.data, data.data_size))
     } else if let Some(uri) = cstr_to_string(data.uri) {
@@ -761,14 +760,14 @@ unsafe fn read_image_full(api: &Api, item: *const flItem) -> Option<Item> {
     } else {
         MediaSource::Data(Vec::new())
     };
-    Some(Item::Image(Image {
+    Ok(Item::Image(Image {
         source,
         format: cstr_to_string(data.format),
     }))
 }
 
 /// Read an AUDIO item into an owned [`Item::Audio`].
-unsafe fn read_audio_full(api: &Api, item: *const flItem) -> Option<Item> {
+unsafe fn read_audio_full(api: &Api, item: *const flItem) -> Result<Item> {
     let mut data = flAudioData {
         version: FOUNDRY_LOCAL_API_VERSION,
         data: ptr::null(),
@@ -781,7 +780,7 @@ unsafe fn read_audio_full(api: &Api, item: *const flItem) -> Option<Item> {
         deleter: None,
         deleter_user_data: ptr::null_mut(),
     };
-    api.check((api.item_api().GetAudio)(item, &mut data)).ok()?;
+    api.check((api.item_api().GetAudio)(item, &mut data))?;
     let source = if !data.data.is_null() && data.data_size > 0 {
         MediaSource::Data(copy_bytes(data.data, data.data_size))
     } else if let Some(uri) = cstr_to_string(data.uri) {
@@ -789,7 +788,7 @@ unsafe fn read_audio_full(api: &Api, item: *const flItem) -> Option<Item> {
     } else {
         MediaSource::Data(Vec::new())
     };
-    Some(Item::Audio(Audio {
+    Ok(Item::Audio(Audio {
         source,
         format: cstr_to_string(data.format),
         sample_rate: data.sample_rate,
@@ -798,7 +797,7 @@ unsafe fn read_audio_full(api: &Api, item: *const flItem) -> Option<Item> {
 }
 
 /// Read a MESSAGE item into an owned [`Item::Message`], recursively decoding parts.
-unsafe fn read_message_full(api: &Api, item: *const flItem) -> Option<Item> {
+unsafe fn read_message_full(api: &Api, item: *const flItem) -> Result<Item> {
     let mut data = flMessageData {
         version: FOUNDRY_LOCAL_API_VERSION,
         role: FOUNDRY_LOCAL_ROLE_NONE,
@@ -806,18 +805,15 @@ unsafe fn read_message_full(api: &Api, item: *const flItem) -> Option<Item> {
         content_items_count: 0,
         name: ptr::null(),
     };
-    api.check((api.item_api().GetMessage)(item, &mut data))
-        .ok()?;
+    api.check((api.item_api().GetMessage)(item, &mut data))?;
     let mut content = Vec::with_capacity(data.content_items_count);
     if !data.content_items.is_null() {
         for i in 0..data.content_items_count {
             let part = *data.content_items.add(i);
-            if let Some(child) = item_from_native(api, part) {
-                content.push(child);
-            }
+            content.push(item_from_native(api, part)?);
         }
     }
-    Some(Item::Message(Message {
+    Ok(Item::Message(Message {
         role: MessageRole::from_native(data.role),
         content,
         name: cstr_to_string(data.name),
@@ -825,16 +821,15 @@ unsafe fn read_message_full(api: &Api, item: *const flItem) -> Option<Item> {
 }
 
 /// Read a TOOL_CALL item into an owned [`Item::ToolCall`].
-unsafe fn read_tool_call_full(api: &Api, item: *const flItem) -> Option<Item> {
+unsafe fn read_tool_call_full(api: &Api, item: *const flItem) -> Result<Item> {
     let mut data = flToolCallData {
         version: FOUNDRY_LOCAL_API_VERSION,
         call_id: ptr::null(),
         name: ptr::null(),
         arguments: ptr::null(),
     };
-    api.check((api.item_api().GetToolCall)(item, &mut data))
-        .ok()?;
-    Some(Item::ToolCall(ToolCall {
+    api.check((api.item_api().GetToolCall)(item, &mut data))?;
+    Ok(Item::ToolCall(ToolCall {
         call_id: cstr_to_string(data.call_id).unwrap_or_default(),
         name: cstr_to_string(data.name).unwrap_or_default(),
         arguments: cstr_to_string(data.arguments).unwrap_or_default(),
@@ -842,22 +837,21 @@ unsafe fn read_tool_call_full(api: &Api, item: *const flItem) -> Option<Item> {
 }
 
 /// Read a TOOL_RESULT item into an owned [`Item::ToolResult`].
-unsafe fn read_tool_result_full(api: &Api, item: *const flItem) -> Option<Item> {
+unsafe fn read_tool_result_full(api: &Api, item: *const flItem) -> Result<Item> {
     let mut data = flToolResultData {
         version: FOUNDRY_LOCAL_API_VERSION,
         call_id: ptr::null(),
         result: ptr::null(),
     };
-    api.check((api.item_api().GetToolResult)(item, &mut data))
-        .ok()?;
-    Some(Item::ToolResult(ToolResult {
+    api.check((api.item_api().GetToolResult)(item, &mut data))?;
+    Ok(Item::ToolResult(ToolResult {
         call_id: cstr_to_string(data.call_id).unwrap_or_default(),
         result: cstr_to_string(data.result).unwrap_or_default(),
     }))
 }
 
 /// Read a SPEECH_SEGMENT item into an owned [`SpeechSegment`] value.
-unsafe fn read_speech_segment_value(api: &Api, item: *const flItem) -> Option<SpeechSegment> {
+unsafe fn read_speech_segment_value(api: &Api, item: *const flItem) -> Result<SpeechSegment> {
     let mut data = flSpeechSegmentData {
         version: FOUNDRY_LOCAL_API_VERSION,
         kind: FOUNDRY_LOCAL_SPEECH_SEGMENT_NONE,
@@ -869,8 +863,7 @@ unsafe fn read_speech_segment_value(api: &Api, item: *const flItem) -> Option<Sp
         words_count: 0,
         language: ptr::null::<c_char>(),
     };
-    api.check((api.item_api().GetSpeechSegment)(item, &mut data))
-        .ok()?;
+    api.check((api.item_api().GetSpeechSegment)(item, &mut data))?;
     let mut words = Vec::with_capacity(data.words_count);
     if !data.words.is_null() {
         for i in 0..data.words_count {
@@ -889,7 +882,7 @@ unsafe fn read_speech_segment_value(api: &Api, item: *const flItem) -> Option<Sp
             });
         }
     }
-    Some(SpeechSegment {
+    Ok(SpeechSegment {
         kind: SpeechSegmentKind::from_native(data.kind),
         text: cstr_to_string(data.text).unwrap_or_default(),
         start_time_ms: opt_ms(data.start_time_ms),
@@ -901,7 +894,7 @@ unsafe fn read_speech_segment_value(api: &Api, item: *const flItem) -> Option<Sp
 }
 
 /// Read a SPEECH_RESULT item into an owned [`Item::SpeechResult`].
-unsafe fn read_speech_result_full(api: &Api, item: *const flItem) -> Option<Item> {
+unsafe fn read_speech_result_full(api: &Api, item: *const flItem) -> Result<Item> {
     let mut data = flSpeechResultData {
         version: FOUNDRY_LOCAL_API_VERSION,
         text: ptr::null::<c_char>(),
@@ -910,18 +903,15 @@ unsafe fn read_speech_result_full(api: &Api, item: *const flItem) -> Option<Item
         segments: ptr::null::<*const flItem>(),
         segments_count: 0,
     };
-    api.check((api.item_api().GetSpeechResult)(item, &mut data))
-        .ok()?;
+    api.check((api.item_api().GetSpeechResult)(item, &mut data))?;
     let mut segments = Vec::with_capacity(data.segments_count);
     if !data.segments.is_null() {
         for i in 0..data.segments_count {
             let seg = *data.segments.add(i);
-            if let Some(child) = item_from_native(api, seg) {
-                segments.push(child);
-            }
+            segments.push(item_from_native(api, seg)?);
         }
     }
-    Some(Item::SpeechResult(SpeechResult {
+    Ok(Item::SpeechResult(SpeechResult {
         text: cstr_to_string(data.text).unwrap_or_default(),
         language: cstr_to_string(data.language),
         duration_ms: opt_ms(data.duration_ms),
@@ -931,15 +921,19 @@ unsafe fn read_speech_result_full(api: &Api, item: *const flItem) -> Option<Item
 
 /// Decode a native `flItem` into an owned public [`Item`].
 ///
-/// Returns `None` for a null item or an item whose type is not representable.
+/// Returns an error for a null item, an unsupported item type, or a native
+/// getter failure so callers never silently lose response data.
 ///
 /// # Safety
 /// `item` must be null or a valid item pointer alive for the duration of this call.
-pub(crate) unsafe fn item_from_native(api: &Api, item: *const flItem) -> Option<Item> {
+pub(crate) unsafe fn item_from_native(api: &Api, item: *const flItem) -> Result<Item> {
     if item.is_null() {
-        return None;
+        return Err(FoundryLocalError::Internal {
+            reason: "native response contained a null item".into(),
+        });
     }
-    match (api.item_api().GetType)(item) {
+    let item_type = (api.item_api().GetType)(item);
+    match item_type {
         FOUNDRY_LOCAL_ITEM_TEXT => read_text_full(api, item),
         FOUNDRY_LOCAL_ITEM_BYTES => read_bytes_full(api, item),
         FOUNDRY_LOCAL_ITEM_TENSOR => read_tensor_full(api, item),
@@ -952,6 +946,8 @@ pub(crate) unsafe fn item_from_native(api: &Api, item: *const flItem) -> Option<
             read_speech_segment_value(api, item).map(Item::SpeechSegment)
         }
         FOUNDRY_LOCAL_ITEM_SPEECH_RESULT => read_speech_result_full(api, item),
-        _ => None,
+        _ => Err(FoundryLocalError::Internal {
+            reason: format!("native response contained unsupported item type {item_type}"),
+        }),
     }
 }

--- a/sdk_v2/rust/src/detail/items.rs
+++ b/sdk_v2/rust/src/detail/items.rs
@@ -247,16 +247,20 @@ fn duration_ms_to_seconds(ms: i64) -> Option<f64> {
     }
 }
 
-/// Read a SPEECH_SEGMENT item (output-only). Returns `None` for null/other items.
+/// Read a SPEECH_SEGMENT item (output-only).
+///
+/// Returns `Ok(None)` for a null or non-SPEECH_SEGMENT item so callers can fall
+/// through to another item type, and `Err` when the native getter fails so a
+/// genuine read failure is propagated rather than silently dropped.
 ///
 /// # Safety
 /// `item` must be null or a valid item pointer alive for the duration of this call.
 pub(crate) unsafe fn read_speech_segment(
     api: &Api,
     item: *const flItem,
-) -> Option<SpeechSegmentText> {
+) -> Result<Option<SpeechSegmentText>> {
     if item.is_null() || (api.item_api().GetType)(item) != FOUNDRY_LOCAL_ITEM_SPEECH_SEGMENT {
-        return None;
+        return Ok(None);
     }
     let mut data = flSpeechSegmentData {
         version: FOUNDRY_LOCAL_API_VERSION,
@@ -269,19 +273,14 @@ pub(crate) unsafe fn read_speech_segment(
         words_count: 0,
         language: ptr::null::<c_char>(),
     };
-    if api
-        .check((api.item_api().GetSpeechSegment)(item, &mut data))
-        .is_err()
-    {
-        return None;
-    }
-    Some(SpeechSegmentText {
+    api.check((api.item_api().GetSpeechSegment)(item, &mut data))?;
+    Ok(Some(SpeechSegmentText {
         text: cstr_to_string(data.text).unwrap_or_default(),
         // PARTIAL is an interim hypothesis; FINAL (and NONE entries) are stable.
         is_final: data.kind == FOUNDRY_LOCAL_SPEECH_SEGMENT_FINAL,
         start_time_s: duration_ms_to_seconds(data.start_time_ms),
         end_time_s: duration_ms_to_seconds(data.end_time_ms),
-    })
+    }))
 }
 
 /// Read the concatenated transcript of a SPEECH_RESULT item (output-only).

--- a/sdk_v2/rust/src/detail/native.rs
+++ b/sdk_v2/rust/src/detail/native.rs
@@ -231,6 +231,31 @@ impl NativeCatalog {
         self.list(self.api.catalog_api().GetLoadedModels)
     }
 
+    pub(crate) fn get_model_versions(
+        &self,
+        model_alias: &str,
+        model_name: Option<&str>,
+        max_versions: i32,
+    ) -> Result<Vec<NativeModel>> {
+        let model_alias = super::api::to_cstring(model_alias)?;
+        let model_name = model_name.map(super::api::to_cstring).transpose()?;
+        let model_name_ptr = model_name
+            .as_ref()
+            .map_or(std::ptr::null(), |name| name.as_ptr());
+        let mut list: *mut flModelList = std::ptr::null_mut();
+        let status = unsafe {
+            (self.api.catalog_api().GetModelVersions)(
+                self.ptr,
+                model_alias.as_ptr(),
+                model_name_ptr,
+                max_versions,
+                &mut list,
+            )
+        };
+        self.api.check(status)?;
+        Ok(collect_models(&self.api, &self.manager, list))
+    }
+
     fn lookup(
         &self,
         f: unsafe extern "system" fn(

--- a/sdk_v2/rust/src/detail/session.rs
+++ b/sdk_v2/rust/src/detail/session.rs
@@ -6,7 +6,10 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
 use std::sync::Arc;
 
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::{
+    mpsc::{UnboundedReceiver, UnboundedSender},
+    oneshot,
+};
 
 use super::api::{Api, Kvps};
 use super::ffi::*;
@@ -132,26 +135,22 @@ impl NativeResponse {
     }
 
     /// Read the response item at `idx` into an owned [`Item`].
-    pub(crate) fn item(&self, idx: usize) -> Option<Item> {
+    pub(crate) fn item(&self, idx: usize) -> Result<Item> {
         let mut item: *const flItem = ptr::null();
         let status =
             unsafe { (self.api.inference_api().Response_GetItem)(self.ptr, idx, &mut item) };
-        if self.api.check(status).is_err() {
-            return None;
-        }
+        self.api.check(status)?;
         unsafe { item_from_native(&self.api, item) }
     }
 
     /// Collect all response items into owned [`Item`]s.
-    pub(crate) fn items(&self) -> Vec<Item> {
+    pub(crate) fn items(&self) -> Result<Vec<Item>> {
         let count = self.item_count();
         let mut out = Vec::with_capacity(count);
         for i in 0..count {
-            if let Some(item) = self.item(i) {
-                out.push(item);
-            }
+            out.push(self.item(i)?);
         }
-        out
+        Ok(out)
     }
 
     /// The native finish-reason discriminant for the response.
@@ -159,8 +158,8 @@ impl NativeResponse {
         unsafe { (self.api.inference_api().Response_GetFinishReason)(self.ptr) }
     }
 
-    /// Token usage as `(prompt, completion, total)`; zeros if unavailable.
-    pub(crate) fn usage(&self) -> (i64, i64, i64) {
+    /// Token usage as `(prompt, completion, total)`.
+    pub(crate) fn usage(&self) -> Result<(i64, i64, i64)> {
         let mut usage = flUsage {
             version: FOUNDRY_LOCAL_API_VERSION,
             prompt_tokens: 0,
@@ -168,14 +167,12 @@ impl NativeResponse {
             total_tokens: 0,
         };
         let status = unsafe { (self.api.inference_api().Response_GetUsage)(self.ptr, &mut usage) };
-        if self.api.check(status).is_err() {
-            return (0, 0, 0);
-        }
-        (
+        self.api.check(status)?;
+        Ok((
             usage.prompt_tokens,
             usage.completion_tokens,
             usage.total_tokens,
-        )
+        ))
     }
 }
 
@@ -247,15 +244,15 @@ impl NativeItemQueue {
     ///
     /// Returns `None` when the queue is currently empty. Ownership of the popped
     /// native item transfers to us, so it is released after decoding.
-    pub(crate) fn try_pop_value(&self) -> Option<Item> {
+    pub(crate) fn try_pop_value(&self) -> Result<Option<Item>> {
         let mut item: *mut flItem = ptr::null_mut();
         let popped = unsafe { (self.api.item_api().ItemQueue_TryPop)(self.ptr, &mut item) };
         if !popped || item.is_null() {
-            return None;
+            return Ok(None);
         }
         let decoded = unsafe { item_from_native(&self.api, item) };
         unsafe { (self.api.item_api().Item_Release)(item) };
-        decoded
+        decoded.map(Some)
     }
 
     /// The number of items currently buffered in the queue.
@@ -554,6 +551,18 @@ struct ItemStreamCtx {
     tx: UnboundedSender<Result<Item>>,
 }
 
+fn duplicate_stream_error(error: &FoundryLocalError) -> FoundryLocalError {
+    match error {
+        FoundryLocalError::Native { code, message } => FoundryLocalError::Native {
+            code: *code,
+            message: message.clone(),
+        },
+        _ => FoundryLocalError::Internal {
+            reason: error.to_string(),
+        },
+    }
+}
+
 unsafe extern "C" fn item_stream_trampoline(
     data: flStreamingCallbackData,
     user_data: *mut std::ffi::c_void,
@@ -580,9 +589,15 @@ unsafe extern "C" fn item_stream_trampoline(
             // Ownership of `item` transferred to us — decode then release.
             let decoded = item_from_native(&ctx.api, item);
             (item_api.Item_Release)(item);
-            if let Some(decoded) = decoded {
-                if ctx.tx.send(Ok(decoded)).is_err() {
-                    return 1; // receiver dropped — cancel generation
+            match decoded {
+                Ok(decoded) => {
+                    if ctx.tx.send(Ok(decoded)).is_err() {
+                        return 1; // receiver dropped — cancel generation
+                    }
+                }
+                Err(error) => {
+                    let _ = ctx.tx.send(Err(error));
+                    return 1;
                 }
             }
         }
@@ -602,8 +617,12 @@ pub(crate) fn run_item_streaming(
     items: Vec<Item>,
     input_queue: Option<Arc<NativeItemQueue>>,
     option_pairs: Vec<(String, String)>,
-) -> UnboundedReceiver<Result<Item>> {
+) -> (
+    UnboundedReceiver<Result<Item>>,
+    oneshot::Receiver<Result<crate::response::Response>>,
+) {
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<Item>>();
+    let (response_tx, response_rx) = oneshot::channel();
 
     tokio::task::spawn_blocking(move || {
         let ctx = Box::new(ItemStreamCtx {
@@ -618,11 +637,12 @@ pub(crate) fn run_item_streaming(
         let guard = session.lock_ops();
 
         if let Err(e) = session.set_streaming_callback(Some(item_stream_trampoline), ctx_ptr) {
-            let _ = tx.send(Err(e));
+            let _ = tx.send(Err(duplicate_stream_error(&e)));
+            let _ = response_tx.send(Err(e));
             return;
         }
 
-        let run = (|| -> Result<()> {
+        let run = (|| -> Result<crate::response::Response> {
             let request = NativeRequest::new(Arc::clone(&session.api))?;
             for item in &items {
                 request.add_item_value(item)?;
@@ -637,12 +657,13 @@ pub(crate) fn run_item_streaming(
                 )?;
                 request.set_options(kvps.as_ptr())?;
             }
-            let _response = session.process_request(&request)?;
-            Ok(())
+            let response = session.process_request(&request)?;
+            crate::response::Response::from_native(&response)
         })();
-        if let Err(e) = run {
-            let _ = tx.send(Err(e));
+        if let Err(e) = &run {
+            let _ = tx.send(Err(duplicate_stream_error(e)));
         }
+        let _ = response_tx.send(run);
 
         // Uninstall the callback, then release the op-lock before dropping ctx.
         let _ = session.set_streaming_callback(None, ptr::null_mut());
@@ -651,5 +672,5 @@ pub(crate) fn run_item_streaming(
         drop(session);
     });
 
-    rx
+    (rx, response_rx)
 }

--- a/sdk_v2/rust/src/detail/session.rs
+++ b/sdk_v2/rust/src/detail/session.rs
@@ -112,25 +112,27 @@ impl NativeResponse {
         unsafe { (self.api.inference_api().Response_GetItemCount)(self.ptr) }
     }
 
-    /// Read the text payload of the response item at `idx` (if it is a TEXT item).
-    pub(crate) fn item_text(&self, idx: usize) -> Option<String> {
+    /// Read the text payload of the response item at `idx`.
+    ///
+    /// Returns `Ok(None)` if the item is not a TEXT item, and `Err` if fetching
+    /// the item or reading its text fails, so conversion failures propagate.
+    pub(crate) fn item_text(&self, idx: usize) -> Result<Option<String>> {
         let mut item: *const flItem = ptr::null();
         let status =
             unsafe { (self.api.inference_api().Response_GetItem)(self.ptr, idx, &mut item) };
-        if self.api.check(status).is_err() {
-            return None;
-        }
+        self.api.check(status)?;
         unsafe { read_text_item(&self.api, item) }
     }
 
-    /// Read the transcript of the response item at `idx` (if it is a SPEECH_RESULT item).
-    pub(crate) fn item_speech_result_text(&self, idx: usize) -> Option<String> {
+    /// Read the transcript of the response item at `idx`.
+    ///
+    /// Returns `Ok(None)` if the item is not a SPEECH_RESULT item, and `Err` if
+    /// fetching the item or reading it fails, so conversion failures propagate.
+    pub(crate) fn item_speech_result_text(&self, idx: usize) -> Result<Option<String>> {
         let mut item: *const flItem = ptr::null();
         let status =
             unsafe { (self.api.inference_api().Response_GetItem)(self.ptr, idx, &mut item) };
-        if self.api.check(status).is_err() {
-            return None;
-        }
+        self.api.check(status)?;
         unsafe { read_speech_result_text(&self.api, item) }
     }
 
@@ -429,7 +431,7 @@ impl NativeSession {
             });
         }
         response
-            .item_text(0)
+            .item_text(0)?
             .ok_or_else(|| FoundryLocalError::CommandExecution {
                 reason: "Native response item was not readable text".into(),
             })
@@ -479,6 +481,15 @@ unsafe extern "C" fn stream_trampoline(
             // Ownership of `item` transferred to us — read then release.
             let text = read_text_item(&ctx.api, item);
             (item_api.Item_Release)(item);
+
+            let text = match text {
+                Ok(text) => text,
+                Err(error) => {
+                    let _ = ctx.tx.send(Err(error));
+                    return 1; // read failure — stop generation and surface the error
+                }
+            };
+
             if let Some(text) = text {
                 if let Some(transformed) = (ctx.transform)(text) {
                     if ctx.tx.send(Ok(transformed)).is_err() {
@@ -551,13 +562,48 @@ struct ItemStreamCtx {
     tx: UnboundedSender<Result<Item>>,
 }
 
+/// Clone a streaming error so the same failure can be delivered on both the item
+/// channel and the terminal-response channel.
+///
+/// `FoundryLocalError` is not `Clone` because a few variants wrap non-`Clone`
+/// external errors (`reqwest`, `serde_json`, `std::io`). Every string-backed
+/// variant is duplicated as its own variant so error identity is preserved —
+/// collapsing them into `Internal` would, for example, rewrite a `Validation`
+/// from `add_item_value` into `Internal` with a doubly-prefixed message. Only the
+/// non-clonable external-error variants (which do not arise on the streaming
+/// request path) degrade to `Internal` carrying the original message.
 fn duplicate_stream_error(error: &FoundryLocalError) -> FoundryLocalError {
     match error {
         FoundryLocalError::Native { code, message } => FoundryLocalError::Native {
             code: *code,
             message: message.clone(),
         },
-        _ => FoundryLocalError::Internal {
+        FoundryLocalError::LibraryLoad { reason } => FoundryLocalError::LibraryLoad {
+            reason: reason.clone(),
+        },
+        FoundryLocalError::CommandExecution { reason } => FoundryLocalError::CommandExecution {
+            reason: reason.clone(),
+        },
+        FoundryLocalError::InvalidConfiguration { reason } => {
+            FoundryLocalError::InvalidConfiguration {
+                reason: reason.clone(),
+            }
+        }
+        FoundryLocalError::ModelOperation { reason } => FoundryLocalError::ModelOperation {
+            reason: reason.clone(),
+        },
+        FoundryLocalError::Validation { reason } => FoundryLocalError::Validation {
+            reason: reason.clone(),
+        },
+        FoundryLocalError::Internal { reason } => FoundryLocalError::Internal {
+            reason: reason.clone(),
+        },
+        // Non-clonable external-error variants. These do not occur on the streaming
+        // request path; degrade to Internal with the original message rather than
+        // losing it entirely.
+        FoundryLocalError::HttpRequest(_)
+        | FoundryLocalError::Serialization(_)
+        | FoundryLocalError::Io(_) => FoundryLocalError::Internal {
             reason: error.to_string(),
         },
     }

--- a/sdk_v2/rust/src/detail/session.rs
+++ b/sdk_v2/rust/src/detail/session.rs
@@ -709,13 +709,22 @@ pub(crate) fn run_item_streaming(
         if let Err(e) = &run {
             let _ = tx.send(Err(duplicate_stream_error(e)));
         }
-        let _ = response_tx.send(run);
 
-        // Uninstall the callback, then release the op-lock before dropping ctx.
+        // Release the worker's hold on the native session BEFORE publishing the
+        // terminal response. A caller may await `response()` without draining the
+        // item stream, then drop its `Session` and unload the model as soon as the
+        // response resolves. If the worker still held a session reference at that
+        // point, `ModelLoadManager::UnloadModel` would reject the unload with
+        // "session(s) still using it". Uninstall the callback, release the op-lock,
+        // and drop the worker's ctx/channel/session references first so the caller
+        // observes a fully-released session once the response is published.
         let _ = session.set_streaming_callback(None, ptr::null_mut());
         drop(guard);
         drop(ctx);
+        drop(tx);
         drop(session);
+
+        let _ = response_tx.send(run);
     });
 
     (rx, response_rx)

--- a/sdk_v2/rust/src/error.rs
+++ b/sdk_v2/rust/src/error.rs
@@ -1,8 +1,28 @@
 use thiserror::Error;
 
+/// Stable error codes reported by the native Foundry Local library.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum NativeErrorCode {
+    Ok,
+    NotImplemented,
+    Internal,
+    InvalidArgument,
+    InvalidUsage,
+    OperationCancelled,
+    Network,
+    Unknown(i32),
+}
+
 /// Errors that can occur when using the Foundry Local SDK.
 #[derive(Debug, Error)]
 pub enum FoundryLocalError {
+    /// The native core library returned an error.
+    #[error("native error ({code:?}): {message}")]
+    Native {
+        code: NativeErrorCode,
+        message: String,
+    },
     /// The native core library could not be loaded.
     #[error("library load error: {reason}")]
     LibraryLoad { reason: String },
@@ -32,5 +52,49 @@ pub enum FoundryLocalError {
     Internal { reason: String },
 }
 
+impl FoundryLocalError {
+    /// Returns the native error code, if this error originated in the native library.
+    pub fn native_code(&self) -> Option<NativeErrorCode> {
+        match self {
+            Self::Native { code, .. } => Some(*code),
+            _ => None,
+        }
+    }
+
+    /// Returns the native error message, if this error originated in the native library.
+    pub fn native_message(&self) -> Option<&str> {
+        match self {
+            Self::Native { message, .. } => Some(message),
+            _ => None,
+        }
+    }
+}
+
 /// Convenience alias used throughout the SDK.
 pub type Result<T> = std::result::Result<T, FoundryLocalError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{FoundryLocalError, NativeErrorCode};
+
+    #[test]
+    fn native_error_exposes_code_and_message() {
+        let error = FoundryLocalError::Native {
+            code: NativeErrorCode::Network,
+            message: "connection failed".into(),
+        };
+
+        assert_eq!(error.native_code(), Some(NativeErrorCode::Network));
+        assert_eq!(error.native_message(), Some("connection failed"));
+    }
+
+    #[test]
+    fn non_native_error_has_no_native_details() {
+        let error = FoundryLocalError::Validation {
+            reason: "invalid".into(),
+        };
+
+        assert_eq!(error.native_code(), None);
+        assert_eq!(error.native_message(), None);
+    }
+}

--- a/sdk_v2/rust/src/item_queue.rs
+++ b/sdk_v2/rust/src/item_queue.rs
@@ -43,7 +43,7 @@ impl ItemQueue {
     }
 
     /// Pop the next available item, or `None` if the queue is currently empty.
-    pub fn try_pop(&self) -> Option<Item> {
+    pub fn try_pop(&self) -> Result<Option<Item>> {
         self.inner.try_pop_value()
     }
 

--- a/sdk_v2/rust/src/lib.rs
+++ b/sdk_v2/rust/src/lib.rs
@@ -19,7 +19,7 @@ pub mod openai;
 pub use self::catalog::Catalog;
 pub use self::configuration::{FoundryLocalConfig, LogLevel, Logger};
 pub use self::detail::model::{DownloadBuilder, Model};
-pub use self::error::FoundryLocalError;
+pub use self::error::{FoundryLocalError, NativeErrorCode};
 pub use self::foundry_local_manager::{EpDownloadBuilder, FoundryLocalManager};
 pub use self::item::{
     Audio, Image, Item, ItemType, MediaSource, Message, MessageRole, SpeechResult, SpeechSegment,

--- a/sdk_v2/rust/src/openai/live_audio_session.rs
+++ b/sdk_v2/rust/src/openai/live_audio_session.rs
@@ -427,14 +427,23 @@ unsafe extern "C" fn live_trampoline(
             }
             // The native audio path now streams SPEECH_SEGMENT items; older cores
             // (and the OpenAI-JSON path) stream plain TEXT items. Handle both.
-            let response = if let Some(text) = read_text_item(&ctx.api, item) {
-                (!text.is_empty()).then(|| LiveAudioTranscriptionResponse::from_text(text, false))
-            } else {
-                read_speech_segment(&ctx.api, item)
+            let text = read_text_item(&ctx.api, item);
+
+            let response = match text {
+                Ok(Some(text)) => (!text.is_empty())
+                    .then(|| LiveAudioTranscriptionResponse::from_text(text, false)),
+                Ok(None) => read_speech_segment(&ctx.api, item)
                     .filter(|seg| !seg.text.is_empty())
-                    .map(LiveAudioTranscriptionResponse::from_segment)
+                    .map(LiveAudioTranscriptionResponse::from_segment),
+                Err(error) => {
+                    (item_api.Item_Release)(item);
+                    let _ = ctx.tx.send(Err(error));
+                    return 1; // read failure — stop streaming and surface the error
+                }
             };
+
             (item_api.Item_Release)(item);
+
             if let Some(response) = response {
                 if ctx.tx.send(Ok(response)).is_err() {
                     return 1; // receiver dropped — cancel
@@ -498,10 +507,12 @@ fn run_worker(
         // (and older cores) return TEXT items.
         let mut final_text = String::new();
         for i in 0..response.item_count() {
-            if let Some(text) = response
-                .item_text(i)
-                .or_else(|| response.item_speech_result_text(i))
-            {
+            let text = match response.item_text(i)? {
+                Some(text) => Some(text),
+                None => response.item_speech_result_text(i)?,
+            };
+
+            if let Some(text) = text {
                 final_text.push_str(&text);
             }
         }

--- a/sdk_v2/rust/src/openai/live_audio_session.rs
+++ b/sdk_v2/rust/src/openai/live_audio_session.rs
@@ -426,23 +426,29 @@ unsafe extern "C" fn live_trampoline(
                 continue;
             }
             // The native audio path now streams SPEECH_SEGMENT items; older cores
-            // (and the OpenAI-JSON path) stream plain TEXT items. Handle both.
-            let text = read_text_item(&ctx.api, item);
+            // (and the OpenAI-JSON path) stream plain TEXT items. Handle both, and
+            // propagate a genuine read failure from either getter rather than
+            // silently dropping the item.
+            let response = (|| -> Result<Option<LiveAudioTranscriptionResponse>> {
+                if let Some(text) = read_text_item(&ctx.api, item)? {
+                    return Ok((!text.is_empty())
+                        .then(|| LiveAudioTranscriptionResponse::from_text(text, false)));
+                }
 
-            let response = match text {
-                Ok(Some(text)) => (!text.is_empty())
-                    .then(|| LiveAudioTranscriptionResponse::from_text(text, false)),
-                Ok(None) => read_speech_segment(&ctx.api, item)
+                Ok(read_speech_segment(&ctx.api, item)?
                     .filter(|seg| !seg.text.is_empty())
-                    .map(LiveAudioTranscriptionResponse::from_segment),
+                    .map(LiveAudioTranscriptionResponse::from_segment))
+            })();
+
+            (item_api.Item_Release)(item);
+
+            let response = match response {
+                Ok(response) => response,
                 Err(error) => {
-                    (item_api.Item_Release)(item);
                     let _ = ctx.tx.send(Err(error));
                     return 1; // read failure — stop streaming and surface the error
                 }
             };
-
-            (item_api.Item_Release)(item);
 
             if let Some(response) = response {
                 if ctx.tx.send(Ok(response)).is_err() {

--- a/sdk_v2/rust/src/response.rs
+++ b/sdk_v2/rust/src/response.rs
@@ -4,6 +4,7 @@
 
 use crate::detail::ffi::*;
 use crate::detail::session::NativeResponse;
+use crate::error::Result;
 use crate::item::Item;
 
 /// Why generation stopped for a [`Response`].
@@ -75,15 +76,15 @@ pub struct Response {
 
 impl Response {
     /// Snapshot a native response into an owned [`Response`].
-    pub(crate) fn from_native(native: &NativeResponse) -> Response {
-        let items = native.items();
+    pub(crate) fn from_native(native: &NativeResponse) -> Result<Response> {
+        let items = native.items()?;
         let finish_reason = FinishReason::from_native(native.finish_reason());
-        let (prompt, completion, total) = native.usage();
-        Response {
+        let (prompt, completion, total) = native.usage()?;
+        Ok(Response {
             items,
             finish_reason,
             usage: Usage::from_native(prompt, completion, total),
-        }
+        })
     }
 
     /// The concatenated text of all textual output items.

--- a/sdk_v2/rust/src/session.rs
+++ b/sdk_v2/rust/src/session.rs
@@ -14,7 +14,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
 
 use crate::detail::api::{Api, Kvps};
 use crate::detail::model::Model;
@@ -81,7 +81,7 @@ impl Session {
             let _guard = inner.lock_ops();
             populate_native_request(&inner.api, &native_task, &request)?;
             let response = inner.process_request(&native_task)?;
-            Ok::<Response, FoundryLocalError>(Response::from_native(&response))
+            Response::from_native(&response)
         });
 
         // Cancel the in-flight request if this future is dropped before the
@@ -110,8 +110,12 @@ impl Session {
             .map(RequestOptions::to_pairs)
             .unwrap_or_default();
         let input_queue = input_queue.map(ItemQueue::into_native);
-        let rx = run_item_streaming(Arc::clone(&self.inner), items, input_queue, option_pairs);
-        ItemStream { rx }
+        let (rx, response_rx) =
+            run_item_streaming(Arc::clone(&self.inner), items, input_queue, option_pairs);
+        ItemStream {
+            rx,
+            response_rx: Some(response_rx),
+        }
     }
 
     /// Apply session-scoped options that persist across subsequent requests.
@@ -200,6 +204,13 @@ impl Drop for CancelGuard {
     }
 }
 
+/// The terminal-response oneshot was dropped before the worker sent a response.
+fn worker_ended_without_response() -> FoundryLocalError {
+    FoundryLocalError::Internal {
+        reason: "streaming response worker ended without a terminal response".into(),
+    }
+}
+
 /// An asynchronous stream of output [`Item`](crate::Item)s from
 /// [`Session::process_streaming_request`].
 ///
@@ -207,6 +218,58 @@ impl Drop for CancelGuard {
 /// combinators (e.g. `while let Some(item) = stream.next().await`).
 pub struct ItemStream {
     rx: UnboundedReceiver<Result<Item>>,
+    response_rx: Option<oneshot::Receiver<Result<Response>>>,
+}
+
+impl ItemStream {
+    /// Wait for and return the terminal response, including finish reason and
+    /// token usage.
+    ///
+    /// This may be called after draining the item stream or instead of draining
+    /// it. The terminal response can be taken only once.
+    pub async fn response(&mut self) -> Result<Response> {
+        if self.response_rx.is_none() {
+            return Err(FoundryLocalError::Validation {
+                reason: "the streaming response has already been taken".into(),
+            });
+        }
+
+        loop {
+            match self.rx.try_recv() {
+                Ok(Ok(_)) => continue,
+                Ok(Err(error)) => return Err(error),
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {}
+                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => break,
+            }
+
+            let response_rx = self.response_rx.as_mut().expect("checked above");
+            tokio::select! {
+                response = &mut *response_rx => {
+                    self.response_rx.take();
+                    while let Ok(item) = self.rx.try_recv() {
+                        item?;
+                    }
+                    return response.map_err(|_| worker_ended_without_response())?;
+                }
+                item = self.rx.recv() => {
+                    match item {
+                        Some(Ok(_)) => {}
+                        Some(Err(error)) => return Err(error),
+                        None => break,
+                    }
+                }
+            }
+        }
+
+        let response = self
+            .response_rx
+            .as_mut()
+            .expect("checked above")
+            .await
+            .map_err(|_| worker_ended_without_response())?;
+        self.response_rx.take();
+        response
+    }
 }
 
 impl Unpin for ItemStream {}
@@ -247,6 +310,43 @@ impl ToolDefinition {
     }
 }
 
+/// Reject a model whose task is not one of `allowed` before a typed session is
+/// created.
+///
+/// The native session constructor requires the model to already be loaded and
+/// only rejects a wrong-task model *after* that load requirement is satisfied.
+/// The model's task, however, is catalog metadata available without loading, so
+/// validating it here surfaces a precise, task-specific error regardless of load
+/// state and keeps the error identical whether or not the model happens to be
+/// loaded. This mirrors the C#, JavaScript, and Python bindings, which validate
+/// the task the same way for the same reason.
+fn validate_session_task(model: &Model, session: &str, allowed: &[&str]) -> Result<()> {
+    let info = model.info()?;
+
+    check_task(info.task.as_deref(), session, allowed)
+}
+
+/// Pure task-compatibility check shared by [`validate_session_task`]; split out
+/// so the accept/reject logic and error message can be unit-tested without a
+/// native model.
+fn check_task(task: Option<&str>, session: &str, allowed: &[&str]) -> Result<()> {
+    let task = task.unwrap_or("");
+
+    if !allowed.contains(&task) {
+        let expected = allowed
+            .iter()
+            .map(|t| format!("'{t}'"))
+            .collect::<Vec<_>>()
+            .join(" or ");
+
+        return Err(FoundryLocalError::Validation {
+            reason: format!("{session} requires a model with task {expected}, but got '{task}'."),
+        });
+    }
+
+    Ok(())
+}
+
 /// A chat-oriented [`Session`] with tool registration and turn management.
 ///
 /// Dereferences to [`Session`], so all base methods
@@ -260,7 +360,16 @@ pub struct ChatSession {
 
 impl ChatSession {
     /// Open a chat session on a loaded model.
+    ///
+    /// Returns [`FoundryLocalError::Validation`] if the model's task is not
+    /// `"chat-completion"` or `"vision-language-chat"`.
     pub async fn new(model: &Model) -> Result<ChatSession> {
+        validate_session_task(
+            model,
+            "ChatSession",
+            &["chat-completion", "vision-language-chat"],
+        )?;
+
         Ok(ChatSession {
             session: Session::new(model).await?,
         })
@@ -321,7 +430,12 @@ pub struct EmbeddingsSession {
 
 impl EmbeddingsSession {
     /// Open an embeddings session on a loaded model.
+    ///
+    /// Returns [`FoundryLocalError::Validation`] if the model's task is not
+    /// `"embeddings"`.
     pub async fn new(model: &Model) -> Result<EmbeddingsSession> {
+        validate_session_task(model, "EmbeddingsSession", &["embeddings"])?;
+
         Ok(EmbeddingsSession {
             session: Session::new(model).await?,
         })
@@ -399,7 +513,12 @@ pub struct AudioSession {
 
 impl AudioSession {
     /// Open an audio session on a loaded model.
+    ///
+    /// Returns [`FoundryLocalError::Validation`] if the model's task is not
+    /// `"automatic-speech-recognition"`.
     pub async fn new(model: &Model) -> Result<AudioSession> {
+        validate_session_task(model, "AudioSession", &["automatic-speech-recognition"])?;
+
         Ok(AudioSession {
             session: Session::new(model).await?,
         })
@@ -436,5 +555,126 @@ impl Deref for AudioSession {
 
     fn deref(&self) -> &Session {
         &self.session
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::sync::Arc;
+    use std::task::{Wake, Waker};
+
+    use super::*;
+
+    struct NoopWake;
+
+    impl Wake for NoopWake {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    #[tokio::test]
+    async fn item_stream_returns_terminal_response_once() {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (response_tx, response_rx) = oneshot::channel();
+        let expected = Response {
+            items: vec![Item::text("complete")],
+            finish_reason: crate::FinishReason::Stop,
+            usage: crate::Usage {
+                prompt_tokens: 3,
+                completion_tokens: 1,
+                total_tokens: 4,
+            },
+        };
+        tx.send(Ok(Item::text("chunk one"))).unwrap();
+        tx.send(Ok(Item::text("chunk two"))).unwrap();
+        drop(tx);
+        response_tx.send(Ok(expected.clone())).unwrap();
+
+        let mut stream = ItemStream {
+            rx,
+            response_rx: Some(response_rx),
+        };
+
+        assert_eq!(stream.response().await.unwrap(), expected);
+        assert!(stream.rx.is_empty());
+        assert!(matches!(
+            stream.response().await,
+            Err(FoundryLocalError::Validation { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancelling_response_await_keeps_terminal_response_available() {
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (response_tx, response_rx) = oneshot::channel();
+        let mut stream = ItemStream {
+            rx,
+            response_rx: Some(response_rx),
+        };
+
+        let mut response = Box::pin(stream.response());
+        let waker = Waker::from(Arc::new(NoopWake));
+        let mut context = Context::from_waker(&waker);
+        assert!(matches!(
+            response.as_mut().poll(&mut context),
+            Poll::Pending
+        ));
+        drop(response);
+
+        response_tx
+            .send(Ok(Response {
+                items: Vec::new(),
+                finish_reason: crate::FinishReason::Stop,
+                usage: crate::Usage::default(),
+            }))
+            .unwrap();
+        assert_eq!(
+            stream.response().await.unwrap().finish_reason,
+            crate::FinishReason::Stop
+        );
+    }
+
+    #[test]
+    fn check_task_accepts_allowed_tasks() {
+        assert!(check_task(
+            Some("chat-completion"),
+            "ChatSession",
+            &["chat-completion", "vision-language-chat"]
+        )
+        .is_ok());
+        assert!(check_task(
+            Some("vision-language-chat"),
+            "ChatSession",
+            &["chat-completion", "vision-language-chat"]
+        )
+        .is_ok());
+        assert!(check_task(Some("embeddings"), "EmbeddingsSession", &["embeddings"]).is_ok());
+    }
+
+    #[test]
+    fn check_task_rejects_wrong_task() {
+        let err = check_task(
+            Some("chat-completion"),
+            "EmbeddingsSession",
+            &["embeddings"],
+        )
+        .expect_err("wrong task should be rejected");
+
+        match err {
+            FoundryLocalError::Validation { reason } => {
+                assert!(reason.contains("EmbeddingsSession"), "reason: {reason}");
+                assert!(reason.contains("'embeddings'"), "reason: {reason}");
+                assert!(reason.contains("'chat-completion'"), "reason: {reason}");
+            }
+            other => panic!("expected Validation error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_task_treats_missing_task_as_mismatch() {
+        let err = check_task(None, "AudioSession", &["automatic-speech-recognition"])
+            .expect_err("missing task should be rejected");
+
+        assert!(matches!(err, FoundryLocalError::Validation { .. }));
     }
 }

--- a/sdk_v2/rust/tests/integration/catalog_test.rs
+++ b/sdk_v2/rust/tests/integration/catalog_test.rs
@@ -1,5 +1,6 @@
 use super::common;
 use foundry_local_sdk::FoundryLocalManager;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 fn manager() -> Arc<FoundryLocalManager> {
@@ -43,6 +44,110 @@ async fn should_get_model_by_alias() {
         .expect("get_model failed");
 
     assert_eq!(model.alias(), common::TEST_MODEL_ALIAS);
+}
+
+#[tokio::test]
+async fn should_get_latest_version_per_model_name() {
+    let manager = manager();
+    let all_versions = manager
+        .catalog()
+        .get_model_versions(common::TEST_MODEL_ALIAS, None, 0)
+        .await
+        .expect("uncapped get_model_versions failed");
+    let latest_versions = manager
+        .catalog()
+        .get_model_versions(common::TEST_MODEL_ALIAS, None, 1)
+        .await
+        .expect("capped get_model_versions failed");
+
+    assert!(
+        !all_versions.is_empty(),
+        "Expected at least one version for '{}'",
+        common::TEST_MODEL_ALIAS
+    );
+    assert!(
+        !latest_versions.is_empty(),
+        "Expected at least one latest version for '{}'",
+        common::TEST_MODEL_ALIAS
+    );
+
+    let mut latest_by_name = std::collections::HashMap::new();
+    for model in all_versions {
+        let info = model.info().expect("model info should be readable");
+        latest_by_name
+            .entry(info.name)
+            .and_modify(|version: &mut u64| *version = (*version).max(info.version))
+            .or_insert(info.version);
+    }
+
+    let mut model_names = HashSet::new();
+    for model in latest_versions {
+        assert_eq!(model.alias(), common::TEST_MODEL_ALIAS);
+        let info = model.info().expect("model info should be readable");
+        assert!(
+            model_names.insert(info.name.clone()),
+            "max_versions=1 returned multiple versions for '{}'",
+            info.name
+        );
+        assert_eq!(
+            Some(&info.version),
+            latest_by_name.get(&info.name),
+            "max_versions=1 did not return the latest version for '{}'",
+            info.name
+        );
+    }
+}
+
+#[tokio::test]
+async fn should_filter_versions_by_model_name() {
+    let manager = manager();
+    let all_versions = manager
+        .catalog()
+        .get_model_versions(common::TEST_MODEL_ALIAS, None, 0)
+        .await
+        .expect("unfiltered get_model_versions failed");
+    assert!(
+        !all_versions.is_empty(),
+        "Expected at least one version for '{}'",
+        common::TEST_MODEL_ALIAS
+    );
+
+    // Pick a real model name from the unfiltered results and narrow to it.
+    let target_name = all_versions[0]
+        .info()
+        .expect("model info should be readable")
+        .name;
+
+    let filtered = manager
+        .catalog()
+        .get_model_versions(common::TEST_MODEL_ALIAS, Some(&target_name), 0)
+        .await
+        .expect("filtered get_model_versions failed");
+
+    assert!(
+        !filtered.is_empty(),
+        "Expected at least one version for model name '{target_name}'"
+    );
+    for model in &filtered {
+        assert_eq!(model.alias(), common::TEST_MODEL_ALIAS);
+        let info = model.info().expect("model info should be readable");
+        assert_eq!(
+            info.name, target_name,
+            "model_name filter returned an unexpected model name"
+        );
+    }
+}
+
+#[tokio::test]
+async fn should_throw_when_getting_model_versions_with_empty_alias() {
+    let manager = manager();
+    let result = manager.catalog().get_model_versions("", None, 0).await;
+    assert!(result.is_err(), "Expected error for empty alias");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Model alias must be a non-empty string"),
+        "Unexpected error message: {err_msg}"
+    );
 }
 
 #[tokio::test]

--- a/sdk_v2/rust/tests/integration/session_test.rs
+++ b/sdk_v2/rust/tests/integration/session_test.rs
@@ -4,8 +4,8 @@
 use std::sync::Arc;
 
 use foundry_local_sdk::{
-    ChatSession, EmbeddingsSession, Item, MessageRole, Model, Request, RequestOptions,
-    SearchOptions,
+    ChatSession, EmbeddingsSession, FinishReason, FoundryLocalError, Item, MessageRole, Model,
+    NativeErrorCode, Request, RequestOptions, SearchOptions,
 };
 use tokio_stream::StreamExt;
 
@@ -48,6 +48,28 @@ fn deterministic_options() -> RequestOptions {
             ..Default::default()
         },
         ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn should_reject_wrong_task_at_construction() {
+    let manager = common::get_test_manager();
+    let model = manager
+        .catalog()
+        .get_model(common::TEST_MODEL_ALIAS)
+        .await
+        .expect("get_model failed");
+
+    // The chat model's task is not "embeddings". The typed constructor must
+    // reject it up front — before any load — with a Validation error, rather
+    // than deferring to a native "model must be loaded" / task failure. This is
+    // the construction-time contract shared by every binding.
+    match EmbeddingsSession::new(&model).await {
+        Ok(_) => panic!("EmbeddingsSession from a chat model should fail"),
+        Err(err) => assert!(
+            matches!(err, FoundryLocalError::Validation { .. }),
+            "expected a Validation error, got: {err:?}"
+        ),
     }
 }
 
@@ -106,6 +128,54 @@ async fn should_stream_items() {
     assert!(
         collected.contains("42"),
         "Expected streamed text to contain '42', got: {collected}"
+    );
+
+    let response = stream
+        .response()
+        .await
+        .expect("terminal streaming response failed");
+    assert!(
+        matches!(
+            response.finish_reason,
+            FinishReason::Stop | FinishReason::Length
+        ),
+        "unexpected finish reason: {:?}",
+        response.finish_reason
+    );
+    assert!(
+        response.usage.total_tokens > 0,
+        "terminal response should report token usage"
+    );
+    assert_eq!(
+        response.usage.total_tokens,
+        response.usage.prompt_tokens + response.usage.completion_tokens
+    );
+
+    drop(session); // release the session so the model can unload
+    model.unload().await.expect("unload should succeed");
+}
+
+#[tokio::test]
+async fn should_expose_native_error_code_on_failure() {
+    let (session, model) = setup_chat_session().await;
+
+    // Undoing more turns than exist is rejected by the native inference layer
+    // with a stable INVALID_USAGE code. Verify the native error identity
+    // (code + message) survives the FFI boundary rather than being flattened
+    // into an opaque string.
+    let err = session
+        .undo_turns(5)
+        .await
+        .expect_err("undo_turns beyond the turn count should fail");
+
+    assert_eq!(
+        err.native_code(),
+        Some(NativeErrorCode::InvalidUsage),
+        "expected a native InvalidUsage error, got: {err:?}"
+    );
+    assert!(
+        err.native_message().is_some_and(|m| !m.is_empty()),
+        "native error should carry a non-empty message: {err:?}"
     );
 
     drop(session); // release the session so the model can unload

--- a/sdk_v2/rust/tests/public_api.rs
+++ b/sdk_v2/rust/tests/public_api.rs
@@ -1,0 +1,29 @@
+use foundry_local_sdk::{FoundryLocalConfig, FoundryLocalError, NativeErrorCode};
+
+#[test]
+fn catalog_configuration_builders_are_publicly_usable() {
+    let _config = FoundryLocalConfig::new("public-api-test")
+        .catalog_region("eastus")
+        .catalog_url_with_filter("https://example.test/catalog", "task=chat-completion")
+        .catalog_url("https://fallback.example.test/catalog");
+}
+
+#[test]
+fn native_errors_expose_stable_and_unknown_codes() {
+    let cancelled = FoundryLocalError::Native {
+        code: NativeErrorCode::OperationCancelled,
+        message: "cancelled".to_string(),
+    };
+    assert_eq!(
+        cancelled.native_code(),
+        Some(NativeErrorCode::OperationCancelled)
+    );
+    assert_eq!(cancelled.native_message(), Some("cancelled"));
+
+    let unknown = FoundryLocalError::Native {
+        code: NativeErrorCode::Unknown(42),
+        message: "future native error".to_string(),
+    };
+    assert_eq!(unknown.native_code(), Some(NativeErrorCode::Unknown(42)));
+    assert_eq!(unknown.native_message(), Some("future native error"));
+}


### PR DESCRIPTION
Bring the Rust SDK V2 binding to parity with C#, JavaScript, and Python, and close cross-binding consistency gaps so all five bindings behave the same way.

Rust parity fixes:
- Propagate native item/response conversion failures instead of silently discarding them (Result<Item> rather than None for absent vs. failed).
- Expose the terminal streaming Response via ItemStream::response().
- Make catalog region and multiple catalog sources configurable; split the catalog_url builder into catalog_url(url) and catalog_url_with_filter(url, filter).
- Preserve native error identity via FoundryLocalError::Native { code, message } and a NativeErrorCode enum (native_code()/native_message()).
- Deduplicate the ItemStream worker-ended error path into a helper.

Cross-binding consistency:
- Add a public GetModelVersions/get_model_versions catalog operation to C#, JavaScript, and Python (previously Rust/C++ only), with alias, optional model-name filter, and a per-name version limit.
- Add construction-time typed-session task validation to Rust (ChatSession/EmbeddingsSession/AudioSession) to match C#/JS/Python. The check lives in each binding by design: native Session_Create requires the model to be loaded and reports "not loaded" before it inspects the task, whereas the task is catalog metadata available without loading, so validating in the binding yields a precise task-mismatch error regardless of load state.

Docs/tests:
- Add sdk_v2/rust/docs/parity-review.md documenting the parity decisions.
- Add Rust unit tests (check_task), public_api tests, and integration tests for native error codes, streaming terminal response, model-version filtering, and wrong-task construction rejection; add matching catalog/session tests in the other bindings.