### PR TITLE
fetches test models from azure artifacts feed

### DIFF
--- a/.pipelines/templates/fetch-test-data-from-blob.yml
+++ b/.pipelines/templates/fetch-test-data-from-blob.yml
@@ -1,5 +1,5 @@
-# Download test model data from blob storage into a local directory.
-# Uses azcopy with AZCLI auth so the agent identity can read from storage.
+# Download test model data from Azure Artifacts into a local cache directory.
+# The template name and scriptType parameter are retained to avoid changing existing callers.
 
 parameters:
 - name: destinationPath
@@ -11,151 +11,62 @@ parameters:
   values: ['pscore', 'ps']
 
 steps:
-- task: AzureCLI@2
-  displayName: 'Fetch test data from blob'
+- task: UniversalPackages@0
+  displayName: 'Fetch Qwen 2.5 0.5B Instruct test model'
   inputs:
-    azureSubscription: 'ortcibuild_readonly_mi2-ONNX Runtime-AIFoundryLocal'
-    scriptType: ${{ parameters.scriptType }}
-    scriptLocation: inlineScript
-    inlineScript: |
-      $ErrorActionPreference = 'Stop'
+    command: download
+    feedsToUse: internal
+    vstsFeed: 'AIFoundryLocal/AIFoundryLocal_PublicPackages'
+    vstsFeedPackage: 'foundry-local-qwen-2-5-0-5b-instruct-generic-cpu'
+    vstsPackageVersion: '4.0.2'
+    downloadDirectory: '${{ parameters.destinationPath }}/Microsoft/qwen2.5-0.5b-instruct-generic-cpu-4'
 
-      $destination = '${{ parameters.destinationPath }}'
-      $storageAccount = 'foundrylocalmodels'
-      $container = 'models'
-      $prefix = 'foundrylocal/models'
+- task: UniversalPackages@0
+  displayName: 'Fetch OpenAI Whisper Tiny test model'
+  inputs:
+    command: download
+    feedsToUse: internal
+    vstsFeed: 'AIFoundryLocal/AIFoundryLocal_PublicPackages'
+    vstsFeedPackage: 'foundry-local-openai-whisper-tiny-generic-cpu'
+    vstsPackageVersion: '4.0.0'
+    downloadDirectory: '${{ parameters.destinationPath }}/Microsoft/openai-whisper-tiny-generic-cpu-4'
 
-      $azcopyCommand = Get-Command azcopy -ErrorAction SilentlyContinue
-      if (-not $azcopyCommand) {
-        if ($IsMacOS) {
-          Write-Host 'azcopy not found on macOS agent. Installing via Homebrew...'
-          if (-not (Get-Command brew -ErrorAction SilentlyContinue)) {
-            throw 'Homebrew is required to install azcopy on macOS agents, but brew was not found.'
-          }
+- task: UniversalPackages@0
+  displayName: 'Fetch Nemotron Speech Streaming test model'
+  inputs:
+    command: download
+    feedsToUse: internal
+    vstsFeed: 'AIFoundryLocal/AIFoundryLocal_PublicPackages'
+    vstsFeedPackage: 'foundry-local-nemotron-speech-streaming-en-0-6b-generic-cpu'
+    vstsPackageVersion: '3.0.0'
+    downloadDirectory: '${{ parameters.destinationPath }}/Microsoft/nemotron-speech-streaming-en-0.6b-generic-cpu-3'
 
-          brew update --quiet
-          brew install --quiet azcopy
-        } elseif ($env:AGENT_OS -eq 'Windows_NT' -and $env:AGENT_OSARCHITECTURE -eq 'ARM64') {
-          Write-Host 'azcopy not found on Windows agent. Installing from official zip...'
-          $zipPath = Join-Path $env:TEMP 'azcopy_windows.zip'
-          $extractRoot = Join-Path $env:TEMP 'azcopy'
-          Invoke-WebRequest -Uri 'https://aka.ms/downloadazcopy-v10-windows' -OutFile $zipPath -UseBasicParsing
-          if (Test-Path $extractRoot) {
-            Remove-Item -Path $extractRoot -Recurse -Force
-          }
-          Expand-Archive -Path $zipPath -DestinationPath $extractRoot -Force
-          $azcopyExe = Get-ChildItem -Path $extractRoot -Filter 'azcopy.exe' -Recurse | Select-Object -First 1
-          if (-not $azcopyExe) {
-            throw 'azcopy install completed but azcopy.exe was not found.'
-          }
-          $env:PATH = "$($azcopyExe.Directory.FullName);$env:PATH"
-        } else {
-          throw 'azcopy is not installed on this agent.'
-        }
+- task: UniversalPackages@0
+  displayName: 'Fetch Qwen3 Embedding test model'
+  inputs:
+    command: download
+    feedsToUse: internal
+    vstsFeed: 'AIFoundryLocal/AIFoundryLocal_PublicPackages'
+    vstsFeedPackage: 'foundry-local-qwen3-embedding-0-6b-generic-cpu'
+    vstsPackageVersion: '1.0.0'
+    downloadDirectory: '${{ parameters.destinationPath }}/Microsoft/qwen3-embedding-0.6b-generic-cpu-1'
 
-        $azcopyCommand = Get-Command azcopy -ErrorAction SilentlyContinue
-      }
+- task: UniversalPackages@0
+  displayName: 'Fetch Qwen3.5 0.8B test model'
+  inputs:
+    command: download
+    feedsToUse: internal
+    vstsFeed: 'AIFoundryLocal/AIFoundryLocal_PublicPackages'
+    vstsFeedPackage: 'foundry-local-qwen3-5-0-8b-generic-cpu'
+    vstsPackageVersion: '2.0.0'
+    downloadDirectory: '${{ parameters.destinationPath }}/Microsoft/qwen3.5-0.8b-generic-cpu-2'
 
-      if (-not $azcopyCommand) {
-        throw 'azcopy is not available on PATH after installation/probe.'
-      }
-
-      azcopy --version
-
-      New-Item -ItemType Directory -Path $destination -Force | Out-Null
-      $publisherRoot = Join-Path $destination 'Microsoft'
-      New-Item -ItemType Directory -Path $publisherRoot -Force | Out-Null
-
-      function Invoke-AzCopy {
-        param(
-          [string]$Source,
-          [string]$Target
-        )
-
-        $parent = Split-Path -Path $Target -Parent
-        if (-not [string]::IsNullOrEmpty($parent)) {
-          New-Item -ItemType Directory -Path $parent -Force | Out-Null
-        }
-
-        $args = @('copy', $Source, $Target, '--recursive')
-
-        & azcopy @args
-        if ($LASTEXITCODE -ne 0) {
-          throw "azcopy failed downloading test data from $Source"
-        }
-      }
-
-      function Generate-InferenceModelJson {
-        param(
-          [string]$ModelRoot,
-          [string]$TargetAlias
-        )
-
-        if ($TargetAlias -notmatch '-\d+$') {
-          throw "TargetAlias '$TargetAlias' does not end with a numeric version suffix."
-        }
-
-        # Convert '<name>-<version>' to '<name>:<version>' by replacing the last '-'.
-        $modelId = $TargetAlias -replace '-(?=[^-]+$)', ':'
-
-        $inferenceModelPath = Join-Path $ModelRoot 'inference_model.json'
-        @{ Name = $modelId } |
-          ConvertTo-Json -Depth 2 |
-          Set-Content -Path $inferenceModelPath -Encoding utf8
-
-        Write-Host "Generated inference_model.json: $inferenceModelPath (Name=$modelId)"
-      }
-
-      # The active SDK tests resolve versioned model aliases in cache.
-      # Keep explicit version per model, then derive target alias and v{N} path.
-      $modelMappings = @(
-        @{
-          SourcePath = 'qwen2.5-0.5b-instruct'
-          Version = 4
-        },
-        @{
-          SourcePath = 'openai-whisper-tiny'
-          Version = 4
-        },
-        @{
-          SourcePath = 'nemotron-speech-streaming-en-0.6b'
-          Version = 3
-        },
-        @{
-          SourcePath = 'qwen3-embedding-0.6b'
-          Version = 1
-        },
-        @{
-          SourcePath = 'qwen3.5-0.8b'
-          Version = 2
-        },
-        @{
-          SourcePath = 'deepseek-r1-distill-qwen-14b'
-          Version = 4
-        }
-      )
-
-      foreach ($model in $modelMappings) {
-        $targetAlias = "$($model.SourcePath)-generic-cpu-$($model.Version)"
-        $requestedUrl = "https://$storageAccount.blob.core.windows.net/$container/$prefix/$($model.SourcePath)/onnx/cpu_and_mobile/v$($model.Version)/*"
-        Write-Host "Requested blob URL: $requestedUrl"
-
-        $target = Join-Path (Join-Path $publisherRoot $targetAlias) ("v" + $model.Version)
-        Invoke-AzCopy -Source $requestedUrl -Target $target
-        Generate-InferenceModelJson -ModelRoot $target -TargetAlias $targetAlias
-      }
-
-      $count = @(Get-ChildItem -Path $destination -Recurse -File).Count
-
-      if ($count -eq 0) {
-        throw "Downloaded test data is empty at $destination"
-      }
-
-      Write-Host "Downloaded $count files into $destination"
-      Write-Host "Cache directory contents for $destination"
-      (Get-ChildItem -Path $destination -Recurse -Force |
-        Select-Object FullName, Length |
-        Format-Table -AutoSize |
-        Out-String).TrimEnd() | Write-Host
-  env:
-    AZCOPY_AUTO_LOGIN_TYPE: AZCLI
+- task: UniversalPackages@0
+  displayName: 'Fetch DeepSeek R1 Distill Qwen 14B test model'
+  inputs:
+    command: download
+    feedsToUse: internal
+    vstsFeed: 'AIFoundryLocal/AIFoundryLocal_PublicPackages'
+    vstsFeedPackage: 'foundry-local-deepseek-r1-distill-qwen-14b-generic-cpu'
+    vstsPackageVersion: '4.0.0'
+    downloadDirectory: '${{ parameters.destinationPath }}/Microsoft/deepseek-r1-distill-qwen-14b-generic-cpu-4'

--- a/sdk_v2/DEVELOPMENT.md
+++ b/sdk_v2/DEVELOPMENT.md
@@ -92,7 +92,7 @@ See `pwsh ./build_and_test_all.ps1 -?` for the full parameter list.
 Model-dependent sdk_v2 tests require `FOUNDRY_TEST_DATA_DIR` to point to a
 local model cache directory.
 
-In CI, sdk_v2 pipelines pre-populate this directory from blob storage.
+In CI, sdk_v2 pipelines pre-populate this directory from Azure Artifacts.
 For local runs, developers should populate a local cache first, then point
 `FOUNDRY_TEST_DATA_DIR` at it.
 
@@ -134,24 +134,96 @@ model set into `FOUNDRY_TEST_DATA_DIR` using:
 
 - `.pipelines/templates/fetch-test-data-from-blob.yml`
 
-That template downloads versioned model assets and writes `inference_model.json`
-entries expected by the local model scanner.
+The legacy template name is retained to avoid changing its existing callers. The
+template downloads pinned Universal Packages from the project-scoped
+`AIFoundryLocal/AIFoundryLocal_PublicPackages` feed. The pipeline and feed are in
+the same Azure DevOps organization, so downloads use the pipeline identity and
+do not require an Azure service connection.
+
+Each package contains one model's `v<model-version>` directory. The template
+downloads it into the cache layout expected by the local model scanner:
+
+```text
+test-data-shared/
+└── Microsoft/
+    └── <model-alias>-<model-version>/
+        └── v<model-version>/
+            ├── genai_config.json
+            ├── inference_model.json
+            └── <model files>
+```
 
 ### Updating the test models available in CI
 
-When tests need a different model/version set, update the model mapping list in:
+Models are published as separate Universal Packages so one model can be added or
+updated without republishing the entire test cache. Universal Package versions
+are immutable.
+
+To publish a model, first stage a complete cache alias directory. For example:
+
+```text
+C:\model-staging\qwen2.5-0.5b-instruct-generic-cpu-4\
+└── v4\
+    ├── genai_config.json
+    ├── inference_model.json
+    └── <model files>
+```
+
+The model leaf must contain `inference_model.json` with the versioned cache ID:
+
+```json
+{
+  "Name": "qwen2.5-0.5b-instruct-generic-cpu:4"
+}
+```
+
+Install the Azure DevOps CLI extension, authenticate with an identity that has
+Feed Publisher permission, and publish the alias directory:
+
+```powershell
+az extension add --name azure-devops
+az login
+
+$packageName = '<lowercase-package-name>'
+$packageVersion = '<major.minor.patch>'
+$modelDirectory = 'C:\model-staging\<cache-alias>-<model-version>'
+
+az artifacts universal publish `
+  --organization "https://dev.azure.com/aiinfra" `
+  --project "AIFoundryLocal" `
+  --scope project `
+  --feed "AIFoundryLocal_PublicPackages" `
+  --name $packageName `
+  --version $packageVersion `
+  --description "Foundry Local generic CPU test model cache" `
+  --path $modelDirectory
+```
+
+Publishing the alias directory makes `v4` the package root. Do not ZIP the
+directory; `UniversalPackages@0` downloads its files directly into the target
+cache alias directory.
+
+After publishing, add or update the corresponding `UniversalPackages@0` task in:
 
 - `.pipelines/templates/fetch-test-data-from-blob.yml`
 
 Checklist:
 
-1. Add or update the model entry (`SourcePath` + `Version`) in `modelMappings`.
-2. Ensure the selected version path exists in blob storage (`v<Version>`).
-3. Keep at least one model per test task used across SDKs (chat, embeddings,
+1. Use a stable lowercase package name for a model variant and pin an exact
+   semantic package version in the template; do not use `*`.
+2. Set `downloadDirectory` to
+   `${{ parameters.destinationPath }}/Microsoft/<cache-alias>-<model-version>`.
+3. For a new model version, stage the new `v<model-version>` directory, update
+   `inference_model.json`, publish a new package version, and update the cache
+   alias, package version, and download path in the template.
+4. To correct packaging without changing the model version, publish a new patch
+   package version (for example, `4.0.1`) and update only
+   `vstsPackageVersion`. The cache ID can remain at model version `4`.
+5. Keep at least one model per test task used across SDKs (chat, embeddings,
   audio/ASR) so integration suites remain runnable.
-4. Validate by running `pwsh ./build_and_test_all.ps1` with
+6. Validate by running `pwsh ./build_and_test_all.ps1` with
   `FOUNDRY_TEST_DATA_DIR` set to a cache containing the same model set.
-5. If local instructions change, update this file so contributors can mirror CI.
+7. Verify the package with a CI download before removing an older package entry.
 
 ## Troubleshooting
 


### PR DESCRIPTION
- allows 3P contributors to run our CIs from forked repos as download from azure artifacts feed within the same ADO org as our CI pipelines requires no authentication
- updated documentation to reflect new process
- existing models uploaded to AIFoundryLocal_PublicPackages:
[Qwen 2.5 0.5B Instruct, generic CPU, v4 (package 4.0.2)](https://dev.azure.com/aiinfra/AIFoundryLocal/_artifacts/feed/AIFoundryLocal_PublicPackages/UPack/foundry-local-qwen-2-5-0-5b-instruct-generic-cpu/overview/4.0.2)
[OpenAI Whisper Tiny, generic CPU, v4 (package 4.0.0)](https://dev.azure.com/aiinfra/AIFoundryLocal/_artifacts/feed/AIFoundryLocal_PublicPackages/UPack/foundry-local-openai-whisper-tiny-generic-cpu/overview/4.0.0)
[Nemotron Speech Streaming EN 0.6B, generic CPU, v3 (package 3.0.0)](https://dev.azure.com/aiinfra/AIFoundryLocal/_artifacts/feed/AIFoundryLocal_PublicPackages/UPack/foundry-local-nemotron-speech-streaming-en-0-6b-generic-cpu/overview/3.0.0)
[Qwen3 Embedding 0.6B, generic CPU, v1 (package 1.0.0)](https://dev.azure.com/aiinfra/AIFoundryLocal/_artifacts/feed/AIFoundryLocal_PublicPackages/UPack/foundry-local-qwen3-embedding-0-6b-generic-cpu/overview/1.0.0)
[Qwen3.5 0.8B, generic CPU, v2 (package 2.0.0)](https://dev.azure.com/aiinfra/AIFoundryLocal/_artifacts/feed/AIFoundryLocal_PublicPackages/UPack/foundry-local-qwen3-5-0-8b-generic-cpu/overview/2.0.0)
[DeepSeek R1 Distill Qwen 14B, generic CPU, v4 (package 4.0.0)](https://dev.azure.com/aiinfra/AIFoundryLocal/_artifacts/feed/AIFoundryLocal_PublicPackages/UPack/foundry-local-deepseek-r1-distill-qwen-14b-generic-cpu/overview/4.0.0)