### PR TITLE
fetches test models from azure artifacts feed

### DIFF
--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -267,3 +267,4 @@ extends:
         ortVersion: $(cppOrtVersion)
         genaiVersion: $(cppGenaiVersion)
         winmlVersion: $(cppWinmlVersion)
+        isRelease: ${{ parameters.isRelease }}

--- a/.pipelines/templates/fetch-models-from-artifacts-feed.yml
+++ b/.pipelines/templates/fetch-models-from-artifacts-feed.yml
@@ -1,5 +1,4 @@
-# Download test model data from Azure Artifacts into a local cache directory.
-# The template name and scriptType parameter are retained to avoid changing existing callers.
+# Download test models from Azure Artifacts into a local cache directory.
 
 parameters:
 - name: destinationPath

--- a/.pipelines/templates/fetch-test-data-from-blob.yml
+++ b/.pipelines/templates/fetch-test-data-from-blob.yml
@@ -1,5 +1,5 @@
-# Download test model data from blob storage into a local directory.
-# Uses azcopy with AZCLI auth so the agent identity can read from storage.
+# Download test model data from Azure Artifacts into a local cache directory.
+# The template name and scriptType parameter are retained to avoid changing existing callers.
 
 parameters:
 - name: destinationPath
@@ -11,151 +11,62 @@ parameters:
   values: ['pscore', 'ps']
 
 steps:
-- task: AzureCLI@2
-  displayName: 'Fetch test data from blob'
+- task: UniversalPackages@0
+  displayName: 'Fetch Qwen 2.5 0.5B Instruct test model'
   inputs:
-    azureSubscription: 'ortcibuild_readonly_mi2-ONNX Runtime-AIFoundryLocal'
-    scriptType: ${{ parameters.scriptType }}
-    scriptLocation: inlineScript
-    inlineScript: |
-      $ErrorActionPreference = 'Stop'
+    command: download
+    feedsToUse: internal
+    vstsFeed: 'AIFoundryLocal/AIFoundryLocal_PublicPackages'
+    vstsFeedPackage: 'foundry-local-qwen-2-5-0-5b-instruct-generic-cpu'
+    vstsPackageVersion: '4.0.2'
+    downloadDirectory: '${{ parameters.destinationPath }}/Microsoft/qwen2.5-0.5b-instruct-generic-cpu-4'
 
-      $destination = '${{ parameters.destinationPath }}'
-      $storageAccount = 'foundrylocalmodels'
-      $container = 'models'
-      $prefix = 'foundrylocal/models'
+- task: UniversalPackages@0
+  displayName: 'Fetch OpenAI Whisper Tiny test model'
+  inputs:
+    command: download
+    feedsToUse: internal
+    vstsFeed: 'AIFoundryLocal/AIFoundryLocal_PublicPackages'
+    vstsFeedPackage: 'foundry-local-openai-whisper-tiny-generic-cpu'
+    vstsPackageVersion: '4.0.0'
+    downloadDirectory: '${{ parameters.destinationPath }}/Microsoft/openai-whisper-tiny-generic-cpu-4'
 
-      $azcopyCommand = Get-Command azcopy -ErrorAction SilentlyContinue
-      if (-not $azcopyCommand) {
-        if ($IsMacOS) {
-          Write-Host 'azcopy not found on macOS agent. Installing via Homebrew...'
-          if (-not (Get-Command brew -ErrorAction SilentlyContinue)) {
-            throw 'Homebrew is required to install azcopy on macOS agents, but brew was not found.'
-          }
+- task: UniversalPackages@0
+  displayName: 'Fetch Nemotron Speech Streaming test model'
+  inputs:
+    command: download
+    feedsToUse: internal
+    vstsFeed: 'AIFoundryLocal/AIFoundryLocal_PublicPackages'
+    vstsFeedPackage: 'foundry-local-nemotron-speech-streaming-en-0-6b-generic-cpu'
+    vstsPackageVersion: '3.0.0'
+    downloadDirectory: '${{ parameters.destinationPath }}/Microsoft/nemotron-speech-streaming-en-0.6b-generic-cpu-3'
 
-          brew update --quiet
-          brew install --quiet azcopy
-        } elseif ($env:AGENT_OS -eq 'Windows_NT' -and $env:AGENT_OSARCHITECTURE -eq 'ARM64') {
-          Write-Host 'azcopy not found on Windows agent. Installing from official zip...'
-          $zipPath = Join-Path $env:TEMP 'azcopy_windows.zip'
-          $extractRoot = Join-Path $env:TEMP 'azcopy'
-          Invoke-WebRequest -Uri 'https://aka.ms/downloadazcopy-v10-windows' -OutFile $zipPath -UseBasicParsing
-          if (Test-Path $extractRoot) {
-            Remove-Item -Path $extractRoot -Recurse -Force
-          }
-          Expand-Archive -Path $zipPath -DestinationPath $extractRoot -Force
-          $azcopyExe = Get-ChildItem -Path $extractRoot -Filter 'azcopy.exe' -Recurse | Select-Object -First 1
-          if (-not $azcopyExe) {
-            throw 'azcopy install completed but azcopy.exe was not found.'
-          }
-          $env:PATH = "$($azcopyExe.Directory.FullName);$env:PATH"
-        } else {
-          throw 'azcopy is not installed on this agent.'
-        }
+- task: UniversalPackages@0
+  displayName: 'Fetch Qwen3 Embedding test model'
+  inputs:
+    command: download
+    feedsToUse: internal
+    vstsFeed: 'AIFoundryLocal/AIFoundryLocal_PublicPackages'
+    vstsFeedPackage: 'foundry-local-qwen3-embedding-0-6b-generic-cpu'
+    vstsPackageVersion: '1.0.0'
+    downloadDirectory: '${{ parameters.destinationPath }}/Microsoft/qwen3-embedding-0.6b-generic-cpu-1'
 
-        $azcopyCommand = Get-Command azcopy -ErrorAction SilentlyContinue
-      }
+- task: UniversalPackages@0
+  displayName: 'Fetch Qwen3.5 0.8B test model'
+  inputs:
+    command: download
+    feedsToUse: internal
+    vstsFeed: 'AIFoundryLocal/AIFoundryLocal_PublicPackages'
+    vstsFeedPackage: 'foundry-local-qwen3-5-0-8b-generic-cpu'
+    vstsPackageVersion: '2.0.0'
+    downloadDirectory: '${{ parameters.destinationPath }}/Microsoft/qwen3.5-0.8b-generic-cpu-2'
 
-      if (-not $azcopyCommand) {
-        throw 'azcopy is not available on PATH after installation/probe.'
-      }
-
-      azcopy --version
-
-      New-Item -ItemType Directory -Path $destination -Force | Out-Null
-      $publisherRoot = Join-Path $destination 'Microsoft'
-      New-Item -ItemType Directory -Path $publisherRoot -Force | Out-Null
-
-      function Invoke-AzCopy {
-        param(
-          [string]$Source,
-          [string]$Target
-        )
-
-        $parent = Split-Path -Path $Target -Parent
-        if (-not [string]::IsNullOrEmpty($parent)) {
-          New-Item -ItemType Directory -Path $parent -Force | Out-Null
-        }
-
-        $args = @('copy', $Source, $Target, '--recursive')
-
-        & azcopy @args
-        if ($LASTEXITCODE -ne 0) {
-          throw "azcopy failed downloading test data from $Source"
-        }
-      }
-
-      function Generate-InferenceModelJson {
-        param(
-          [string]$ModelRoot,
-          [string]$TargetAlias
-        )
-
-        if ($TargetAlias -notmatch '-\d+$') {
-          throw "TargetAlias '$TargetAlias' does not end with a numeric version suffix."
-        }
-
-        # Convert '<name>-<version>' to '<name>:<version>' by replacing the last '-'.
-        $modelId = $TargetAlias -replace '-(?=[^-]+$)', ':'
-
-        $inferenceModelPath = Join-Path $ModelRoot 'inference_model.json'
-        @{ Name = $modelId } |
-          ConvertTo-Json -Depth 2 |
-          Set-Content -Path $inferenceModelPath -Encoding utf8
-
-        Write-Host "Generated inference_model.json: $inferenceModelPath (Name=$modelId)"
-      }
-
-      # The active SDK tests resolve versioned model aliases in cache.
-      # Keep explicit version per model, then derive target alias and v{N} path.
-      $modelMappings = @(
-        @{
-          SourcePath = 'qwen2.5-0.5b-instruct'
-          Version = 4
-        },
-        @{
-          SourcePath = 'openai-whisper-tiny'
-          Version = 4
-        },
-        @{
-          SourcePath = 'nemotron-speech-streaming-en-0.6b'
-          Version = 3
-        },
-        @{
-          SourcePath = 'qwen3-embedding-0.6b'
-          Version = 1
-        },
-        @{
-          SourcePath = 'qwen3.5-0.8b'
-          Version = 2
-        },
-        @{
-          SourcePath = 'deepseek-r1-distill-qwen-14b'
-          Version = 4
-        }
-      )
-
-      foreach ($model in $modelMappings) {
-        $targetAlias = "$($model.SourcePath)-generic-cpu-$($model.Version)"
-        $requestedUrl = "https://$storageAccount.blob.core.windows.net/$container/$prefix/$($model.SourcePath)/onnx/cpu_and_mobile/v$($model.Version)/*"
-        Write-Host "Requested blob URL: $requestedUrl"
-
-        $target = Join-Path (Join-Path $publisherRoot $targetAlias) ("v" + $model.Version)
-        Invoke-AzCopy -Source $requestedUrl -Target $target
-        Generate-InferenceModelJson -ModelRoot $target -TargetAlias $targetAlias
-      }
-
-      $count = @(Get-ChildItem -Path $destination -Recurse -File).Count
-
-      if ($count -eq 0) {
-        throw "Downloaded test data is empty at $destination"
-      }
-
-      Write-Host "Downloaded $count files into $destination"
-      Write-Host "Cache directory contents for $destination"
-      (Get-ChildItem -Path $destination -Recurse -Force |
-        Select-Object FullName, Length |
-        Format-Table -AutoSize |
-        Out-String).TrimEnd() | Write-Host
-  env:
-    AZCOPY_AUTO_LOGIN_TYPE: AZCLI
+- task: UniversalPackages@0
+  displayName: 'Fetch DeepSeek R1 Distill Qwen 14B test model'
+  inputs:
+    command: download
+    feedsToUse: internal
+    vstsFeed: 'AIFoundryLocal/AIFoundryLocal_PublicPackages'
+    vstsFeedPackage: 'foundry-local-deepseek-r1-distill-qwen-14b-generic-cpu'
+    vstsPackageVersion: '4.0.0'
+    downloadDirectory: '${{ parameters.destinationPath }}/Microsoft/deepseek-r1-distill-qwen-14b-generic-cpu-4'

--- a/.pipelines/v2/templates/stages-build-native.yml
+++ b/.pipelines/v2/templates/stages-build-native.yml
@@ -18,6 +18,8 @@ parameters:
   type: string
 - name: winmlVersion
   type: string
+- name: isRelease
+  type: boolean
 
 stages:
 
@@ -192,6 +194,7 @@ stages:
           ortVersion: ${{ parameters.ortVersion }}
           genaiVersion: ${{ parameters.genaiVersion }}
           runTests: true
+          isRelease: ${{ parameters.isRelease }}
 
   # ====================================================================
   # Pack — C++ SDK tgz bundles (base platforms)

--- a/.pipelines/v2/templates/stages-cs.yml
+++ b/.pipelines/v2/templates/stages-cs.yml
@@ -67,7 +67,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
       parameters:
         scriptType: ps
     - template: steps-test-cs.yml
@@ -96,7 +96,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
       parameters:
         scriptType: ps
     - template: steps-test-cs.yml
@@ -127,7 +127,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-test-cs.yml
       parameters:
         flNugetDir: '$(Pipeline.Workspace)/cpp-nuget'
@@ -157,7 +157,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-test-cs.yml
       parameters:
         flNugetDir: '$(Pipeline.Workspace)/cpp-nuget'
@@ -188,7 +188,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-test-cs.yml
       parameters:
         flNugetDir: '$(Pipeline.Workspace)/cpp-nuget'

--- a/.pipelines/v2/templates/stages-js.yml
+++ b/.pipelines/v2/templates/stages-js.yml
@@ -208,7 +208,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-test-js.yml
       parameters:
         rid: 'win-x64'
@@ -233,7 +233,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
       parameters:
         scriptType: ps
     - template: steps-test-js.yml
@@ -259,7 +259,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-test-js.yml
       parameters:
         rid: 'linux-x64'
@@ -284,7 +284,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-test-js.yml
       parameters:
         rid: 'linux-arm64'
@@ -310,7 +310,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-test-js.yml
       parameters:
         rid: 'osx-arm64'

--- a/.pipelines/v2/templates/stages-js.yml
+++ b/.pipelines/v2/templates/stages-js.yml
@@ -13,6 +13,10 @@
 #
 # Tests run on the same platform as the build.
 
+parameters:
+- name: isRelease
+  type: boolean
+
 stages:
 
 # =====================================================================
@@ -30,7 +34,8 @@ stages:
       name: onnxruntime-Win-CPU-2022
       os: windows
     variables:
-    - group: FoundryLocal-ESRP-Signing
+    - ${{ if eq(parameters.isRelease, true) }}:
+      - group: FoundryLocal-ESRP-Signing
     templateContext:
       inputs:
       - input: pipelineArtifact
@@ -51,7 +56,7 @@ stages:
         rid: 'win-x64'
         nativeArtifactDir: '$(Pipeline.Workspace)/cpp-native-win-x64'
         outputDir: '$(Build.ArtifactStagingDirectory)/js-prebuild'
-        signWindows: true
+        signWindows: ${{ parameters.isRelease }}
 
 - stage: js_build_win_arm64
   displayName: 'JS SDK: Build Windows ARM64'
@@ -65,7 +70,8 @@ stages:
       os: windows
       hostArchitecture: arm64
     variables:
-    - group: FoundryLocal-ESRP-Signing
+    - ${{ if eq(parameters.isRelease, true) }}:
+      - group: FoundryLocal-ESRP-Signing
     templateContext:
       inputs:
       - input: pipelineArtifact
@@ -86,7 +92,7 @@ stages:
         rid: 'win-arm64'
         nativeArtifactDir: '$(Pipeline.Workspace)/cpp-native-win-arm64'
         outputDir: '$(Build.ArtifactStagingDirectory)/js-prebuild'
-        signWindows: true
+        signWindows: ${{ parameters.isRelease }}
 
 - stage: js_build_linux_x64
   displayName: 'JS SDK: Build Linux x64'
@@ -164,7 +170,8 @@ stages:
       demands:
       - ImageOverride -equals ACES_VM_SharedPool_Sequoia
     variables:
-    - group: FoundryLocal-ESRP-Signing
+    - ${{ if eq(parameters.isRelease, true) }}:
+      - group: FoundryLocal-ESRP-Signing
     templateContext:
       inputs:
       - input: pipelineArtifact
@@ -185,7 +192,7 @@ stages:
         rid: 'osx-arm64'
         nativeArtifactDir: '$(Pipeline.Workspace)/cpp-native-osx-arm64'
         outputDir: '$(Build.ArtifactStagingDirectory)/js-prebuild'
-        signMac: true
+        signMac: ${{ parameters.isRelease }}
 
 # ================================================================
 # Test stages - same platform only.

--- a/.pipelines/v2/templates/stages-python.yml
+++ b/.pipelines/v2/templates/stages-python.yml
@@ -224,7 +224,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
       parameters:
         scriptType: ps
     - template: steps-test-python.yml
@@ -250,7 +250,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-test-python.yml
       parameters:
         wheelDir: '$(Pipeline.Workspace)/python-sdk-linux-x64'
@@ -274,7 +274,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-test-python.yml
       parameters:
         wheelDir: '$(Pipeline.Workspace)/python-sdk-linux-arm64'
@@ -300,7 +300,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-test-python.yml
       parameters:
         wheelDir: '$(Pipeline.Workspace)/python-sdk-osx-arm64'

--- a/.pipelines/v2/templates/stages-rust.yml
+++ b/.pipelines/v2/templates/stages-rust.yml
@@ -48,9 +48,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/checkout-steps.yml@self
-      parameters:
-        repoName: test-data-shared
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-build-rust.yml
       parameters:
         rid: 'win-x64'
@@ -109,7 +107,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-build-rust.yml
       parameters:
         rid: 'linux-x64'
@@ -142,7 +140,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-build-rust.yml
       parameters:
         rid: 'linux-arm64'
@@ -176,7 +174,7 @@ stages:
     steps:
     - checkout: self
       clean: true
-    - template: ../../templates/fetch-test-data-from-blob.yml@self
+    - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     - template: steps-build-rust.yml
       parameters:
         rid: 'osx-arm64'

--- a/.pipelines/v2/templates/stages-sdk-v2.yml
+++ b/.pipelines/v2/templates/stages-sdk-v2.yml
@@ -22,6 +22,8 @@ parameters:
   type: string
 - name: winmlVersion
   type: string
+- name: isRelease
+  type: boolean
 
 stages:
 
@@ -32,6 +34,7 @@ stages:
     ortVersion: ${{ parameters.ortVersion }}
     genaiVersion: ${{ parameters.genaiVersion }}
     winmlVersion: ${{ parameters.winmlVersion }}
+    isRelease: ${{ parameters.isRelease }}
 
 # ── C# SDK ──
 - template: stages-cs.yml

--- a/.pipelines/v2/templates/stages-sdk-v2.yml
+++ b/.pipelines/v2/templates/stages-sdk-v2.yml
@@ -44,6 +44,8 @@ stages:
 
 # ── JS SDK (single multi-platform tarball) ──
 - template: stages-js.yml
+  parameters:
+    isRelease: ${{ parameters.isRelease }}
 
 # ── Rust SDK (single platform-independent crate) ──
 # Needs the ORT/GenAI versions to assemble a runnable native dir for its

--- a/.pipelines/v2/templates/steps-build-linux.yml
+++ b/.pipelines/v2/templates/steps-build-linux.yml
@@ -48,7 +48,7 @@ steps:
   displayName: 'Append version define'
 
 - ${{ if eq(parameters.runTests, true) }}:
-  - template: ../../templates/fetch-test-data-from-blob.yml@self
+  - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     parameters:
       destinationPath: '$(Agent.BuildDirectory)/test-data-shared'
 

--- a/.pipelines/v2/templates/steps-build-macos.yml
+++ b/.pipelines/v2/templates/steps-build-macos.yml
@@ -51,7 +51,7 @@ steps:
   displayName: 'Append version define'
 
 - ${{ if eq(parameters.runTests, true) }}:
-  - template: ../../templates/fetch-test-data-from-blob.yml@self
+  - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     parameters:
       destinationPath: '$(Agent.BuildDirectory)/test-data-shared'
 

--- a/.pipelines/v2/templates/steps-build-macos.yml
+++ b/.pipelines/v2/templates/steps-build-macos.yml
@@ -12,6 +12,8 @@ parameters:
 - name: runTests
   type: boolean
   default: false
+- name: isRelease
+  type: boolean
 
 steps:
 
@@ -113,52 +115,53 @@ steps:
 
   displayName: 'Stage native artifacts'
 
-- bash: |
-    set -euo pipefail
-    rm -f libfoundry_local_dylib.zip
-    zip libfoundry_local_dylib.zip libfoundry_local.dylib
-  displayName: 'Zip libfoundry_local.dylib for signing'
-  workingDirectory: '$(Build.ArtifactStagingDirectory)/native'
+- ${{ if eq(parameters.isRelease, true) }}:
+  - bash: |
+      set -euo pipefail
+      rm -f libfoundry_local_dylib.zip
+      zip libfoundry_local_dylib.zip libfoundry_local.dylib
+    displayName: 'Zip libfoundry_local.dylib for signing'
+    workingDirectory: '$(Build.ArtifactStagingDirectory)/native'
 
-# ESRP requires a ZIP or DMG transport for macOS signing. The C++ SDK archive,
-# runtime NuGet/C# SDK, Python wheel, and JS prebuild all consume the signed
-# staged dylib restored from this archive.
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
-  displayName: 'Sign libfoundry_local.dylib ZIP'
-  inputs:
-    ConnectedServiceName: 'OnnxrunTimeCodeSign_20240611'
-    UseMSIAuthentication: true
-    AppRegistrationClientId: '$(esrpClientId)'
-    AppRegistrationTenantId: '$(esrpTenantId)'
-    EsrpClientId: '$(esrpClientId)'
-    AuthAKVName: '$(esrpAkvName)'
-    AuthSignCertName: '$(esrpSignCertName)'
-    FolderPath: '$(Build.ArtifactStagingDirectory)/native'
-    Pattern: 'libfoundry_local_dylib.zip'
-    SessionTimeout: 90
-    ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
-    MaxConcurrency: 25
-    signConfigType: inlineSignParams
-    inlineOperation: |
-      [{"keyCode":"CP-401337-Apple","operationSetCode":"MacAppDeveloperSign","parameters":[{"parameterName":"Hardening","parameterValue":"--options=runtime"}],"toolName":"sign","toolVersion":"6.2.9304.0"}]
+  # ESRP requires a ZIP or DMG transport for macOS signing. The C++ SDK archive,
+  # runtime NuGet/C# SDK, Python wheel, and JS prebuild all consume the signed
+  # staged dylib restored from this archive.
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+    displayName: 'Sign libfoundry_local.dylib ZIP'
+    inputs:
+      ConnectedServiceName: 'OnnxrunTimeCodeSign_20240611'
+      UseMSIAuthentication: true
+      AppRegistrationClientId: '$(esrpClientId)'
+      AppRegistrationTenantId: '$(esrpTenantId)'
+      EsrpClientId: '$(esrpClientId)'
+      AuthAKVName: '$(esrpAkvName)'
+      AuthSignCertName: '$(esrpSignCertName)'
+      FolderPath: '$(Build.ArtifactStagingDirectory)/native'
+      Pattern: 'libfoundry_local_dylib.zip'
+      SessionTimeout: 90
+      ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
+      MaxConcurrency: 25
+      signConfigType: inlineSignParams
+      inlineOperation: |
+        [{"keyCode":"CP-401337-Apple","operationSetCode":"MacAppDeveloperSign","parameters":[{"parameterName":"Hardening","parameterValue":"--options=runtime"}],"toolName":"sign","toolVersion":"6.2.9304.0"}]
 
-- bash: |
-    set -euo pipefail
-    unzip -o libfoundry_local_dylib.zip
-    rm -- libfoundry_local_dylib.zip
-  displayName: 'Extract signed libfoundry_local.dylib'
-  workingDirectory: '$(Build.ArtifactStagingDirectory)/native'
+  - bash: |
+      set -euo pipefail
+      unzip -o libfoundry_local_dylib.zip
+      rm -- libfoundry_local_dylib.zip
+    displayName: 'Extract signed libfoundry_local.dylib'
+    workingDirectory: '$(Build.ArtifactStagingDirectory)/native'
 
-- bash: |
-    set -euo pipefail
-    dylib='$(Build.ArtifactStagingDirectory)/native/libfoundry_local.dylib'
-    codesign --verify --strict --verbose=2 "$dylib"
-    signature=$(codesign --display --verbose=4 "$dylib" 2>&1)
-    echo "$signature"
-    grep -q '^Authority=Developer ID Application:' <<<"$signature"
-    grep -Eq '^CodeDirectory .*flags=.*\(.*runtime.*\)' <<<"$signature"
-    grep -q '^Timestamp=' <<<"$signature"
-  displayName: 'Verify libfoundry_local.dylib signature'
+  - bash: |
+      set -euo pipefail
+      dylib='$(Build.ArtifactStagingDirectory)/native/libfoundry_local.dylib'
+      codesign --verify --strict --verbose=2 "$dylib"
+      signature=$(codesign --display --verbose=4 "$dylib" 2>&1)
+      echo "$signature"
+      grep -q '^Authority=Developer ID Application:' <<<"$signature"
+      grep -Eq '^CodeDirectory .*flags=.*\(.*runtime.*\)' <<<"$signature"
+      grep -q '^Timestamp=' <<<"$signature"
+    displayName: 'Verify libfoundry_local.dylib signature'
 
 # Stage debug symbols into a separate artifact so they can be published
 # independently without being bundled into the Python wheel (which consumes

--- a/.pipelines/v2/templates/steps-build-windows.yml
+++ b/.pipelines/v2/templates/steps-build-windows.yml
@@ -78,7 +78,7 @@ steps:
 
 # Tests need shared model files.
 - ${{ if eq(parameters.runTests, true) }}:
-  - template: ../../templates/fetch-test-data-from-blob.yml@self
+  - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     parameters:
       destinationPath: '$(Agent.BuildDirectory)/test-data-shared'
       scriptType: ps

--- a/sdk_v2/DEVELOPMENT.md
+++ b/sdk_v2/DEVELOPMENT.md
@@ -132,7 +132,7 @@ model files expected by the tests you are running.
 CI does not run `foundry model download ...`. Instead, pipelines fetch a fixed
 model set into `FOUNDRY_TEST_DATA_DIR` using:
 
-- `.pipelines/templates/fetch-test-data-from-blob.yml`
+- `.pipelines/templates/fetch-models-from-artifacts-feed.yml`
 
 The legacy template name is retained to avoid changing its existing callers. The
 template downloads pinned Universal Packages from the project-scoped
@@ -206,7 +206,7 @@ the package into the target cache alias directory. Do not ZIP the directory.
 
 After publishing, add or update the corresponding `UniversalPackages@0` task in:
 
-- `.pipelines/templates/fetch-test-data-from-blob.yml`
+- `.pipelines/templates/fetch-models-from-artifacts-feed.yml`
 
 Checklist:
 

--- a/sdk_v2/DEVELOPMENT.md
+++ b/sdk_v2/DEVELOPMENT.md
@@ -92,7 +92,7 @@ See `pwsh ./build_and_test_all.ps1 -?` for the full parameter list.
 Model-dependent sdk_v2 tests require `FOUNDRY_TEST_DATA_DIR` to point to a
 local model cache directory.
 
-In CI, sdk_v2 pipelines pre-populate this directory from blob storage.
+In CI, sdk_v2 pipelines pre-populate this directory from Azure Artifacts.
 For local runs, developers should populate a local cache first, then point
 `FOUNDRY_TEST_DATA_DIR` at it.
 
@@ -134,24 +134,96 @@ model set into `FOUNDRY_TEST_DATA_DIR` using:
 
 - `.pipelines/templates/fetch-test-data-from-blob.yml`
 
-That template downloads versioned model assets and writes `inference_model.json`
-entries expected by the local model scanner.
+The legacy template name is retained to avoid changing its existing callers. The
+template downloads pinned Universal Packages from the project-scoped
+`AIFoundryLocal/AIFoundryLocal_PublicPackages` feed. The pipeline and feed are in
+the same Azure DevOps organization, so downloads use the pipeline identity and
+do not require an Azure service connection.
+
+Each package contains one model's `v<model-version>` directory. The template
+downloads it into the cache layout expected by the local model scanner:
+
+```text
+test-data-shared/
+└── Microsoft/
+    └── <model-alias>-<model-version>/
+        └── v<model-version>/
+            ├── genai_config.json
+            ├── inference_model.json
+            └── <model files>
+```
 
 ### Updating the test models available in CI
 
-When tests need a different model/version set, update the model mapping list in:
+Models are published as separate Universal Packages so one model can be added or
+updated without republishing the entire test cache. Universal Package versions
+are immutable.
+
+To publish a model, first stage a complete cache alias directory. For example:
+
+```text
+C:\model-staging\qwen2.5-0.5b-instruct-generic-cpu-4\
+└── v4\
+    ├── genai_config.json
+    ├── inference_model.json
+    └── <model files>
+```
+
+The model leaf must contain `inference_model.json` with the versioned cache ID:
+
+```json
+{
+  "Name": "qwen2.5-0.5b-instruct-generic-cpu:4"
+}
+```
+
+Install the Azure DevOps CLI extension, authenticate with an identity that has
+Feed Publisher permission, and publish the alias directory:
+
+```powershell
+az extension add --name azure-devops
+az login
+
+$packageName = '<lowercase-package-name>'
+$packageVersion = '<major.minor.patch>'
+$modelDirectory = 'C:\model-staging\<cache-alias>-<model-version>'
+
+az artifacts universal publish `
+  --organization "https://dev.azure.com/aiinfra" `
+  --project "AIFoundryLocal" `
+  --scope project `
+  --feed "AIFoundryLocal_PublicPackages" `
+  --name $packageName `
+  --version $packageVersion `
+  --description "Foundry Local generic CPU test model cache" `
+  --path $modelDirectory
+```
+
+Publishing the alias directory makes `v4` the package root. Do not ZIP the
+directory; `UniversalPackages@0` downloads its files directly into the target
+cache alias directory.
+
+After publishing, add or update the corresponding `UniversalPackages@0` task in:
 
 - `.pipelines/templates/fetch-test-data-from-blob.yml`
 
 Checklist:
 
-1. Add or update the model entry (`SourcePath` + `Version`) in `modelMappings`.
-2. Ensure the selected version path exists in blob storage (`v<Version>`).
-3. Keep at least one model per test task used across SDKs (chat, embeddings,
+1. Use a stable lowercase package name for a model variant and pin an exact
+   semantic package version in the template; do not use `*`.
+2. Set `downloadDirectory` to
+   `${{ parameters.destinationPath }}/Microsoft/<cache-alias>-<model-version>`.
+3. For a new model version, stage the new `v<model-version>` directory, update
+   `inference_model.json`, publish a new package version, and update the cache
+   alias, package version, and download path in the template.
+4. To correct packaging without changing the model version, publish a new patch
+   package version (for example, `4.0.1`) and update only
+   `vstsPackageVersion`. The cache ID can remain at model version `4`.
+5. Keep at least one model per test task used across SDKs (chat, embeddings,
   audio/ASR) so integration suites remain runnable.
-4. Validate by running `pwsh ./build_and_test_all.ps1` with
+6. Validate by running `pwsh ./build_and_test_all.ps1` with
   `FOUNDRY_TEST_DATA_DIR` set to a cache containing the same model set.
-5. If local instructions change, update this file so contributors can mirror CI.
+7. Verify the package with a CI download before removing an older package entry.
 
 ## Troubleshooting
 

--- a/sdk_v2/DEVELOPMENT.md
+++ b/sdk_v2/DEVELOPMENT.md
@@ -120,7 +120,7 @@ Then set env var `FOUNDRY_TEST_DATA_DIR` to the cache path you want tests to use
 Example:
 
 ```powershell
-$env:FOUNDRY_TEST_DATA_DIR = '$env:USERPROFILE\.foundry\cache\models\Microsoft'
+$env:FOUNDRY_TEST_DATA_DIR = "$env:USERPROFILE\.foundry\cache\models"
 pwsh ./build_and_test_all.ps1
 ```
 
@@ -199,9 +199,10 @@ az artifacts universal publish `
   --path $modelDirectory
 ```
 
-Publishing the alias directory makes `v4` the package root. Do not ZIP the
-directory; `UniversalPackages@0` downloads its files directly into the target
-cache alias directory.
+Publishing the alias directory uploads its contents, so `v4` is a top-level
+directory within the package. Do not publish the contents of `v4` directly;
+the version directory must remain present when `UniversalPackages@0` downloads
+the package into the target cache alias directory. Do not ZIP the directory.
 
 After publishing, add or update the corresponding `UniversalPackages@0` task in:
 


### PR DESCRIPTION
- allows 3P contributors to run our CIs from forked repos as download from azure artifacts feed within the same ADO org as our CI pipelines requires no authentication
- updated documentation to reflect new process
- existing models uploaded to AIFoundryLocal_PublicPackages:
[Qwen 2.5 0.5B Instruct, generic CPU, v4 (package 4.0.2)](https://dev.azure.com/aiinfra/AIFoundryLocal/_artifacts/feed/AIFoundryLocal_PublicPackages/UPack/foundry-local-qwen-2-5-0-5b-instruct-generic-cpu/overview/4.0.2)
[OpenAI Whisper Tiny, generic CPU, v4 (package 4.0.0)](https://dev.azure.com/aiinfra/AIFoundryLocal/_artifacts/feed/AIFoundryLocal_PublicPackages/UPack/foundry-local-openai-whisper-tiny-generic-cpu/overview/4.0.0)
[Nemotron Speech Streaming EN 0.6B, generic CPU, v3 (package 3.0.0)](https://dev.azure.com/aiinfra/AIFoundryLocal/_artifacts/feed/AIFoundryLocal_PublicPackages/UPack/foundry-local-nemotron-speech-streaming-en-0-6b-generic-cpu/overview/3.0.0)
[Qwen3 Embedding 0.6B, generic CPU, v1 (package 1.0.0)](https://dev.azure.com/aiinfra/AIFoundryLocal/_artifacts/feed/AIFoundryLocal_PublicPackages/UPack/foundry-local-qwen3-embedding-0-6b-generic-cpu/overview/1.0.0)
[Qwen3.5 0.8B, generic CPU, v2 (package 2.0.0)](https://dev.azure.com/aiinfra/AIFoundryLocal/_artifacts/feed/AIFoundryLocal_PublicPackages/UPack/foundry-local-qwen3-5-0-8b-generic-cpu/overview/2.0.0)
[DeepSeek R1 Distill Qwen 14B, generic CPU, v4 (package 4.0.0)](https://dev.azure.com/aiinfra/AIFoundryLocal/_artifacts/feed/AIFoundryLocal_PublicPackages/UPack/foundry-local-deepseek-r1-distill-qwen-14b-generic-cpu/overview/4.0.0)
- fixes rust pipeline to use new setup
- puts macos signing steps behind isRelease flag to allow forked repos to run the pipeline w/o missing signing secrets