### PR TITLE
Add token-aware reasoning to Chat Completions and Responses

### DIFF
--- a/sdk_v2/cpp/src/contracts/chat_completions.cc
+++ b/sdk_v2/cpp/src/contracts/chat_completions.cc
@@ -171,6 +171,10 @@ void to_json(nlohmann::json& j, const ChatCompletionResponseMessage& m) {
     j["content"] = nullptr;
   }
 
+  if (m.reasoning_content.has_value()) {
+    j["reasoning_content"] = *m.reasoning_content;
+  }
+
   if (m.tool_calls.has_value()) {
     j["tool_calls"] = *m.tool_calls;
   }
@@ -241,6 +245,10 @@ void to_json(nlohmann::json& j, const ChatCompletionDelta& d) {
 
   if (d.content.has_value()) {
     j["content"] = *d.content;
+  }
+
+  if (d.reasoning_content.has_value()) {
+    j["reasoning_content"] = *d.reasoning_content;
   }
 
   if (d.tool_calls.has_value()) {

--- a/sdk_v2/cpp/src/contracts/chat_completions.h
+++ b/sdk_v2/cpp/src/contracts/chat_completions.h
@@ -94,11 +94,12 @@ struct ChatCompletionToolCall {
   std::optional<int> index;  // streaming only — distinguishes parallel tool calls
 };
 
-/// The message in a response choice. JSON keys: "role", "content", "refusal", "tool_calls"
+/// The message in a response choice. JSON keys: "role", "content", "reasoning_content", "refusal", "tool_calls"
 struct ChatCompletionResponseMessage {
   std::string role = "assistant";
-  std::optional<std::string> content;  // nullable when tool_calls present
-  std::optional<std::string> refusal;  // null unless refusal
+  std::optional<std::string> content;            // nullable when tool_calls present
+  std::optional<std::string> reasoning_content;  // present only for reasoning models
+  std::optional<std::string> refusal;            // null unless refusal
   std::optional<std::vector<ChatCompletionToolCall>> tool_calls;
 };
 
@@ -143,10 +144,11 @@ struct ChatCompletionResponse {
 
 // --- Streaming types ---
 
-/// Delta content in a streaming chunk. JSON keys: "role", "content", "tool_calls"
+/// Delta content in a streaming chunk. JSON keys: "role", "content", "reasoning_content", "tool_calls"
 struct ChatCompletionDelta {
   std::optional<std::string> role;
   std::optional<std::string> content;
+  std::optional<std::string> reasoning_content;  // present only for reasoning model chunks
   std::optional<std::vector<ChatCompletionToolCall>> tool_calls;
 };
 

--- a/sdk_v2/cpp/src/contracts/chat_completions_converter.cc
+++ b/sdk_v2/cpp/src/contracts/chat_completions_converter.cc
@@ -226,6 +226,7 @@ ChatCompletionResponse BuildResponse(const Response& response,
                                      const std::string& model_name) {
   // Extract assistant message and tool calls from response items
   std::string response_text;
+  std::string reasoning_text;
   std::vector<ChatCompletionToolCall> tool_calls;
 
   for (const auto& item : response.items) {
@@ -241,6 +242,8 @@ ChatCompletionResponse BuildResponse(const Response& response,
           const auto& ti = static_cast<const TextItem&>(*part.view);
           if (ti.text_type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT) {
             response_text += ti.text;
+          } else if (ti.text_type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING) {
+            reasoning_text += ti.text;
           }
         }
       }
@@ -261,6 +264,10 @@ ChatCompletionResponse BuildResponse(const Response& response,
   choice.index = 0;
   choice.finish_reason = MapFinishReason(response.finish_reason);
   choice.message.content = response_text;
+
+  if (!reasoning_text.empty()) {
+    choice.message.reasoning_content = std::move(reasoning_text);
+  }
 
   if (has_tool_calls) {
     choice.message.tool_calls = std::move(tool_calls);
@@ -292,6 +299,22 @@ std::string FormatStreamingChunk(const std::string& content,
 
   ChatCompletionChunkChoice choice;
   choice.delta.content = content;
+  chunk.choices.push_back(std::move(choice));
+
+  return nlohmann::json(chunk).dump();
+}
+
+std::string FormatReasoningStreamingChunk(const std::string& reasoning_content,
+                                          const std::string& completion_id,
+                                          int64_t created,
+                                          const std::string& model_name) {
+  ChatCompletionChunk chunk;
+  chunk.id = completion_id;
+  chunk.created = created;
+  chunk.model = model_name;
+
+  ChatCompletionChunkChoice choice;
+  choice.delta.reasoning_content = reasoning_content;
   chunk.choices.push_back(std::move(choice));
 
   return nlohmann::json(chunk).dump();

--- a/sdk_v2/cpp/src/contracts/chat_completions_converter.cc
+++ b/sdk_v2/cpp/src/contracts/chat_completions_converter.cc
@@ -3,6 +3,7 @@
 #include "contracts/chat_completions_converter.h"
 
 #include "items/message_item.h"
+#include "items/text_item.h"
 #include "items/tool_call_item.h"
 #include "items/tool_result_item.h"
 #include "utils.h"
@@ -231,19 +232,15 @@ ChatCompletionResponse BuildResponse(const Response& response,
     if (item->type == FOUNDRY_LOCAL_ITEM_MESSAGE) {
       auto& msg_item = static_cast<MessageItem&>(*item);
       if (msg_item.role == FOUNDRY_LOCAL_ROLE_ASSISTANT) {
-        if (msg_item.IsSimpleText()) {
-          response_text = msg_item.GetSimpleText();
-        } else {
-          // Reasoning model: assistant message has multiple typed parts. The OpenAI Chat Completions response shape
-          // exposes only visible (DEFAULT) text — REASONING parts are surfaced via the Responses API path.
-          for (const auto& part : msg_item.content) {
-            if (!part.view || part.view->type != FOUNDRY_LOCAL_ITEM_TEXT) {
-              continue;
-            }
-            const auto& ti = static_cast<const TextItem&>(*part.view);
-            if (ti.text_type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT) {
-              response_text += ti.text;
-            }
+        // Chat Completions exposes only visible text. Inspect the TextItem type even for a one-part message because a
+        // generation truncated inside a reasoning block produces exactly one REASONING part.
+        for (const auto& part : msg_item.content) {
+          if (!part.view || part.view->type != FOUNDRY_LOCAL_ITEM_TEXT) {
+            continue;
+          }
+          const auto& ti = static_cast<const TextItem&>(*part.view);
+          if (ti.text_type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT) {
+            response_text += ti.text;
           }
         }
       }
@@ -278,6 +275,8 @@ ChatCompletionResponse BuildResponse(const Response& response,
   result.usage.prompt_tokens = static_cast<int>(response.usage.prompt_tokens);
   result.usage.completion_tokens = static_cast<int>(response.usage.completion_tokens);
   result.usage.total_tokens = static_cast<int>(response.usage.total_tokens);
+  result.usage.completion_tokens_details.reasoning_tokens =
+      static_cast<int>(response.usage.reasoning_tokens);
 
   return result;
 }

--- a/sdk_v2/cpp/src/contracts/chat_completions_converter.h
+++ b/sdk_v2/cpp/src/contracts/chat_completions_converter.h
@@ -56,6 +56,12 @@ std::string FormatStreamingChunk(const std::string& content,
                                  int64_t created,
                                  const std::string& model_name);
 
+/// Format a streaming chunk with reasoning_content in the delta as JSON string.
+std::string FormatReasoningStreamingChunk(const std::string& reasoning_content,
+                                          const std::string& completion_id,
+                                          int64_t created,
+                                          const std::string& model_name);
+
 /// Format a streaming chunk with tool call data in delta.tool_calls.
 std::string FormatToolCallStreamingChunk(const std::vector<ChatCompletionToolCall>& tool_calls,
                                          const std::string& completion_id,

--- a/sdk_v2/cpp/src/inferencing/generative/chat/chat_generator.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/chat_generator.h
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include <cstdint>
+#include <optional>
 #include <string>
 
 namespace fl {
@@ -26,6 +28,9 @@ class ChatGenerator {
   /// Decode the most recently generated token into text.
   /// Returns empty string for special/control tokens that should not be surfaced.
   virtual std::string Decode() = 0;
+
+  /// Get the most recently generated token ID before Decode consumes it.
+  virtual std::optional<int32_t> CurrentTokenId() const = 0;
 
   /// Get the total number of tokens (input + generated) so far.
   virtual int TokenCount() const = 0;

--- a/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.cc
@@ -719,8 +719,7 @@ void ChatSession::ProcessChatCompletionsJson(const std::string& request_json, co
   int next_tool_call_index = 0;
   std::vector<GeneratedOutputEvent> generated_events;
 
-  // Chat Completions suppresses REASONING segments, but final response construction still consumes this same typed
-  // sequence so it does not need to re-split decoded text.
+  // Use the same typed segments for streaming and final response construction.
   auto splitter = CreateReasoningSplitter(tool_ctx, Model());
 
   auto emit_visible_text = [&](std::string visible) {
@@ -760,13 +759,20 @@ void ChatSession::ProcessChatCompletionsJson(const std::string& request_json, co
 
   auto process_segments = [&](const std::vector<ReasoningStreamSplitter::Segment>& segments) {
     for (const auto& seg : segments) {
-      // REASONING segments: intentionally dropped from the Chat Completions stream. Never feed reasoning text to
-      // the tool-call accumulator — tool-call-shaped text inside <think>...</think> is scratchpad, not a real call.
+      // REASONING segments: never feed reasoning text to the tool-call accumulator — tool-call-shaped text inside
+      // <think>...</think> is scratchpad, not a real call. Emit via reasoning_content, not content.
       if (seg.type != FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT) {
         if (!tool_accumulator.InsideToolCall()) {
           process_tool_output(tool_accumulator.Flush());
         }
         AppendGeneratedSegment(generated_events, seg.text, seg.type);
+
+        if (is_streaming && !seg.text.empty()) {
+          auto chunk_json = chat_completions::FormatReasoningStreamingChunk(
+              seg.text, completion_id, created, model_name);
+          streaming_callback->PushItem(std::make_unique<TextItem>(
+              std::move(chunk_json), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+        }
         continue;
       }
 

--- a/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.cc
@@ -48,6 +48,54 @@ void ApplyToolChoiceToContext(std::optional<flToolChoice> tool_choice, ToolCallC
   }
 }
 
+using TextSegment = ReasoningStreamSplitter::Segment;
+
+ReasoningStreamSplitter CreateReasoningSplitter(const ToolCallContext& tool_ctx,
+                                                GenAIModelInstance& model) {
+  if (!tool_ctx.supports_reasoning) {
+    return {"", ""};
+  }
+
+  const auto& tag_info = model.GetTagInfo();
+  auto start = tool_ctx.reasoning_start.empty() ? tag_info.bor_str : tool_ctx.reasoning_start;
+  auto end = tool_ctx.reasoning_end.empty() ? tag_info.eor_str : tool_ctx.reasoning_end;
+  auto start_token_ids =
+      tag_info.bor_id.has_value() ? std::vector<int32_t>{*tag_info.bor_id} : std::vector<int32_t>{};
+  auto end_token_ids =
+      tag_info.eor_id.has_value() ? std::vector<int32_t>{*tag_info.eor_id} : std::vector<int32_t>{};
+  auto ignored_token_ids = model.GetPreprocessor().GetEosTokenIds();
+  return {std::move(start), std::move(end), std::move(start_token_ids), std::move(end_token_ids),
+          std::move(ignored_token_ids)};
+}
+
+void AppendSegment(std::vector<TextSegment>& destination, std::string text, flTextItemType type) {
+  if (text.empty()) {
+    return;
+  }
+
+  if (!destination.empty() && destination.back().type == type) {
+    destination.back().text += text;
+  } else {
+    destination.push_back({std::move(text), type});
+  }
+}
+
+void AppendGeneratedSegment(std::vector<GeneratedOutputEvent>& destination, std::string text, flTextItemType type) {
+  if (text.empty()) {
+    return;
+  }
+
+  if (!destination.empty()) {
+    auto* previous = std::get_if<TextSegment>(&destination.back());
+    if (previous && previous->type == type) {
+      previous->text += text;
+      return;
+    }
+  }
+
+  destination.push_back(TextSegment{std::move(text), type});
+}
+
 }  // namespace
 
 ChatSession::ChatSession(const fl::Model& catalog_model, GenAIModelInstance& model, ILogger& logger, ITelemetry& telemetry)
@@ -238,128 +286,19 @@ ToolCallContext ChatSession::BuildToolCallContext(const Request& request) const 
   return tool_ctx;
 }
 
-// A segment of generated assistant text, tagged with whether it is ordinary visible text or reasoning content.
-struct TextSegment {
-  std::string text;
-  flTextItemType type;
-};
-
-// Split assistant output around <think>...</think> (or equivalent reasoning markers) into typed segments.
-//
-// - Text outside the markers is emitted as DEFAULT (visible) segments.
-// - Text inside the markers is emitted as REASONING segments. The markers themselves are stripped.
-// - Truncated reasoning (no closing marker) is treated as a REASONING segment running to end of input.
-// - Empty segments are skipped.
-// - When start_marker is empty, the entire input is returned as a single DEFAULT segment.
-//
-// Leading whitespace/newlines on visible segments that immediately follow a closed reasoning block are trimmed —
-// matches the prior strip behavior, which dropped a trailing newline after </think> plus any leading whitespace.
-static std::vector<TextSegment> SplitReasoningContent(const std::string& text,
-                                                      const std::string& start_marker,
-                                                      const std::string& end_marker) {
-  std::vector<TextSegment> segments;
-
-  if (start_marker.empty() || text.empty()) {
-    if (!text.empty()) {
-      segments.push_back({text, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT});
-    }
-    return segments;
-  }
-
-  auto push_default = [&](std::string s) {
-    // Trim leading whitespace from visible segments (prior strip logic dropped these).
-    size_t first = s.find_first_not_of(" \t\n\r");
-    if (first == std::string::npos) {
-      return;
-    }
-    s.erase(0, first);
-    if (!s.empty()) {
-      segments.push_back({std::move(s), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT});
-    }
-  };
-
-  auto push_reasoning = [&](std::string s) {
-    if (!s.empty()) {
-      segments.push_back({std::move(s), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING});
-    }
-  };
-
-  size_t pos = 0;
-  while (pos < text.size()) {
-    size_t start_pos = text.find(start_marker, pos);
-
-    if (start_pos == std::string::npos) {
-      push_default(text.substr(pos));
-      break;
-    }
-
-    // Visible text before the reasoning block.
-    push_default(text.substr(pos, start_pos - pos));
-
-    size_t reasoning_begin = start_pos + start_marker.size();
-    size_t end_pos = text.find(end_marker, reasoning_begin);
-
-    if (end_pos == std::string::npos) {
-      // Truncated — reasoning runs to end of string. Drop nothing; expose what we have.
-      push_reasoning(text.substr(reasoning_begin));
-      break;
-    }
-
-    push_reasoning(text.substr(reasoning_begin, end_pos - reasoning_begin));
-    pos = end_pos + end_marker.size();
-
-    // Drop a single trailing newline after </think> (matches prior strip behavior).
-    if (pos < text.size() && text[pos] == '\n') {
-      ++pos;
-    }
-  }
-
-  return segments;
-}
-
-void ChatSession::ProcessGeneratedOutput(std::string text, const ToolCallContext& tool_ctx,
+void ChatSession::ProcessGeneratedOutput(std::vector<GeneratedOutputEvent> events,
                                          const SearchOptions& effective_options, bool canceled,
                                          Response& response, int prompt_tokens, int total_tokens,
-                                         std::vector<ParsedToolCall> pre_parsed_calls) {
+                                         int reasoning_tokens) {
   int completion_tokens = total_tokens - prompt_tokens;
-
-  // Check if the generated text contains tool calls. If the caller has already parsed them (streaming path), reuse
-  // those so call_ids stay stable across stream deltas and the final response — OpenAI Chat Completions semantics.
   bool has_tool_calls = false;
-  std::vector<ParsedToolCall> parsed_calls;
-
-  if (!pre_parsed_calls.empty()) {
-    parsed_calls = std::move(pre_parsed_calls);
-    has_tool_calls = true;
-  } else if (tool_ctx.HasTools() && tool_ctx.tool_output && tool_ctx.HasToolCallTokens()) {
-    parsed_calls = ParseToolCalls(text, tool_ctx.tool_call_start, tool_ctx.tool_call_end);
-    has_tool_calls = !parsed_calls.empty();
-  }
-
-  if (has_tool_calls) {
-    // Add structured tool call items to the response
-    auto tool_items = ToolCallsToItems(parsed_calls);
-    for (auto& ti : tool_items) {
-      response.items.push_back(std::move(ti));
-    }
-  }
-
-  // Split assistant output around reasoning markers so reasoning content can be returned to the caller as a typed
-  // TextItem alongside the visible response text. RenderContent in chat_template.cc skips REASONING parts when
-  // re-applying the template to history, so storing reasoning here doesn't contaminate subsequent prompts.
   std::vector<TextSegment> segments;
 
-  if (tool_ctx.supports_reasoning) {
-    std::string start = tool_ctx.reasoning_start.empty() ? "<think>" : tool_ctx.reasoning_start;
-    std::string end = tool_ctx.reasoning_end.empty() ? "</think>" : tool_ctx.reasoning_end;
-    segments = SplitReasoningContent(text, start, end);
-  } else if (!text.empty()) {
-    segments.push_back({std::move(text), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT});
-  }
+  auto flush_segments = [&]() {
+    if (segments.empty()) {
+      return;
+    }
 
-  // Build the assistant message from the segments. Tool-call-only outputs may produce zero segments — emit no
-  // message in that case, since MessageItem requires non-empty content.
-  if (!segments.empty()) {
     std::unique_ptr<MessageItem> output_item;
 
     if (segments.size() == 1 && segments.front().type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT) {
@@ -376,7 +315,22 @@ void ChatSession::ProcessGeneratedOutput(std::string text, const ToolCallContext
     }
 
     response.items.push_back(std::move(output_item));
+    segments.clear();
+  };
+
+  for (auto& event : events) {
+    if (auto* segment = std::get_if<TextSegment>(&event)) {
+      AppendSegment(segments, std::move(segment->text), segment->type);
+      continue;
+    }
+
+    flush_segments();
+    auto& call = std::get<ParsedToolCall>(event);
+    response.items.push_back(std::make_unique<ToolCallItem>(std::move(call.id), std::move(call.name),
+                                                            std::move(call.arguments)));
+    has_tool_calls = true;
   }
+  flush_segments();
 
   if (canceled) {
     response.finish_reason = FOUNDRY_LOCAL_FINISH_NONE;
@@ -395,10 +349,12 @@ void ChatSession::ProcessGeneratedOutput(std::string text, const ToolCallContext
   response.usage.prompt_tokens = prompt_tokens;
   response.usage.completion_tokens = completion_tokens;
   response.usage.total_tokens = total_tokens;
+  response.usage.reasoning_tokens = reasoning_tokens;
 
   logger_.Log(LogLevel::Verbose,
-              fmt::format("Completion stats: Total Tokens: {}, Prompt Tokens: {}, Completion Tokens: {}",
-                          total_tokens, prompt_tokens, completion_tokens));
+              fmt::format(
+                  "Completion stats: Total Tokens: {}, Prompt Tokens: {}, Completion Tokens: {}, Reasoning Tokens: {}",
+                  total_tokens, prompt_tokens, completion_tokens, reasoning_tokens));
 }
 
 void ChatSession::ProcessRequestImpl(const Request& request, Response& response) {
@@ -529,23 +485,18 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
   }
 
   int max_output = effective_options.max_output_tokens.value_or(0);
+  const auto committed_tool_ctx = cached_tool_ctx_;
 
   // Generate token-by-token with optional streaming.
   // Check request.canceled each iteration — a streaming callback returning
   // non-zero sets this flag asynchronously via CallbackHandler.
-  std::string text;
   auto streaming_callback = CreateCallbackHandler(request);
   int output_tokens = 0;
+  std::vector<GeneratedOutputEvent> generated_events;
 
-  // Splitter: only active for reasoning models. For non-reasoning models start_marker is empty and the splitter
-  // degrades to a passthrough (every token becomes one DEFAULT segment), so the streaming path stays uniform.
-  ReasoningStreamSplitter splitter(
-      cached_tool_ctx_.supports_reasoning ? (cached_tool_ctx_.reasoning_start.empty() ? std::string("<think>")
-                                                                                      : cached_tool_ctx_.reasoning_start)
-                                          : std::string(),
-      cached_tool_ctx_.supports_reasoning ? (cached_tool_ctx_.reasoning_end.empty() ? std::string("</think>")
-                                                                                    : cached_tool_ctx_.reasoning_end)
-                                          : std::string());
+  // Marker IDs are derived from the configured strings with the model tokenizer. This detects special markers even
+  // when their decoded chunks are empty, while non-reasoning models retain the DEFAULT passthrough.
+  auto splitter = CreateReasoningSplitter(cached_tool_ctx_, Model());
 
   // Accumulator: separates visible text from tool-call blocks in the DEFAULT-segment stream. For models without
   // tool-call markers configured, both marker strings are empty and the accumulator degrades to passthrough.
@@ -555,61 +506,75 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
       cached_tool_ctx_.tool_output ? cached_tool_ctx_.tool_call_start : std::string{},
       cached_tool_ctx_.tool_output ? cached_tool_ctx_.tool_call_end : std::string{});
 
-  // Tool calls parsed during streaming. Reused by ProcessGeneratedOutput so call_ids stay stable across stream
-  // deltas and the final response (OpenAI Chat Completions contract). Populated even when there is no streaming
-  // callback — the accumulator still parses on close — but in that case the final-response path re-parses anyway,
-  // which is fine because the IDs only need to be stable when a client is observing the stream.
-  std::vector<ParsedToolCall> streamed_tool_calls;
+  std::string assistant_history_text;
+
+  auto append_history_call = [&](const ParsedToolCall& call) {
+    nlohmann::ordered_json rendered;
+    rendered["name"] = call.name;
+    auto arguments = nlohmann::json::parse(call.arguments, nullptr, /*allow_exceptions=*/false);
+    rendered["arguments"] = arguments.is_discarded() ? nlohmann::json(call.arguments) : std::move(arguments);
+    if (!assistant_history_text.empty() && assistant_history_text.back() != '\n') {
+      assistant_history_text.push_back('\n');
+    }
+    if (committed_tool_ctx.HasToolCallTokens()) {
+      assistant_history_text += committed_tool_ctx.tool_call_start + "\n" + rendered.dump() + "\n" +
+                                committed_tool_ctx.tool_call_end;
+    } else {
+      assistant_history_text += rendered.dump();
+    }
+  };
+
+  auto emit_tool_output = [&](ToolCallStreamAccumulator::Output out) {
+    for (auto& event : out.events) {
+      if (auto* text = std::get_if<std::string>(&event)) {
+        assistant_history_text += *text;
+        AppendGeneratedSegment(generated_events, *text, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT);
+        if (streaming_callback) {
+          streaming_callback->PushItem(
+              std::make_unique<TextItem>(*text, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT));
+        }
+        continue;
+      }
+
+      auto call = std::move(std::get<ParsedToolCall>(event));
+      append_history_call(call);
+      if (streaming_callback) {
+        streaming_callback->PushItem(std::make_unique<ToolCallItem>(call.id, call.name, call.arguments));
+      }
+      generated_events.push_back(std::move(call));
+    }
+  };
 
   auto emit_segments = [&](const std::vector<ReasoningStreamSplitter::Segment>& segments) {
     for (const auto& seg : segments) {
-      if (seg.type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING) {
+      if (seg.type != FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT) {
+        // Release a visible prefix held as a potential tool marker before appending later reasoning.
+        if (!tool_accumulator.InsideToolCall()) {
+          emit_tool_output(tool_accumulator.Flush());
+        }
         // REASONING goes straight through — never feed it to the tool-call accumulator.
+        AppendGeneratedSegment(generated_events, seg.text, seg.type);
         if (streaming_callback) {
           streaming_callback->PushItem(std::make_unique<TextItem>(seg.text, seg.type));
         }
         continue;
       }
 
-      auto out = tool_accumulator.Push(seg.text);
-
-      if (streaming_callback && !out.visible_text.empty()) {
-        streaming_callback->PushItem(
-            std::make_unique<TextItem>(std::move(out.visible_text), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT));
-      }
-
-      for (auto& pc : out.ready_calls) {
-        if (streaming_callback) {
-          streaming_callback->PushItem(std::make_unique<ToolCallItem>(pc.id, pc.name, pc.arguments));
-        }
-        streamed_tool_calls.push_back(std::move(pc));
-      }
+      emit_tool_output(tool_accumulator.Push(seg.text));
     }
   };
 
-  auto flush_accumulator = [&]() {
-    auto out = tool_accumulator.Flush();
-
-    if (streaming_callback && !out.visible_text.empty()) {
-      streaming_callback->PushItem(
-          std::make_unique<TextItem>(std::move(out.visible_text), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT));
-    }
-
-    for (auto& pc : out.ready_calls) {
-      if (streaming_callback) {
-        streaming_callback->PushItem(std::make_unique<ToolCallItem>(pc.id, pc.name, pc.arguments));
-      }
-      streamed_tool_calls.push_back(std::move(pc));
-    }
-  };
+  auto flush_accumulator = [&]() { emit_tool_output(tool_accumulator.Flush()); };
 
   while (!cached_generator_->IsDone() && !request.canceled) {
     cached_generator_->GenerateNextToken();
+    const auto token_id = cached_generator_->CurrentTokenId();
     std::string token = cached_generator_->Decode();
     ++output_tokens;
 
-    if (!token.empty()) {
-      text += token;
+    if (token_id.has_value()) {
+      emit_segments(splitter.Push(*token_id, std::move(token)));
+    } else if (!token.empty()) {
       emit_segments(splitter.Push(token));
     }
 
@@ -633,8 +598,8 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
     cached_generator_->RewindTo(pre_turn_token_count);
   }
 
-  ProcessGeneratedOutput(std::move(text), cached_tool_ctx_, effective_options, request.canceled,
-                         response, prompt_tokens, total_tokens, std::move(streamed_tool_calls));
+  ProcessGeneratedOutput(std::move(generated_events), effective_options, request.canceled, response,
+                         prompt_tokens, total_tokens, splitter.ReasoningTokenCount());
 
   // Commit input messages + assistant reply to history only on success (not cancelled)
   if (!request.canceled) {
@@ -654,7 +619,7 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
       cached_tool_ctx_ = {};
     }
 
-    CommitTurn(std::move(new_messages), response, pre_turn_token_count, total_tokens);
+    CommitTurn(std::move(new_messages), std::move(assistant_history_text), pre_turn_token_count, total_tokens);
 
     // After a media turn, drop the cached generator so any text follow-up
     // rebuilds from history. AppendMessages cannot extend a media-decoded
@@ -751,22 +716,12 @@ void ChatSession::ProcessChatCompletionsJson(const std::string& request_json, co
   ToolCallStreamAccumulator tool_accumulator(tool_ctx.tool_output ? tool_ctx.tool_call_start : std::string{},
                                              tool_ctx.tool_output ? tool_ctx.tool_call_end : std::string{});
 
-  // Tool calls parsed during streaming. Reused by ProcessGeneratedOutput so call_ids stay stable across stream
-  // deltas and the final ChatCompletionResponse (OpenAI Chat Completions contract).
-  std::vector<ParsedToolCall> streamed_tool_calls;
+  int next_tool_call_index = 0;
+  std::vector<GeneratedOutputEvent> generated_events;
 
-  // Reasoning-aware token splitter. For non-reasoning models the splitter is a passthrough (every token becomes one
-  // DEFAULT segment) so the loop body is uniform. For reasoning models, REASONING segments are suppressed from the
-  // Chat Completions stream — the OpenAI Chat Completions spec has no reasoning-delta concept; reasoning is exposed
-  // via the Responses API path in Stage 4. The non-streaming response already excludes reasoning text from
-  // `delta.content` via the typed-MessageItem build in ProcessGeneratedOutput.
-  ReasoningStreamSplitter splitter(
-      tool_ctx.supports_reasoning ? (tool_ctx.reasoning_start.empty() ? std::string("<think>")
-                                                                      : tool_ctx.reasoning_start)
-                                  : std::string(),
-      tool_ctx.supports_reasoning ? (tool_ctx.reasoning_end.empty() ? std::string("</think>")
-                                                                    : tool_ctx.reasoning_end)
-                                  : std::string());
+  // Chat Completions suppresses REASONING segments, but final response construction still consumes this same typed
+  // sequence so it does not need to re-split decoded text.
+  auto splitter = CreateReasoningSplitter(tool_ctx, Model());
 
   auto emit_visible_text = [&](std::string visible) {
     if (visible.empty() || !is_streaming) {
@@ -778,33 +733,28 @@ void ChatSession::ProcessChatCompletionsJson(const std::string& request_json, co
                                                             FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
   };
 
-  auto emit_ready_calls = [&](std::vector<ParsedToolCall>& ready) {
-    if (ready.empty()) {
-      return;
-    }
-
-    if (is_streaming) {
-      std::vector<ChatCompletionToolCall> tc_list;
-      tc_list.reserve(ready.size());
-      int tc_index = 0;
-
-      for (const auto& pc : ready) {
-        ChatCompletionToolCall tc;
-        tc.index = tc_index++;
-        tc.id = pc.id;
-        tc.type = "function";
-        tc.function.name = pc.name;
-        tc.function.arguments = pc.arguments;
-        tc_list.push_back(std::move(tc));
+  auto process_tool_output = [&](ToolCallStreamAccumulator::Output out) {
+    for (auto& event : out.events) {
+      if (auto* text = std::get_if<std::string>(&event)) {
+        AppendGeneratedSegment(generated_events, *text, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT);
+        emit_visible_text(*text);
+        continue;
       }
 
-      auto chunk_json = chat_completions::FormatToolCallStreamingChunk(tc_list, completion_id, created, model_name);
-      streaming_callback->PushItem(std::make_unique<TextItem>(std::move(chunk_json),
-                                                              FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
-    }
-
-    for (auto& pc : ready) {
-      streamed_tool_calls.push_back(std::move(pc));
+      auto call = std::move(std::get<ParsedToolCall>(event));
+      if (is_streaming) {
+        ChatCompletionToolCall streamed;
+        streamed.index = next_tool_call_index++;
+        streamed.id = call.id;
+        streamed.type = "function";
+        streamed.function.name = call.name;
+        streamed.function.arguments = call.arguments;
+        auto chunk_json = chat_completions::FormatToolCallStreamingChunk(
+            {streamed}, completion_id, created, model_name);
+        streaming_callback->PushItem(std::make_unique<TextItem>(
+            std::move(chunk_json), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+      }
+      generated_events.push_back(std::move(call));
     }
   };
 
@@ -813,23 +763,26 @@ void ChatSession::ProcessChatCompletionsJson(const std::string& request_json, co
       // REASONING segments: intentionally dropped from the Chat Completions stream. Never feed reasoning text to
       // the tool-call accumulator — tool-call-shaped text inside <think>...</think> is scratchpad, not a real call.
       if (seg.type != FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT) {
+        if (!tool_accumulator.InsideToolCall()) {
+          process_tool_output(tool_accumulator.Flush());
+        }
+        AppendGeneratedSegment(generated_events, seg.text, seg.type);
         continue;
       }
 
-      auto out = tool_accumulator.Push(seg.text);
-      emit_visible_text(std::move(out.visible_text));
-      emit_ready_calls(out.ready_calls);
+      process_tool_output(tool_accumulator.Push(seg.text));
     }
   };
 
-  // Generate token-by-token
-  std::string text;
+  // Generate token-by-token.
   while (!generator->IsDone() && !original_request.canceled) {
     generator->GenerateNextToken();
+    const auto token_id = generator->CurrentTokenId();
     std::string token = generator->Decode();
 
-    if (!token.empty()) {
-      text += token;
+    if (token_id.has_value()) {
+      process_segments(splitter.Push(*token_id, std::move(token)));
+    } else if (!token.empty()) {
       process_segments(splitter.Push(token));
     }
   }
@@ -837,19 +790,12 @@ void ChatSession::ProcessChatCompletionsJson(const std::string& request_json, co
   // Drain any buffered partial-marker bytes at end-of-stream. Reasoning splitter first so any final DEFAULT bytes
   // feed into the tool accumulator; then drain the tool accumulator.
   process_segments(splitter.Flush());
-  {
-    auto out = tool_accumulator.Flush();
-    emit_visible_text(std::move(out.visible_text));
-    emit_ready_calls(out.ready_calls);
-  }
+  process_tool_output(tool_accumulator.Flush());
 
   int total_tokens = generator->TokenCount();
 
-  // Process the generated output into response items (MessageItem, ToolCallItem, etc.)
-  // This also updates finish_reason, and usage on the response. Streamed-parsed tool calls are reused so call_ids
-  // stay stable across stream deltas and the final ChatCompletionResponse.
-  ProcessGeneratedOutput(std::move(text), tool_ctx, options, original_request.canceled,
-                         response, prompt_tokens, total_tokens, std::move(streamed_tool_calls));
+  ProcessGeneratedOutput(std::move(generated_events), options, original_request.canceled, response,
+                         prompt_tokens, total_tokens, splitter.ReasoningTokenCount());
 
   // Emit final streaming chunk with finish_reason
   if (is_streaming) {
@@ -875,7 +821,7 @@ const std::vector<MessageItem>& ChatSession::GetHistory() const {
   return history_;
 }
 
-void ChatSession::CommitTurn(std::vector<MessageItem>&& new_messages, const Response& response,
+void ChatSession::CommitTurn(std::vector<MessageItem>&& new_messages, std::string assistant_history,
                              int pre_turn_token_count, int post_turn_token_count) {
   size_t history_start = history_.size();
   size_t input_count = new_messages.size();
@@ -885,15 +831,14 @@ void ChatSession::CommitTurn(std::vector<MessageItem>&& new_messages, const Resp
     history_.push_back(std::move(msg));
   }
 
-  // Commit assistant reply from the response (first MESSAGE item with role=assistant)
-  for (const auto& item : response.items) {
-    if (item->type == FOUNDRY_LOCAL_ITEM_MESSAGE) {
-      const auto& msg = static_cast<const MessageItem&>(*item);
-      if (msg.role == FOUNDRY_LOCAL_ROLE_ASSISTANT && !msg.content.empty()) {
-        history_.push_back(msg);
-        break;
-      }
-    }
+  if (assistant_history.empty()) {
+    // A successful turn still owns an assistant role when all generated content was hidden reasoning. Preserve the
+    // role boundary so rebuilding the next turn never produces consecutive user messages.
+    MessageItem assistant;
+    assistant.role = FOUNDRY_LOCAL_ROLE_ASSISTANT;
+    history_.push_back(std::move(assistant));
+  } else {
+    history_.emplace_back(FOUNDRY_LOCAL_ROLE_ASSISTANT, std::move(assistant_history));
   }
 
   turns_.push_back({history_start, input_count, pre_turn_token_count, post_turn_token_count});

--- a/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "inferencing/generative/chat/reasoning_stream_splitter.h"
 #include "inferencing/generative/chat/search_options.h"
 #include "inferencing/generative/toolcalling/tool_call_context.h"
 #include "inferencing/generative/toolcalling/tool_call_utils.h"
@@ -11,12 +12,15 @@
 
 #include <memory>
 #include <string>
+#include <variant>
 #include <vector>
 
 namespace fl {
 
 class GenAIModelInstance;
 class OnnxChatGenerator;
+
+using GeneratedOutputEvent = std::variant<ReasoningStreamSplitter::Segment, ParsedToolCall>;
 
 /// A chat session that maintains conversation history across turns.
 /// Designed for multi-turn conversations where message history accumulates
@@ -85,14 +89,11 @@ class ChatSession : public Session {
   /// while keeping session-level tool definitions and marker tokens stable.
   void UpdateToolContextForTurn(const Request& request, ToolCallContext& tool_ctx) const;
 
-  /// Process generated output: parse tool calls (or reuse pre-parsed ones), set finish reason, usage, and response
-  /// items. When `pre_parsed_calls` is non-empty, it is used as-is and no re-parse of `text` is performed — this is
-  /// how the streaming path keeps `call_id`s stable: the calls parsed during streaming are also the calls returned
-  /// in the final response.
-  void ProcessGeneratedOutput(std::string text, const ToolCallContext& tool_ctx,
+  /// Build final response items from the typed segments and tool calls produced during generation.
+  void ProcessGeneratedOutput(std::vector<GeneratedOutputEvent> events,
                               const SearchOptions& effective_options, bool canceled,
                               Response& response, int prompt_tokens, int total_tokens,
-                              std::vector<ParsedToolCall> pre_parsed_calls = {});
+                              int reasoning_tokens);
 
   /// Process a request whose first item is a TextItem tagged OPENAI_JSON containing an OpenAI chat completions
   /// request. Parses the JSON, converts to internal items, runs generation, and produces an OPENAI_JSON-tagged
@@ -102,7 +103,7 @@ class ChatSession : public Session {
                                   Response& response);
 
   /// Commit input messages and assistant reply to history after a successful turn.
-  void CommitTurn(std::vector<MessageItem>&& new_messages, const Response& response,
+  void CommitTurn(std::vector<MessageItem>&& new_messages, std::string assistant_history,
                   int pre_turn_token_count, int post_turn_token_count);
 
   GenAIModelInstance& Model() { return model_; }

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
@@ -50,11 +50,20 @@ bool OnnxChatGenerator::IsDone() const {
 
 void OnnxChatGenerator::GenerateNextToken() {
   if (cancelled_) {
+    current_token_.reset();
     return;
   }
 
+  current_token_.reset();
+
   try {
     generator_->GenerateNextToken();
+
+    // GetNextTokens returns the batch of next tokens; chat generation always uses batch size 1.
+    const auto next_tokens = generator_->GetNextTokens();
+    if (!next_tokens.empty()) {
+      current_token_ = next_tokens[0];
+    }
   } catch (const std::runtime_error& e) {
     // If cancelled while generating, the OGA engine throws when the session is terminated.
     // This is expected — not an error.
@@ -67,19 +76,12 @@ void OnnxChatGenerator::GenerateNextToken() {
 }
 
 std::string OnnxChatGenerator::Decode() {
-  if (cancelled_) {
+  if (cancelled_ || !current_token_.has_value()) {
     return "";
   }
 
-  // Get the most recently generated token ID.
-  // GetNextTokens returns the batch of next tokens; we use index 0 (batch size = 1).
-  auto next_tokens = generator_->GetNextTokens();
-
-  if (next_tokens.empty()) {
-    return "";
-  }
-
-  int32_t token_id = next_tokens[0];
+  const auto token_id = *current_token_;
+  current_token_.reset();
 
   // Fast path: if this token matches a known tag ID, return the pre-decoded string.
   // Decode is always single-stream for normal tokens.
@@ -105,6 +107,10 @@ std::string OnnxChatGenerator::Decode() {
   // Single decode for all non-tag tokens.
   const char* token_text = stream_->Decode(token_id);
   return token_text ? std::string(token_text) : "";
+}
+
+std::optional<int32_t> OnnxChatGenerator::CurrentTokenId() const {
+  return current_token_;
 }
 
 int OnnxChatGenerator::TokenCount() const {

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.h
@@ -13,6 +13,7 @@
 #include <atomic>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -38,6 +39,7 @@ class OnnxChatGenerator : public ChatGenerator {
   bool IsDone() const override;
   void GenerateNextToken() override;
   std::string Decode() override;
+  std::optional<int32_t> CurrentTokenId() const override;
   int TokenCount() const override;
   int PromptTokenCount() const override;
   void Cancel() override;
@@ -120,6 +122,7 @@ class OnnxChatGenerator : public ChatGenerator {
   std::unique_ptr<OgaNamedTensors> named_tensors_;
   GenAIModelInstance& model_;  // non-owning reference — model outlives generator
   int prompt_token_count_ = 0;
+  std::optional<int32_t> current_token_;
   std::atomic<bool> cancelled_{false};
 };
 

--- a/sdk_v2/cpp/src/inferencing/generative/chat/reasoning_stream_splitter.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/reasoning_stream_splitter.h
@@ -42,7 +42,7 @@ class ReasoningStreamSplitter {
   /// Feed one generated token into the splitter. Marker IDs are consumed even when decoded_text is empty.
   std::vector<Segment> Push(int32_t token_id, std::string decoded_text) {
     if (!HasTextMarkers()) {
-      if (decoded_text.empty()) {
+      if (decoded_text.empty() || IsIgnoredToken(token_id)) {
         return {};
       }
 
@@ -50,7 +50,7 @@ class ReasoningStreamSplitter {
     }
 
     if (!HasTokenMarkers()) {
-      return Push(decoded_text);
+      return PushText(decoded_text, IsIgnoredToken(token_id));
     }
 
     std::vector<Segment> out;
@@ -61,22 +61,7 @@ class ReasoningStreamSplitter {
 
   /// Feed a decoded token into the text-only fallback.
   std::vector<Segment> Push(const std::string& token) {
-    std::vector<Segment> out;
-
-    if (token.empty()) {
-      return out;
-    }
-
-    if (!HasTextMarkers()) {
-      out.push_back({token, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT});
-      return out;
-    }
-
-    pending_text_tokens_.push_back({token});
-    text_buffer_ += token;
-    DrainText(out, /*flushing=*/false);
-
-    return out;
+    return PushText(token, false);
   }
 
   /// Drain pending content at end-of-generation. A partial marker is content in the current reasoning state.
@@ -113,6 +98,7 @@ class ReasoningStreamSplitter {
   struct PendingTextToken {
     std::string text;
     bool reasoning_counted = false;
+    bool ignored = false;
   };
 
   bool HasTextMarkers() const noexcept {
@@ -121,6 +107,26 @@ class ReasoningStreamSplitter {
 
   bool HasTokenMarkers() const noexcept {
     return !start_token_ids_.empty() && !end_token_ids_.empty();
+  }
+
+  std::vector<Segment> PushText(const std::string& token, bool ignored) {
+    std::vector<Segment> out;
+
+    if (token.empty()) {
+      return out;
+    }
+
+    if (!HasTextMarkers()) {
+      if (!ignored) {
+        out.push_back({token, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT});
+      }
+      return out;
+    }
+
+    pending_text_tokens_.push_back({token, false, ignored});
+    text_buffer_ += token;
+    DrainText(out, /*flushing=*/false);
+    return out;
   }
 
   void DrainTokens(std::vector<Segment>& out, bool flushing) {
@@ -291,7 +297,8 @@ class ReasoningStreamSplitter {
   }
 
   std::string ConsumeText(size_t length, flTextItemType type, bool is_content) {
-    auto text = text_buffer_.substr(0, length);
+    std::string text;
+    text.reserve(length);
     text_buffer_.erase(0, length);
 
     auto remaining = length;
@@ -299,10 +306,13 @@ class ReasoningStreamSplitter {
       auto& token = pending_text_tokens_.front();
       const auto consumed = std::min(remaining, token.text.size());
 
-      if (is_content && type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING &&
-          !token.reasoning_counted) {
-        ++reasoning_token_count_;
-        token.reasoning_counted = true;
+      // Ignored token bytes participate in marker matching but are never emitted or counted.
+      if (is_content && !token.ignored) {
+        text.append(token.text, 0, consumed);
+        if (type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING && !token.reasoning_counted) {
+          ++reasoning_token_count_;
+          token.reasoning_counted = true;
+        }
       }
 
       token.text.erase(0, consumed);
@@ -316,7 +326,7 @@ class ReasoningStreamSplitter {
   }
 
   void EmitTextSegment(std::vector<Segment>& out, std::string text, flTextItemType type) {
-    if (type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT && trim_default_prefix_) {
+    if (type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT && trim_default_prefix_ && !text.empty()) {
       if (text.starts_with("\r\n")) {
         text.erase(0, 2);
       } else if (text.starts_with('\n')) {

--- a/sdk_v2/cpp/src/inferencing/generative/chat/reasoning_stream_splitter.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/reasoning_stream_splitter.h
@@ -4,25 +4,23 @@
 
 #include "foundry_local/foundry_local_c.h"
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
 
 namespace fl {
 
-/// Token-level state machine that splits a stream of generated text chunks around reasoning markers
-/// (e.g. `<think>` / `</think>`) into typed segments.
+/// Token-aware state machine that splits generated output around reasoning markers into typed segments.
 ///
-/// The streaming code calls `Push(token)` for every decoded token and forwards the returned segments to the
-/// caller as typed `TextItem`s. At end-of-generation, `Flush()` drains any buffered bytes (e.g. a trailing
-/// partial marker that turned out not to be one).
+/// Marker token IDs come from ORT GenAI's model metadata. Matching IDs before inspecting decoded text is required
+/// for special tokens, whose decoded chunks can be empty when the tokenizer skips special tokens. Token-prefix
+/// buffering also supports compatibility callers that provide markers composed of multiple token IDs.
 ///
-/// Why a state machine: the marker can straddle multiple tokens (a tokenizer might split `</think>` into
-/// `</`, `think`, `>`). We must not emit the partial prefix as visible text and then realize on the next
-/// token that it was actually a marker. The buffer holds the suffix that could still grow into the marker.
-///
-/// When `start_marker` is empty, the splitter degrades to a passthrough that always emits DEFAULT segments —
-/// non-reasoning models share this code without a behavior change.
+/// The text-only Push overload preserves the prior decoded-marker behavior for callers without token IDs. When
+/// `start_marker` is empty, both modes degrade to a DEFAULT passthrough for non-reasoning models.
 class ReasoningStreamSplitter {
  public:
   struct Segment {
@@ -30,10 +28,38 @@ class ReasoningStreamSplitter {
     flTextItemType type;
   };
 
-  ReasoningStreamSplitter(std::string start_marker, std::string end_marker)
-      : start_marker_(std::move(start_marker)), end_marker_(std::move(end_marker)) {}
+  ReasoningStreamSplitter(std::string start_marker,
+                          std::string end_marker,
+                          std::vector<int32_t> start_token_ids = {},
+                          std::vector<int32_t> end_token_ids = {},
+                          std::vector<int32_t> ignored_token_ids = {})
+      : start_marker_(std::move(start_marker)),
+        end_marker_(std::move(end_marker)),
+        start_token_ids_(std::move(start_token_ids)),
+        end_token_ids_(std::move(end_token_ids)),
+        ignored_token_ids_(std::move(ignored_token_ids)) {}
 
-  /// Feed a token into the splitter. Returns zero or more segments to emit.
+  /// Feed one generated token into the splitter. Marker IDs are consumed even when decoded_text is empty.
+  std::vector<Segment> Push(int32_t token_id, std::string decoded_text) {
+    if (!HasTextMarkers()) {
+      if (decoded_text.empty()) {
+        return {};
+      }
+
+      return {{std::move(decoded_text), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT}};
+    }
+
+    if (!HasTokenMarkers()) {
+      return Push(decoded_text);
+    }
+
+    std::vector<Segment> out;
+    pending_tokens_.push_back({token_id, std::move(decoded_text)});
+    DrainTokens(out, /*flushing=*/false);
+    return out;
+  }
+
+  /// Feed a decoded token into the text-only fallback.
   std::vector<Segment> Push(const std::string& token) {
     std::vector<Segment> out;
 
@@ -41,27 +67,32 @@ class ReasoningStreamSplitter {
       return out;
     }
 
-    if (start_marker_.empty()) {
+    if (!HasTextMarkers()) {
       out.push_back({token, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT});
       return out;
     }
 
-    buffer_ += token;
-    Drain(out, /*flushing=*/false);
+    pending_text_tokens_.push_back({token});
+    text_buffer_ += token;
+    DrainText(out, /*flushing=*/false);
 
     return out;
   }
 
-  /// Drain any remaining buffered bytes at end-of-stream. Buffered bytes that looked like a partial marker
-  /// turn out not to be — emit them with the current type.
+  /// Drain pending content at end-of-generation. A partial marker is content in the current reasoning state.
   std::vector<Segment> Flush() {
     std::vector<Segment> out;
 
-    if (start_marker_.empty()) {
+    if (!HasTextMarkers()) {
       return out;
     }
 
-    Drain(out, /*flushing=*/true);
+    if (HasTokenMarkers()) {
+      DrainTokens(out, /*flushing=*/true);
+      DrainText(out, /*flushing=*/true);
+    } else {
+      DrainText(out, /*flushing=*/true);
+    }
 
     return out;
   }
@@ -70,8 +101,146 @@ class ReasoningStreamSplitter {
   /// downstream decisions (e.g. suppressing chunks) without inspecting segment types.
   bool InsideReasoning() const noexcept { return inside_reasoning_; }
 
+  /// Number of generated content tokens classified as reasoning. Boundary marker tokens are excluded.
+  int ReasoningTokenCount() const noexcept { return reasoning_token_count_; }
+
  private:
-  void Drain(std::vector<Segment>& out, bool flushing) {
+  struct PendingToken {
+    int32_t id;
+    std::string text;
+  };
+
+  struct PendingTextToken {
+    std::string text;
+    bool reasoning_counted = false;
+  };
+
+  bool HasTextMarkers() const noexcept {
+    return !start_marker_.empty() && !end_marker_.empty();
+  }
+
+  bool HasTokenMarkers() const noexcept {
+    return !start_token_ids_.empty() && !end_token_ids_.empty();
+  }
+
+  void DrainTokens(std::vector<Segment>& out, bool flushing) {
+    while (!pending_tokens_.empty()) {
+      const auto& marker = inside_reasoning_ ? end_token_ids_ : start_token_ids_;
+      const auto found = FindTokenSequence(pending_tokens_, marker);
+
+      if (found < pending_tokens_.size()) {
+        const auto state_before_prefix = inside_reasoning_;
+        EmitPendingTokens(out, found);
+        if (inside_reasoning_ != state_before_prefix) {
+          continue;
+        }
+
+        // A decoded-marker prefix buffered before this ID marker is ordinary content because the complete boundary
+        // is represented by the IDs below.
+        DrainText(out, /*flushing=*/true);
+        if (inside_reasoning_ != state_before_prefix) {
+          continue;
+        }
+
+        pending_tokens_.erase(
+            pending_tokens_.begin(),
+            pending_tokens_.begin() + static_cast<std::ptrdiff_t>(marker.size()));
+        inside_reasoning_ = !inside_reasoning_;
+        trim_default_prefix_ = !inside_reasoning_;
+        continue;
+      }
+
+      if (flushing) {
+        const auto state_before_flush = inside_reasoning_;
+        EmitPendingTokens(out, pending_tokens_.size());
+        if (inside_reasoning_ == state_before_flush) {
+          return;
+        }
+
+        continue;
+      }
+
+      const auto hold = LongestTokenSuffixThatIsPrefixOf(pending_tokens_, marker);
+      const auto safe = pending_tokens_.size() - hold;
+      const auto state_before_safe_tokens = inside_reasoning_;
+      EmitPendingTokens(out, safe);
+      if (inside_reasoning_ != state_before_safe_tokens) {
+        continue;
+      }
+
+      return;
+    }
+  }
+
+  void EmitPendingTokens(std::vector<Segment>& out, size_t count) {
+    if (count == 0) {
+      return;
+    }
+
+    for (size_t i = 0; i < count; ++i) {
+      auto token = std::move(pending_tokens_.front());
+      pending_tokens_.erase(pending_tokens_.begin());
+      const auto was_inside_reasoning = inside_reasoning_;
+
+      if (IsIgnoredToken(token.id)) {
+        // EOS and configured control tokens are neither reasoning content nor visible output, regardless of how
+        // the tokenizer chooses to decode them.
+      } else if (token.text.empty()) {
+        if (inside_reasoning_) {
+          ++reasoning_token_count_;
+        }
+      } else {
+        pending_text_tokens_.push_back({token.text});
+        text_buffer_ += token.text;
+        DrainText(out, /*flushing=*/false);
+      }
+
+      if (inside_reasoning_ != was_inside_reasoning) {
+        return;
+      }
+    }
+  }
+
+  static size_t FindTokenSequence(const std::vector<PendingToken>& tokens,
+                                  const std::vector<int32_t>& marker) {
+    if (marker.empty() || tokens.size() < marker.size()) {
+      return tokens.size();
+    }
+
+    for (size_t pos = 0; pos + marker.size() <= tokens.size(); ++pos) {
+      const auto matches = std::equal(
+          marker.begin(), marker.end(), tokens.begin() + static_cast<std::ptrdiff_t>(pos),
+          [](int32_t marker_id, const PendingToken& token) { return marker_id == token.id; });
+      if (matches) {
+        return pos;
+      }
+    }
+
+    return tokens.size();
+  }
+
+  bool IsIgnoredToken(int32_t token_id) const {
+    return std::find(ignored_token_ids_.begin(), ignored_token_ids_.end(), token_id) !=
+           ignored_token_ids_.end();
+  }
+
+  static size_t LongestTokenSuffixThatIsPrefixOf(const std::vector<PendingToken>& tokens,
+                                                 const std::vector<int32_t>& marker) {
+    const auto max_length = std::min(tokens.size(), marker.size());
+    for (size_t length = max_length; length > 0; --length) {
+      const auto token_start = tokens.end() - static_cast<std::ptrdiff_t>(length);
+      const auto matches = std::equal(
+          marker.begin(), marker.begin() + static_cast<std::ptrdiff_t>(length), token_start,
+          [](int32_t marker_id, const PendingToken& token) { return marker_id == token.id; });
+      if (matches) {
+        return length;
+      }
+    }
+
+    return 0;
+  }
+
+  void DrainText(std::vector<Segment>& out, bool flushing) {
     while (true) {
       const std::string& marker = inside_reasoning_ ? end_marker_ : start_marker_;
       flTextItemType current_type = inside_reasoning_ ? FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING
@@ -80,27 +249,25 @@ class ReasoningStreamSplitter {
       // Marker may be empty (e.g. end_marker not configured). With no end marker we can never close a
       // reasoning block — drain the buffer with the current type and stop.
       if (marker.empty()) {
-        EmitSegment(out, std::move(buffer_), current_type);
-        buffer_.clear();
+        EmitTextSegment(out, ConsumeText(text_buffer_.size(), current_type, /*is_content=*/true), current_type);
         return;
       }
 
-      size_t found = buffer_.find(marker);
+      size_t found = text_buffer_.find(marker);
 
       if (found != std::string::npos) {
         // Emit prefix with current type, consume marker, flip state.
-        EmitSegment(out, buffer_.substr(0, found), current_type);
-
-        size_t after = found + marker.size();
-
-        // Drop a single trailing newline immediately after the closing marker — matches the non-streaming
-        // SplitReasoningContent behavior so callers see the same visible text either way.
-        if (inside_reasoning_ && after < buffer_.size() && buffer_[after] == '\n') {
-          ++after;
-        }
-
-        buffer_.erase(0, after);
+        EmitTextSegment(out, ConsumeText(found, current_type, /*is_content=*/true), current_type);
+        ConsumeText(marker.size(), current_type, /*is_content=*/false);
+        const auto closed_reasoning = inside_reasoning_;
         inside_reasoning_ = !inside_reasoning_;
+        trim_default_prefix_ = !inside_reasoning_;
+
+        // Preserve the established behavior of dropping a newline immediately after a closed reasoning block.
+        if (closed_reasoning && !text_buffer_.empty() && text_buffer_.front() == '\n') {
+          ConsumeText(1, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT, /*is_content=*/false);
+          trim_default_prefix_ = false;
+        }
 
         continue;  // re-scan the remaining buffer for the next marker
       }
@@ -108,21 +275,57 @@ class ReasoningStreamSplitter {
       // No full marker. If we're flushing, emit everything and stop. Otherwise hold back the longest suffix
       // of buffer_ that could still grow into the marker.
       if (flushing) {
-        EmitSegment(out, std::move(buffer_), current_type);
-        buffer_.clear();
+        EmitTextSegment(out, ConsumeText(text_buffer_.size(), current_type, /*is_content=*/true), current_type);
         return;
       }
 
-      size_t hold = LongestSuffixThatIsPrefixOf(buffer_, marker);
-      size_t safe = buffer_.size() - hold;
+      size_t hold = LongestSuffixThatIsPrefixOf(text_buffer_, marker);
+      size_t safe = text_buffer_.size() - hold;
 
       if (safe > 0) {
-        EmitSegment(out, buffer_.substr(0, safe), current_type);
-        buffer_.erase(0, safe);
+        EmitTextSegment(out, ConsumeText(safe, current_type, /*is_content=*/true), current_type);
       }
 
       return;
     }
+  }
+
+  std::string ConsumeText(size_t length, flTextItemType type, bool is_content) {
+    auto text = text_buffer_.substr(0, length);
+    text_buffer_.erase(0, length);
+
+    auto remaining = length;
+    while (remaining > 0 && !pending_text_tokens_.empty()) {
+      auto& token = pending_text_tokens_.front();
+      const auto consumed = std::min(remaining, token.text.size());
+
+      if (is_content && type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING &&
+          !token.reasoning_counted) {
+        ++reasoning_token_count_;
+        token.reasoning_counted = true;
+      }
+
+      token.text.erase(0, consumed);
+      remaining -= consumed;
+      if (token.text.empty()) {
+        pending_text_tokens_.erase(pending_text_tokens_.begin());
+      }
+    }
+
+    return text;
+  }
+
+  void EmitTextSegment(std::vector<Segment>& out, std::string text, flTextItemType type) {
+    if (type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT && trim_default_prefix_) {
+      if (text.starts_with("\r\n")) {
+        text.erase(0, 2);
+      } else if (text.starts_with('\n')) {
+        text.erase(0, 1);
+      }
+      trim_default_prefix_ = false;
+    }
+
+    EmitSegment(out, std::move(text), type);
   }
 
   static void EmitSegment(std::vector<Segment>& out, std::string text, flTextItemType type) {
@@ -148,8 +351,15 @@ class ReasoningStreamSplitter {
 
   std::string start_marker_;
   std::string end_marker_;
-  std::string buffer_;
+  std::vector<int32_t> start_token_ids_;
+  std::vector<int32_t> end_token_ids_;
+  std::vector<int32_t> ignored_token_ids_;
+  std::vector<PendingToken> pending_tokens_;
+  std::vector<PendingTextToken> pending_text_tokens_;
+  std::string text_buffer_;
   bool inside_reasoning_ = false;
+  bool trim_default_prefix_ = false;
+  int reasoning_token_count_ = 0;
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/openresponses/response_converter.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/openresponses/response_converter.cc
@@ -3,6 +3,8 @@
 
 #include "inferencing/generative/openresponses/response_converter.h"
 
+#include "items/tool_call_item.h"
+
 #include <azure/core/base64.hpp>
 
 #include <chrono>
@@ -570,30 +572,11 @@ std::pair<std::vector<ResponseOutputItem>, std::string> FromSessionResponse(cons
     } else if (item->type == FOUNDRY_LOCAL_ITEM_MESSAGE) {
       MessageItem& msg_item = static_cast<MessageItem&>(*item);
       if (msg_item.role == FOUNDRY_LOCAL_ROLE_ASSISTANT) {
-        if (msg_item.IsSimpleText()) {
-          // Single-text fast path: no reasoning possible, emit one message item.
-          std::string text = msg_item.GetSimpleText();
-
-          if (text.empty()) {
-            continue;
-          }
-
-          output_text += text;
-
-          ResponseOutputMessage msg;
-          msg.id = GenerateId(msg_id_prefix);
-          msg.role = "assistant";
-          msg.status = ResponseStatus::kCompleted;
-          msg.content.push_back(OutputTextContent{std::move(text)});
-          output.push_back(std::move(msg));
-          continue;
-        }
-
-        // Multi-part message (reasoning model, possibly interleaved). Walk the parts in stream order and start
-        // a fresh output item on every type transition. This preserves the produced sequence — e.g. the model
-        // can emit `reasoning -> answer -> reasoning -> answer` and each run becomes its own output item, which
-        // matches how the OpenAI Responses API surfaces interleaved reasoning (one `reasoning` item per
-        // contiguous reasoning run, one `message` item per contiguous visible run).
+        // Walk the parts in stream order and start a fresh output item on every type transition. This preserves the
+        // produced sequence — e.g. the model can emit `reasoning -> answer -> reasoning -> answer` and each run
+        // becomes its own output item, which matches how the OpenAI Responses API surfaces interleaved reasoning.
+        // Inspect the TextItem type even for a one-part message because a generation truncated inside a reasoning
+        // block is reasoning-only.
         std::optional<flTextItemType> current_type;
         std::string current_text;
 
@@ -703,6 +686,7 @@ ResponseObject BuildResponseObject(const std::string& response_id,
   r.usage.input_tokens = static_cast<int>(usage.prompt_tokens);
   r.usage.output_tokens = static_cast<int>(usage.completion_tokens);
   r.usage.total_tokens = static_cast<int>(usage.total_tokens);
+  r.usage.output_tokens_details.reasoning_tokens = static_cast<int>(usage.reasoning_tokens);
 
   EchoRequestParams(r, params);
 
@@ -752,6 +736,57 @@ ResponseObject BuildInitialResponseObject(const std::string& response_id,
   EchoRequestParams(r, params);
 
   return r;
+}
+
+FunctionCallStreamOutput BuildFunctionCallStreamOutput(const ToolCallItem& call,
+                                                       int output_index,
+                                                       int& next_sequence_number) {
+  FunctionCallStreamOutput output;
+  output.events.reserve(4);
+
+  FunctionCallOutputItem in_progress_item;
+  in_progress_item.id = GenerateId("fc");
+  in_progress_item.call_id = call.call_id.empty() ? GenerateId("call") : call.call_id;
+  in_progress_item.name = call.name;
+
+  StreamEvent added;
+  added.type = StreamEventType::kOutputItemAdded;
+  added.sequence_number = next_sequence_number++;
+  added.output_index = output_index;
+  added.item = in_progress_item;
+  output.events.push_back(std::move(added));
+
+  StreamEvent arguments_delta;
+  arguments_delta.type = StreamEventType::kFunctionCallArgumentsDelta;
+  arguments_delta.sequence_number = next_sequence_number++;
+  arguments_delta.output_index = output_index;
+  arguments_delta.item_id = in_progress_item.id;
+  arguments_delta.delta = call.arguments;
+  arguments_delta.function_call_id = in_progress_item.call_id;
+  output.events.push_back(std::move(arguments_delta));
+
+  StreamEvent arguments_done;
+  arguments_done.type = StreamEventType::kFunctionCallArgumentsDone;
+  arguments_done.sequence_number = next_sequence_number++;
+  arguments_done.output_index = output_index;
+  arguments_done.item_id = in_progress_item.id;
+  arguments_done.function_name = in_progress_item.name;
+  arguments_done.function_call_id = in_progress_item.call_id;
+  arguments_done.function_arguments = call.arguments;
+  output.events.push_back(std::move(arguments_done));
+
+  output.completed_item = std::move(in_progress_item);
+  output.completed_item.arguments = call.arguments;
+  output.completed_item.status = ResponseStatus::kCompleted;
+
+  StreamEvent item_done;
+  item_done.type = StreamEventType::kOutputItemDone;
+  item_done.sequence_number = next_sequence_number++;
+  item_done.output_index = output_index;
+  item_done.item = output.completed_item;
+  output.events.push_back(std::move(item_done));
+
+  return output;
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk_v2/cpp/src/inferencing/generative/openresponses/response_converter.h
+++ b/sdk_v2/cpp/src/inferencing/generative/openresponses/response_converter.h
@@ -13,6 +13,8 @@
 
 namespace fl {
 
+struct ToolCallItem;
+
 /// Shared utilities for converting between Responses API format and internal
 /// session types. Used by both the web service handler and the direct
 /// ResponsesClient API.
@@ -90,6 +92,16 @@ ResponseObject BuildInitialResponseObject(const std::string& response_id,
                                           int64_t created_at,
                                           const std::string& model_name,
                                           const ResponseCreateParams& params);
+
+struct FunctionCallStreamOutput {
+  std::vector<StreamEvent> events;
+  FunctionCallOutputItem completed_item;
+};
+
+/// Build the complete Responses streaming event sequence for an atomically parsed function call.
+FunctionCallStreamOutput BuildFunctionCallStreamOutput(const ToolCallItem& call,
+                                                       int output_index,
+                                                       int& next_sequence_number);
 
 /// Convert input items from the request JSON to a storable form.
 /// Returns a JSON array of input items (instructions as system message + input).

--- a/sdk_v2/cpp/src/inferencing/generative/toolcalling/tool_call_stream_accumulator.h
+++ b/sdk_v2/cpp/src/inferencing/generative/toolcalling/tool_call_stream_accumulator.h
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace fl {
@@ -19,10 +20,10 @@ namespace fl {
 /// across tokens, parse it once the closing marker arrives, and surface the structured `ParsedToolCall`s.
 ///
 /// `Push(chunk)` accepts any text chunk (a single decoded token, or a multi-token segment produced by the upstream
-/// `ReasoningStreamSplitter`) and returns:
-///   - `visible_text`: text that is safe to emit to the caller (everything outside a tool-call block, minus any
-///     pending suffix that could still grow into the start marker).
-///   - `ready_calls`: zero or more fully parsed tool calls whose closing marker arrived in this chunk.
+/// `ReasoningStreamSplitter`) and returns ordered events containing:
+///   - text that is safe to emit to the caller (everything outside a tool-call block, minus any pending suffix that
+///     could still grow into the start marker);
+///   - fully parsed tool calls whose closing marker arrived in this chunk.
 ///
 /// Marker matching is buffered, mirroring `ReasoningStreamSplitter`: a marker can straddle multiple tokens, so the
 /// accumulator holds back the longest suffix of its scan buffer that could still extend into the marker rather than
@@ -32,23 +33,24 @@ namespace fl {
 /// returned as visible text — they turned out not to be a tool call, so the caller still sees what the model
 /// produced. Matches `ReasoningStreamSplitter::Flush()`.
 ///
-/// When either marker is empty, the accumulator degrades to a passthrough: `Push` returns its input verbatim as
-/// `visible_text` with no `ready_calls`. This keeps the call site uniform for non-tool-calling models.
+/// When either marker is empty, the accumulator degrades to a passthrough and returns its input as a text event.
+/// This keeps the call site uniform for non-tool-calling models.
 ///
 /// Callers must not feed REASONING-tagged content into `Push` — reasoning is the model's scratchpad and any
 /// tool-call-shaped text inside `<think>...</think>` is not a real tool call. The upstream `ReasoningStreamSplitter`
 /// already routes REASONING segments through a separate path; this accumulator sits below the DEFAULT-segment branch.
 class ToolCallStreamAccumulator {
  public:
+  using Event = std::variant<std::string, ParsedToolCall>;
+
   struct Output {
-    std::string visible_text;
-    std::vector<ParsedToolCall> ready_calls;
+    std::vector<Event> events;
   };
 
   ToolCallStreamAccumulator(std::string start_marker, std::string end_marker)
       : start_marker_(std::move(start_marker)), end_marker_(std::move(end_marker)) {}
 
-  /// Feed a chunk into the accumulator. Returns visible text and any tool calls completed by this chunk.
+  /// Feed a chunk into the accumulator. Returns ordered visible-text and completed-tool-call events.
   Output Push(const std::string& chunk) {
     Output out;
 
@@ -58,7 +60,7 @@ class ToolCallStreamAccumulator {
 
     if (start_marker_.empty() || end_marker_.empty()) {
       // Passthrough mode — no tool-call detection.
-      out.visible_text = chunk;
+      EmitVisible(out, chunk);
       return out;
     }
 
@@ -86,6 +88,19 @@ class ToolCallStreamAccumulator {
   bool InsideToolCall() const noexcept { return inside_tool_call_; }
 
  private:
+  static void EmitVisible(Output& out, std::string text) {
+    if (text.empty()) {
+      return;
+    }
+    if (!out.events.empty()) {
+      if (auto* previous = std::get_if<std::string>(&out.events.back())) {
+        *previous += text;
+        return;
+      }
+    }
+    out.events.emplace_back(std::move(text));
+  }
+
   void Drain(Output& out, bool flushing) {
     while (true) {
       const std::string& marker = inside_tool_call_ ? end_marker_ : start_marker_;
@@ -100,8 +115,14 @@ class ToolCallStreamAccumulator {
           buffer_.erase(0, found + marker.size());
 
           auto parsed = ParseToolCalls(tool_call_buffer_, start_marker_, end_marker_);
-          for (auto& pc : parsed) {
-            out.ready_calls.push_back(std::move(pc));
+          if (parsed.empty()) {
+            // A marker-shaped block that cannot be parsed is model text, not a tool call. Preserve it rather than
+            // silently dropping generated output.
+            EmitVisible(out, tool_call_buffer_);
+          } else {
+            for (auto& pc : parsed) {
+              out.events.emplace_back(std::move(pc));
+            }
           }
 
           tool_call_buffer_.clear();
@@ -110,7 +131,7 @@ class ToolCallStreamAccumulator {
           // Opening marker: emit prefix as visible text, then start buffering the tool-call block (including the
           // marker — ParseToolCalls expects the full `<tool_call>...</tool_call>` substring).
           if (found > 0) {
-            out.visible_text.append(buffer_, 0, found);
+            EmitVisible(out, buffer_.substr(0, found));
           }
           tool_call_buffer_ = buffer_.substr(found, marker.size());
           buffer_.erase(0, found + marker.size());
@@ -125,12 +146,11 @@ class ToolCallStreamAccumulator {
         if (inside_tool_call_) {
           // Unterminated tool-call block: surface the buffered bytes as visible text so the caller still sees what
           // the model produced. Matches ReasoningStreamSplitter::Flush behavior for unterminated reasoning.
-          out.visible_text.append(tool_call_buffer_);
-          out.visible_text.append(buffer_);
+          EmitVisible(out, tool_call_buffer_ + buffer_);
           tool_call_buffer_.clear();
           inside_tool_call_ = false;
         } else {
-          out.visible_text.append(buffer_);
+          EmitVisible(out, buffer_);
         }
         buffer_.clear();
         return;
@@ -152,7 +172,7 @@ class ToolCallStreamAccumulator {
         size_t safe = buffer_.size() - hold;
 
         if (safe > 0) {
-          out.visible_text.append(buffer_, 0, safe);
+          EmitVisible(out, buffer_.substr(0, safe));
           buffer_.erase(0, safe);
         }
       }

--- a/sdk_v2/cpp/src/inferencing/generative/toolcalling/tool_call_utils.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/toolcalling/tool_call_utils.cc
@@ -5,6 +5,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <optional>
 #include <random>
 
 namespace fl {
@@ -28,55 +29,65 @@ std::string RandomAlphanumeric(int length) {
   return result;
 }
 
+std::optional<ParsedToolCall> ParseOneToolCall(const nlohmann::json& call) {
+  if (!call.is_object()) {
+    return std::nullopt;
+  }
+
+  auto name_it = call.find("name");
+  if (name_it == call.end() || !name_it->is_string() || name_it->get<std::string>().empty()) {
+    return std::nullopt;
+  }
+
+  ParsedToolCall tc;
+  tc.name = name_it->get<std::string>();
+
+  if (auto args_it = call.find("arguments"); args_it != call.end()) {
+    tc.arguments = args_it->is_string() ? args_it->get<std::string>() : args_it->dump();
+  } else if (auto params_it = call.find("parameters"); params_it != call.end()) {
+    tc.arguments = params_it->is_string() ? params_it->get<std::string>() : params_it->dump();
+  }
+
+  return tc;
+}
+
 /// Try to parse a JSON string as a list of tool calls.
 /// Handles both array and single-object formats:
 ///   [{"name": "fn", "arguments": {...}}]
 ///   {"name": "fn", "arguments": {...}}
 std::vector<ParsedToolCall> DeserializeToolCalls(const std::string& json_text) {
-  std::vector<ParsedToolCall> results;
-
   try {
     auto json = nlohmann::json::parse(json_text);
-
-    auto parse_one = [&](const nlohmann::json& call) {
-      if (!call.is_object() || !call.contains("name")) {
-        return;
-      }
-
-      ParsedToolCall tc;
-      tc.id = GenerateToolCallId();
-      tc.name = call["name"].get<std::string>();
-
-      // Arguments can be under "arguments" or "parameters"
-      if (call.contains("arguments")) {
-        if (call["arguments"].is_string()) {
-          tc.arguments = call["arguments"].get<std::string>();
-        } else {
-          tc.arguments = call["arguments"].dump();
-        }
-      } else if (call.contains("parameters")) {
-        if (call["parameters"].is_string()) {
-          tc.arguments = call["parameters"].get<std::string>();
-        } else {
-          tc.arguments = call["parameters"].dump();
-        }
-      }
-
-      results.push_back(std::move(tc));
-    };
+    std::vector<ParsedToolCall> results;
 
     if (json.is_array()) {
+      results.reserve(json.size());
+
       for (const auto& item : json) {
-        parse_one(item);
+        auto parsed = ParseOneToolCall(item);
+        if (!parsed) {
+          return {};
+        }
+
+        results.push_back(std::move(*parsed));
       }
     } else if (json.is_object()) {
-      parse_one(json);
-    }
-  } catch (const nlohmann::json::parse_error&) {
-    // Invalid JSON — return whatever we have so far (may be empty)
-  }
+      auto parsed = ParseOneToolCall(json);
+      if (!parsed) {
+        return {};
+      }
 
-  return results;
+      results.push_back(std::move(*parsed));
+    }
+
+    for (auto& result : results) {
+      result.id = GenerateToolCallId();
+    }
+
+    return results;
+  } catch (const nlohmann::json::exception&) {
+    return {};
+  }
 }
 
 }  // namespace

--- a/sdk_v2/cpp/src/inferencing/session/response.h
+++ b/sdk_v2/cpp/src/inferencing/session/response.h
@@ -18,6 +18,7 @@ struct TokenUsage {
   int64_t prompt_tokens = 0;
   int64_t completion_tokens = 0;
   int64_t total_tokens = 0;
+  int64_t reasoning_tokens = 0;
 };
 
 /// Generic inference response — in/out data container.

--- a/sdk_v2/cpp/src/service/chat_completions_handler.cc
+++ b/sdk_v2/cpp/src/service/chat_completions_handler.cc
@@ -246,6 +246,8 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> ChatCompletionsHandler::Ha
         usage.prompt_tokens = static_cast<int>(bg_response.usage.prompt_tokens);
         usage.completion_tokens = static_cast<int>(bg_response.usage.completion_tokens);
         usage.total_tokens = static_cast<int>(bg_response.usage.total_tokens);
+        usage.completion_tokens_details.reasoning_tokens =
+            static_cast<int>(bg_response.usage.reasoning_tokens);
         usage_chunk.usage = std::move(usage);
 
         body_ptr->Push("data: " + nlohmann::json(usage_chunk).dump() + "\n\n");

--- a/sdk_v2/cpp/src/service/responses_handler.cc
+++ b/sdk_v2/cpp/src/service/responses_handler.cc
@@ -14,6 +14,7 @@
 #include "inferencing/session/session_manager.h"
 #include "inferencing/session/session_registration.h"
 #include "items/text_item.h"
+#include "items/tool_call_item.h"
 #include "service/web_service.h"
 #include "telemetry/telemetry_action_tracker.h"
 
@@ -474,6 +475,17 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> ResponsesHandler::HandleSt
       push_event("response.content_part.added", part_added);
     };
 
+    auto emit_tool_call = [&](const fl::ToolCallItem& call) {
+      close_current();
+
+      const int output_index = next_output_index++;
+      auto output = ResponseConverter::BuildFunctionCallStreamOutput(call, output_index, seq);
+      for (const auto& event : output.events) {
+        push_event(StreamEventTypeToString(event.type), event);
+      }
+      closed_items.push_back(std::move(output.completed_item));
+    };
+
     try {
       // Register inside the try so a shutdown rejection (Register throws) is reported as a stream failure
       // instead of escaping this raw std::thread and calling std::terminate.
@@ -489,7 +501,18 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> ResponsesHandler::HandleSt
           return 0;
         }
 
-        assert(item->type == FOUNDRY_LOCAL_ITEM_TEXT);
+        if (item->type == FOUNDRY_LOCAL_ITEM_TOOL_CALL) {
+          emit_tool_call(static_cast<const fl::ToolCallItem&>(*item));
+          return 0;
+        }
+
+        if (item->type != FOUNDRY_LOCAL_ITEM_TEXT) {
+          logger.Log(LogLevel::Debug,
+                     fmt::format("Responses streaming: skipping non-text item type {}",
+                                 static_cast<int>(item->type)));
+          return 0;
+        }
+
         auto* text_item = static_cast<fl::TextItem*>(item.get());
 
         ItemKind incoming = (text_item->text_type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING)

--- a/sdk_v2/cpp/test/CMakeLists.txt
+++ b/sdk_v2/cpp/test/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(foundry_local_tests
     internal_api/callback_handler_test.cc
     internal_api/catalog_cache_test.cc
     internal_api/chat/chat_generator_test.cc
+    internal_api/chat/reasoning_stream_splitter_test.cc
     internal_api/chat/chat_session_test.cc
     internal_api/chat/chat_template_test.cc
     internal_api/chat/onnx_chat_generator_vision_test.cc

--- a/sdk_v2/cpp/test/internal_api/chat/chat_template_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat/chat_template_test.cc
@@ -98,6 +98,13 @@ TEST_F(ChatTemplateTest, MultiTurnConversation) {
   EXPECT_NE(prompt.find("3+3"), std::string::npos);
 }
 
+TEST(ChatTemplateUnitTest, EmptyAssistantMessageRendersAsEmptyContent) {
+  MessageItem empty_assistant;
+  empty_assistant.role = FOUNDRY_LOCAL_ROLE_ASSISTANT;
+
+  EXPECT_EQ(RenderMessageForPrompt(empty_assistant), "");
+}
+
 TEST_F(ChatTemplateTest, EmptyMessagesThrows) {
   std::vector<MessageItem> messages;
   EXPECT_THROW(BuildChatPrompt(messages, GetModel()), fl::Exception);

--- a/sdk_v2/cpp/test/internal_api/chat/reasoning_stream_splitter_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat/reasoning_stream_splitter_test.cc
@@ -88,6 +88,17 @@ TEST(ReasoningStreamSplitterTest, MissingStartMarkerDisablesReasoningClassificat
   EXPECT_EQ(splitter.ReasoningTokenCount(), 0);
 }
 
+TEST(ReasoningStreamSplitterTest, NoTextMarkersOmitIgnoredControlToken) {
+  ReasoningStreamSplitter splitter("", "", {}, {}, {99});
+
+  EXPECT_TRUE(splitter.Push(99, "<|im_end|>").empty());
+  auto segments = splitter.Push(1, "visible");
+
+  ASSERT_EQ(segments.size(), 1u);
+  EXPECT_EQ(segments[0].type, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT);
+  EXPECT_EQ(segments[0].text, "visible");
+}
+
 TEST(ReasoningStreamSplitterTest, IgnoredEmptyDecodedTokensAreNotReasoningContent) {
   ReasoningStreamSplitter splitter("<think>", "</think>", {101}, {102}, {99});
 
@@ -108,6 +119,138 @@ TEST(ReasoningStreamSplitterTest, IgnoredVisibleControlTokensAreNotEmittedOrCoun
   Append(segments, splitter.Flush());
 
   EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "hidden");
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 1);
+}
+
+TEST(ReasoningStreamSplitterTest, IncompleteTokenMarkersOmitIgnoredControlTokenOutsideReasoning) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {}, {}, {99});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(1, "before "));
+  Append(segments, splitter.Push(99, "<|im_end|>"));
+  Append(segments, splitter.Push(2, "after"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "before after");
+  EXPECT_FALSE(splitter.InsideReasoning());
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 0);
+}
+
+TEST(ReasoningStreamSplitterTest, IncompleteTokenMarkersOmitIgnoredControlTokenInsideReasoning) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {}, {}, {99});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(1, "<think>"));
+  Append(segments, splitter.Push(2, "hidden"));
+  Append(segments, splitter.Push(99, "<|im_end|>"));
+  Append(segments, splitter.Push(3, " more"));
+  Append(segments, splitter.Push(4, "</think>"));
+  Append(segments, splitter.Push(5, "after"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "hidden more");
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "after");
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 2);
+}
+
+TEST(ReasoningStreamSplitterTest, IgnoredTokenWhoseDecodedTextIsCompleteMarkerStillToggles) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {}, {}, {99});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(99, "<think>"));
+  EXPECT_TRUE(splitter.InsideReasoning());
+
+  Append(segments, splitter.Push(1, "hidden"));
+  Append(segments, splitter.Push(99, "</think>"));
+  EXPECT_FALSE(splitter.InsideReasoning());
+
+  Append(segments, splitter.Push(2, "after"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "hidden");
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "after");
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 1);
+}
+
+TEST(ReasoningStreamSplitterTest, IgnoredTokenCompletesSplitMarkerAsSuffix) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {}, {}, {99});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(1, "<th"));
+  Append(segments, splitter.Push(99, "ink>"));
+  EXPECT_TRUE(splitter.InsideReasoning());
+
+  Append(segments, splitter.Push(2, "hidden"));
+  Append(segments, splitter.Push(3, "</think>"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "");
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "hidden");
+}
+
+TEST(ReasoningStreamSplitterTest, IgnoredTokenContributesSplitMarkerAsPrefix) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {}, {}, {99});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(99, "<th"));
+  Append(segments, splitter.Push(1, "ink>"));
+  EXPECT_TRUE(splitter.InsideReasoning());
+
+  Append(segments, splitter.Push(2, "hidden"));
+  Append(segments, splitter.Push(3, "</think>"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "hidden");
+}
+
+TEST(ReasoningStreamSplitterTest, IgnoredBoundaryTokenSuppressesNonMarkerText) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {}, {}, {99});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(1, "<th"));
+  Append(segments, splitter.Push(99, "control<think>ignored"));
+  EXPECT_TRUE(splitter.InsideReasoning());
+
+  Append(segments, splitter.Push(2, "hidden"));
+  Append(segments, splitter.Push(99, "control</think>ignored"));
+  EXPECT_FALSE(splitter.InsideReasoning());
+
+  Append(segments, splitter.Push(3, "after"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "<thafter");
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "hidden");
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 1);
+}
+
+TEST(ReasoningStreamSplitterTest, IgnoredTokenAfterClosingMarkerDoesNotConsumeNewlineTrim) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {}, {}, {99});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(1, "<think>hidden</think>"));
+  Append(segments, splitter.Push(99, "<|im_end|>"));
+  Append(segments, splitter.Push(2, "\n\nafter"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "hidden");
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "\nafter");
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 1);
+}
+
+TEST(ReasoningStreamSplitterTest, TokenIdMarkerPathTakesPrecedenceOverOverlappingIgnoredIds) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {101}, {102}, {101, 102, 99});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(101, ""));
+  Append(segments, splitter.Push(1, "hidden"));
+  Append(segments, splitter.Push(99, "<|im_end|>"));
+  Append(segments, splitter.Push(102, ""));
+  Append(segments, splitter.Push(2, "after"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "hidden");
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "after");
+  EXPECT_FALSE(splitter.InsideReasoning());
   EXPECT_EQ(splitter.ReasoningTokenCount(), 1);
 }
 

--- a/sdk_v2/cpp/test/internal_api/chat/reasoning_stream_splitter_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat/reasoning_stream_splitter_test.cc
@@ -1,0 +1,281 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "inferencing/generative/chat/reasoning_stream_splitter.h"
+#include "inferencing/generative/toolcalling/tool_call_stream_accumulator.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <iterator>
+#include <string>
+#include <vector>
+
+using namespace fl;
+
+namespace {
+
+using Segment = ReasoningStreamSplitter::Segment;
+
+void Append(std::vector<Segment>& destination, const std::vector<Segment>& source) {
+  for (const auto& segment : source) {
+    if (!destination.empty() && destination.back().type == segment.type) {
+      destination.back().text += segment.text;
+    } else {
+      destination.push_back(segment);
+    }
+  }
+}
+
+std::string Collect(const std::vector<Segment>& segments, flTextItemType type) {
+  std::string text;
+  for (const auto& segment : segments) {
+    if (segment.type == type) {
+      text += segment.text;
+    }
+  }
+  return text;
+}
+
+}  // namespace
+
+TEST(ReasoningStreamSplitterTest, EmptyDecodedSpecialMarkersClassifyVisibleAndReasoningText) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {101}, {102});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(1, "before "));
+  Append(segments, splitter.Push(101, ""));
+  Append(segments, splitter.Push(2, "hidden"));
+  Append(segments, splitter.Push(102, ""));
+  Append(segments, splitter.Push(3, "after"));
+  Append(segments, splitter.Flush());
+
+  ASSERT_EQ(segments.size(), 3u);
+  EXPECT_EQ(segments[0].type, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT);
+  EXPECT_EQ(segments[0].text, "before ");
+  EXPECT_EQ(segments[1].type, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING);
+  EXPECT_EQ(segments[1].text, "hidden");
+  EXPECT_EQ(segments[2].type, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT);
+  EXPECT_EQ(segments[2].text, "after");
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 1);
+}
+
+TEST(ReasoningStreamSplitterTest, MissingEndMarkerDisablesReasoningClassification) {
+  ReasoningStreamSplitter splitter("<think>", "", {101}, {});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(101, "<think>"));
+  Append(segments, splitter.Push(1, "visible answer"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "<think>visible answer");
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "");
+  EXPECT_FALSE(splitter.InsideReasoning());
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 0);
+}
+
+TEST(ReasoningStreamSplitterTest, MissingStartMarkerDisablesReasoningClassification) {
+  ReasoningStreamSplitter splitter("", "</think>", {}, {102});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(1, "visible answer"));
+  Append(segments, splitter.Push(102, "</think>"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "visible answer</think>");
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "");
+  EXPECT_FALSE(splitter.InsideReasoning());
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 0);
+}
+
+TEST(ReasoningStreamSplitterTest, IgnoredEmptyDecodedTokensAreNotReasoningContent) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {101}, {102}, {99});
+
+  EXPECT_TRUE(splitter.Push(101, "").empty());
+  EXPECT_TRUE(splitter.Push(99, "").empty());
+  EXPECT_TRUE(splitter.Push(102, "").empty());
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 0);
+}
+
+TEST(ReasoningStreamSplitterTest, IgnoredVisibleControlTokensAreNotEmittedOrCounted) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {101}, {102}, {99});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(101, ""));
+  Append(segments, splitter.Push(1, "hidden"));
+  Append(segments, splitter.Push(99, "<|im_end|>"));
+  Append(segments, splitter.Push(102, ""));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "hidden");
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 1);
+}
+
+TEST(ReasoningStreamSplitterTest, ClosingReasoningRemovesOnlyOneImmediateNewline) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {101}, {102});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(101, ""));
+  Append(segments, splitter.Push(1, "hidden"));
+  Append(segments, splitter.Push(102, ""));
+  Append(segments, splitter.Push(2, "\n\n  indented"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "\n  indented");
+}
+
+TEST(ReasoningStreamSplitterTest, DecodedClosingMarkerRemovesOnlyOneImmediateNewline) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {101}, {102});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(1, "<think>hidden</think>\n\n  indented"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "hidden");
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "\n  indented");
+}
+
+TEST(ReasoningStreamSplitterTest, ClosingReasoningPreservesLeadingSpaces) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {101}, {102});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(101, ""));
+  Append(segments, splitter.Push(1, "hidden"));
+  Append(segments, splitter.Push(102, ""));
+  Append(segments, splitter.Push(2, "  code"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "  code");
+}
+
+TEST(ReasoningStreamSplitterTest, MultiTokenMarkersAreBufferedAndNeverExposed) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {10, 11, 12}, {20, 21});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(1, "preface "));
+  Append(segments, splitter.Push(10, "<"));
+  Append(segments, splitter.Push(11, "think"));
+  Append(segments, splitter.Push(12, ">"));
+  Append(segments, splitter.Push(30, "step"));
+  Append(segments, splitter.Push(31, " one"));
+  Append(segments, splitter.Push(20, "</think"));
+  Append(segments, splitter.Push(21, ">"));
+  Append(segments, splitter.Push(40, "\nanswer"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "preface answer");
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "step one");
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 2);
+}
+
+TEST(ReasoningStreamSplitterTest, FlushEmitsPartialMultiTokenMarkerAsContent) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {10, 11, 12}, {20, 21});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(1, "before "));
+  Append(segments, splitter.Push(10, "<"));
+  Append(segments, splitter.Push(11, "think"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "before <think");
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "");
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 0);
+}
+
+TEST(ReasoningStreamSplitterTest, DecodedOrdinaryMarkersRemainAClassificationFallback) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {100}, {200});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(1, "visible "));
+  Append(segments, splitter.Push(2, "<thi"));
+  Append(segments, splitter.Push(3, "nk>"));
+  Append(segments, splitter.Push(4, "reasoning"));
+  Append(segments, splitter.Push(5, "</"));
+  Append(segments, splitter.Push(6, "think"));
+  Append(segments, splitter.Push(7, ">"));
+  Append(segments, splitter.Push(8, "answer"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "visible answer");
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "reasoning");
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 1);
+}
+
+TEST(ReasoningStreamSplitterTest, TextOnlyFallbackCountsReasoningTokens) {
+  ReasoningStreamSplitter splitter("<think>", "</think>");
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push("visible "));
+  Append(segments, splitter.Push("<think>"));
+  Append(segments, splitter.Push("reasoning"));
+  Append(segments, splitter.Push("</think>"));
+  Append(segments, splitter.Push("answer"));
+  Append(segments, splitter.Flush());
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT), "visible answer");
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING), "reasoning");
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 1);
+}
+
+TEST(ReasoningStreamSplitterTest, TruncatedReasoningRemainsReasoningThroughEndOfGeneration) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {10}, {20});
+  std::vector<Segment> segments;
+
+  Append(segments, splitter.Push(10, ""));
+  Append(segments, splitter.Push(30, "unfinished "));
+  Append(segments, splitter.Push(31, "thought"));
+  Append(segments, splitter.Flush());
+
+  ASSERT_EQ(segments.size(), 1u);
+  EXPECT_EQ(segments[0].type, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING);
+  EXPECT_EQ(segments[0].text, "unfinished thought");
+  EXPECT_TRUE(splitter.InsideReasoning());
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 2);
+}
+
+TEST(ReasoningStreamSplitterTest, ToolCallShapedReasoningNeverReachesToolAccumulator) {
+  ReasoningStreamSplitter splitter("<think>", "</think>", {10}, {20});
+  ToolCallStreamAccumulator accumulator("<tool_call>", "</tool_call>");
+  std::vector<Segment> segments;
+  std::vector<ParsedToolCall> calls;
+  std::string visible;
+
+  const auto route = [&](const std::vector<Segment>& emitted) {
+    Append(segments, emitted);
+    for (const auto& segment : emitted) {
+      if (segment.type != FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT) {
+        continue;
+      }
+
+      auto output = accumulator.Push(segment.text);
+      for (auto& event : output.events) {
+        if (auto* text = std::get_if<std::string>(&event)) {
+          visible += *text;
+        } else {
+          calls.push_back(std::move(std::get<ParsedToolCall>(event)));
+        }
+      }
+    }
+  };
+
+  route(splitter.Push(10, ""));
+  route(splitter.Push(30, R"(<tool_call>{"name":"unsafe","arguments":{}}</tool_call>)"));
+  route(splitter.Push(20, ""));
+  route(splitter.Push(40, "safe answer"));
+  route(splitter.Flush());
+
+  auto final_output = accumulator.Flush();
+  for (auto& event : final_output.events) {
+    if (auto* text = std::get_if<std::string>(&event)) {
+      visible += *text;
+    } else {
+      calls.push_back(std::move(std::get<ParsedToolCall>(event)));
+    }
+  }
+
+  EXPECT_EQ(Collect(segments, FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING),
+            R"(<tool_call>{"name":"unsafe","arguments":{}}</tool_call>)");
+  EXPECT_EQ(visible, "safe answer");
+  EXPECT_TRUE(calls.empty());
+  EXPECT_EQ(splitter.ReasoningTokenCount(), 1);
+}

--- a/sdk_v2/cpp/test/internal_api/chat_completions_converter_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat_completions_converter_test.cc
@@ -7,6 +7,7 @@
 #include "contracts/chat_completions_converter.h"
 
 #include "items/message_item.h"
+#include "items/text_item.h"
 #include "items/tool_call_item.h"
 #include "items/tool_result_item.h"
 
@@ -541,7 +542,7 @@ TEST(ChatCompletionsConverterTest, BuildResponse_AssistantTextMessage) {
   response.items.push_back(
       std::make_unique<MessageItem>(FOUNDRY_LOCAL_ROLE_ASSISTANT, "Hello there!"));
   response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
-  response.usage = {10, 5, 15};
+  response.usage = {10, 5, 15, 3};
 
   auto result = BuildResponse(response, "chatcmpl-abc", 1000, "test-model");
 
@@ -557,6 +558,39 @@ TEST(ChatCompletionsConverterTest, BuildResponse_AssistantTextMessage) {
   EXPECT_EQ(result.usage.prompt_tokens, 10);
   EXPECT_EQ(result.usage.completion_tokens, 5);
   EXPECT_EQ(result.usage.total_tokens, 15);
+  EXPECT_EQ(result.usage.completion_tokens_details.reasoning_tokens, 3);
+}
+
+TEST(ChatCompletionsConverterTest, BuildResponse_ReasoningOnlyMessageHasNoVisibleContent) {
+  Response response;
+  std::vector<std::unique_ptr<Item>> parts;
+  parts.push_back(std::make_unique<TextItem>("private scratchpad", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING));
+  response.items.push_back(
+      std::make_unique<MessageItem>(FOUNDRY_LOCAL_ROLE_ASSISTANT, std::move(parts)));
+  response.finish_reason = FOUNDRY_LOCAL_FINISH_LENGTH;
+
+  auto result = BuildResponse(response, "chatcmpl-reasoning", 1000, "test-model");
+
+  ASSERT_EQ(result.choices.size(), 1u);
+  ASSERT_TRUE(result.choices[0].message.content.has_value());
+  EXPECT_TRUE(result.choices[0].message.content->empty());
+}
+
+TEST(ChatCompletionsConverterTest, BuildResponse_InterleavedReasoningKeepsVisibleTextInOrder) {
+  Response response;
+  std::vector<std::unique_ptr<Item>> parts;
+  parts.push_back(std::make_unique<TextItem>("think one", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING));
+  parts.push_back(std::make_unique<TextItem>("answer one", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT));
+  parts.push_back(std::make_unique<TextItem>("think two", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING));
+  parts.push_back(std::make_unique<TextItem>(" answer two", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT));
+  response.items.push_back(std::make_unique<MessageItem>(FOUNDRY_LOCAL_ROLE_ASSISTANT, std::move(parts)));
+  response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+
+  auto result = BuildResponse(response, "chatcmpl-reasoning", 1000, "test-model");
+
+  ASSERT_EQ(result.choices.size(), 1u);
+  ASSERT_TRUE(result.choices[0].message.content.has_value());
+  EXPECT_EQ(*result.choices[0].message.content, "answer one answer two");
 }
 
 TEST(ChatCompletionsConverterTest, BuildResponse_ToolCallItems) {

--- a/sdk_v2/cpp/test/internal_api/chat_completions_converter_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat_completions_converter_test.cc
@@ -727,3 +727,126 @@ TEST(ChatCompletionsConverterTest, FormatFinalStreamingChunk_LengthReason) {
   auto parsed = json::parse(chunk_json);
   EXPECT_EQ(parsed["choices"][0]["finish_reason"], "length");
 }
+
+// ========================================================================
+// BuildResponse — reasoning_content
+// ========================================================================
+
+TEST(ChatCompletionsConverterTest, BuildResponse_ReasoningOnlyPopulatesReasoningContent) {
+  Response response;
+  std::vector<std::unique_ptr<Item>> parts;
+  parts.push_back(std::make_unique<TextItem>("deep thought", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING));
+  response.items.push_back(
+      std::make_unique<MessageItem>(FOUNDRY_LOCAL_ROLE_ASSISTANT, std::move(parts)));
+  response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+
+  auto result = BuildResponse(response, "id", 0, "m");
+
+  ASSERT_EQ(result.choices.size(), 1u);
+  ASSERT_TRUE(result.choices[0].message.reasoning_content.has_value());
+  EXPECT_EQ(*result.choices[0].message.reasoning_content, "deep thought");
+  // Visible content should be empty
+  ASSERT_TRUE(result.choices[0].message.content.has_value());
+  EXPECT_TRUE(result.choices[0].message.content->empty());
+}
+
+TEST(ChatCompletionsConverterTest, BuildResponse_InterleavedReasoningPopulatesBothFields) {
+  Response response;
+  std::vector<std::unique_ptr<Item>> parts;
+  parts.push_back(std::make_unique<TextItem>("think A", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING));
+  parts.push_back(std::make_unique<TextItem>("visible A", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT));
+  parts.push_back(std::make_unique<TextItem>("think B", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING));
+  parts.push_back(std::make_unique<TextItem>(" visible B", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT));
+  response.items.push_back(
+      std::make_unique<MessageItem>(FOUNDRY_LOCAL_ROLE_ASSISTANT, std::move(parts)));
+  response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+
+  auto result = BuildResponse(response, "id", 0, "m");
+
+  ASSERT_EQ(result.choices.size(), 1u);
+  ASSERT_TRUE(result.choices[0].message.content.has_value());
+  EXPECT_EQ(*result.choices[0].message.content, "visible A visible B");
+  ASSERT_TRUE(result.choices[0].message.reasoning_content.has_value());
+  EXPECT_EQ(*result.choices[0].message.reasoning_content, "think Athink B");
+}
+
+TEST(ChatCompletionsConverterTest, BuildResponse_ReasoningAndToolCallPopulateBothFields) {
+  Response response;
+  std::vector<std::unique_ptr<Item>> parts;
+  parts.push_back(std::make_unique<TextItem>("choose a tool", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING));
+  response.items.push_back(
+      std::make_unique<MessageItem>(FOUNDRY_LOCAL_ROLE_ASSISTANT, std::move(parts)));
+  response.items.push_back(std::make_unique<ToolCallItem>("call_1", "search", R"({"query":"term"})"));
+  response.finish_reason = FOUNDRY_LOCAL_FINISH_TOOL_CALLS;
+
+  auto result = BuildResponse(response, "id", 0, "m");
+
+  ASSERT_EQ(result.choices.size(), 1u);
+  ASSERT_TRUE(result.choices[0].message.reasoning_content.has_value());
+  EXPECT_EQ(*result.choices[0].message.reasoning_content, "choose a tool");
+  ASSERT_TRUE(result.choices[0].message.tool_calls.has_value());
+  ASSERT_EQ(result.choices[0].message.tool_calls->size(), 1u);
+  EXPECT_EQ(result.choices[0].message.tool_calls->front().function.name, "search");
+  EXPECT_EQ(result.choices[0].finish_reason, "tool_calls");
+}
+
+TEST(ChatCompletionsConverterTest, BuildResponse_NoReasoningOmitsReasoningContent) {
+  Response response;
+  response.items.push_back(
+      std::make_unique<MessageItem>(FOUNDRY_LOCAL_ROLE_ASSISTANT, "plain text"));
+  response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+
+  auto result = BuildResponse(response, "id", 0, "m");
+
+  ASSERT_EQ(result.choices.size(), 1u);
+  EXPECT_FALSE(result.choices[0].message.reasoning_content.has_value());
+  ASSERT_TRUE(result.choices[0].message.content.has_value());
+  EXPECT_EQ(*result.choices[0].message.content, "plain text");
+
+  // Verify JSON output omits reasoning_content
+  json j = result;
+  EXPECT_FALSE(j["choices"][0]["message"].contains("reasoning_content"));
+}
+
+TEST(ChatCompletionsConverterTest, BuildResponse_ReasoningContentSerializesInJson) {
+  Response response;
+  std::vector<std::unique_ptr<Item>> parts;
+  parts.push_back(std::make_unique<TextItem>("reasoning here", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING));
+  parts.push_back(std::make_unique<TextItem>("answer here", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT));
+  response.items.push_back(
+      std::make_unique<MessageItem>(FOUNDRY_LOCAL_ROLE_ASSISTANT, std::move(parts)));
+  response.finish_reason = FOUNDRY_LOCAL_FINISH_STOP;
+
+  auto result = BuildResponse(response, "chatcmpl-r1", 1000, "reasoning-model");
+  json j = result;
+
+  EXPECT_EQ(j["choices"][0]["message"]["content"], "answer here");
+  EXPECT_EQ(j["choices"][0]["message"]["reasoning_content"], "reasoning here");
+}
+
+// ========================================================================
+// FormatReasoningStreamingChunk
+// ========================================================================
+
+TEST(ChatCompletionsConverterTest, FormatReasoningStreamingChunk_ContainsDeltaReasoningContent) {
+  std::string chunk_json = FormatReasoningStreamingChunk("step 1", "chatcmpl-r1", 1000, "reasoning-model");
+
+  auto parsed = json::parse(chunk_json);
+  EXPECT_EQ(parsed["id"], "chatcmpl-r1");
+  EXPECT_EQ(parsed["created"], 1000);
+  EXPECT_EQ(parsed["model"], "reasoning-model");
+  EXPECT_EQ(parsed["object"], "chat.completion.chunk");
+  ASSERT_EQ(parsed["choices"].size(), 1u);
+  EXPECT_EQ(parsed["choices"][0]["delta"]["reasoning_content"], "step 1");
+  EXPECT_FALSE(parsed["choices"][0]["delta"].contains("content"));
+}
+
+TEST(ChatCompletionsConverterTest, FormatReasoningStreamingChunk_DoesNotContainContent) {
+  std::string chunk_json = FormatReasoningStreamingChunk("thinking", "id", 0, "m");
+
+  auto parsed = json::parse(chunk_json);
+  const auto& delta = parsed["choices"][0]["delta"];
+  EXPECT_TRUE(delta.contains("reasoning_content"));
+  EXPECT_FALSE(delta.contains("content"));
+  EXPECT_FALSE(delta.contains("role"));
+}

--- a/sdk_v2/cpp/test/internal_api/chat_completions_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat_completions_test.cc
@@ -524,3 +524,65 @@ TEST(ChatCompletionStreamingTest, ChunkWithUsage) {
   EXPECT_EQ(j["usage"]["total_tokens"], 15);
   EXPECT_EQ(j["usage"]["completion_tokens_details"]["reasoning_tokens"], 2);
 }
+
+// ========================================================================
+// reasoning_content serialization
+// ========================================================================
+
+TEST(ChatCompletionResponseTest, ResponseMessageWithReasoningContent) {
+  ChatCompletionResponseMessage msg;
+  msg.content = "The answer is 42.";
+  msg.reasoning_content = "Let me think step by step...";
+
+  json j = msg;
+  EXPECT_EQ(j["content"], "The answer is 42.");
+  EXPECT_EQ(j["reasoning_content"], "Let me think step by step...");
+  EXPECT_TRUE(j["refusal"].is_null());
+}
+
+TEST(ChatCompletionResponseTest, ResponseMessageOmitsReasoningContentWhenAbsent) {
+  ChatCompletionResponseMessage msg;
+  msg.content = "Hello!";
+  // reasoning_content left as nullopt
+
+  json j = msg;
+  EXPECT_EQ(j["content"], "Hello!");
+  EXPECT_FALSE(j.contains("reasoning_content"));
+}
+
+TEST(ChatCompletionStreamingTest, DeltaWithReasoningContent) {
+  ChatCompletionDelta delta;
+  delta.reasoning_content = "thinking...";
+
+  json j = delta;
+  EXPECT_EQ(j["reasoning_content"], "thinking...");
+  EXPECT_FALSE(j.contains("content"));
+  EXPECT_FALSE(j.contains("role"));
+}
+
+TEST(ChatCompletionStreamingTest, DeltaOmitsReasoningContentWhenAbsent) {
+  ChatCompletionDelta delta;
+  delta.content = "visible text";
+
+  json j = delta;
+  EXPECT_EQ(j["content"], "visible text");
+  EXPECT_FALSE(j.contains("reasoning_content"));
+}
+
+TEST(ChatCompletionStreamingTest, DeltaDoesNotMixReasoningAndContent) {
+  // Verify that setting only reasoning_content does not produce a content field
+  ChatCompletionDelta delta;
+  delta.reasoning_content = "step 1";
+
+  json j = delta;
+  EXPECT_TRUE(j.contains("reasoning_content"));
+  EXPECT_FALSE(j.contains("content"));
+
+  // And vice versa
+  ChatCompletionDelta delta2;
+  delta2.content = "result";
+
+  json j2 = delta2;
+  EXPECT_TRUE(j2.contains("content"));
+  EXPECT_FALSE(j2.contains("reasoning_content"));
+}

--- a/sdk_v2/cpp/test/internal_api/chat_completions_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat_completions_test.cc
@@ -516,9 +516,11 @@ TEST(ChatCompletionStreamingTest, ChunkWithUsage) {
   usage.prompt_tokens = 5;
   usage.completion_tokens = 10;
   usage.total_tokens = 15;
+  usage.completion_tokens_details.reasoning_tokens = 2;
   chunk.usage = usage;
 
   json j = chunk;
   ASSERT_TRUE(j.contains("usage"));
   EXPECT_EQ(j["usage"]["total_tokens"], 15);
+  EXPECT_EQ(j["usage"]["completion_tokens_details"]["reasoning_tokens"], 2);
 }

--- a/sdk_v2/cpp/test/internal_api/response_converter_test.cc
+++ b/sdk_v2/cpp/test/internal_api/response_converter_test.cc
@@ -15,6 +15,7 @@
 #include "items/image_item.h"
 #include "items/message_item.h"
 #include "items/text_item.h"
+#include "items/tool_call_item.h"
 
 using namespace fl;
 using namespace fl::responses;
@@ -38,6 +39,90 @@ static ResponseCreateParams MakeTestParams() {
   params.metadata["key1"] = "value1";
   params.user = "test-user";
   return params;
+}
+
+TEST(ResponseConverterTest, FromSessionResponse_ReasoningOnlyMessageIsNotOutputText) {
+  Response response;
+  std::vector<std::unique_ptr<Item>> parts;
+  parts.push_back(std::make_unique<TextItem>("private scratchpad", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING));
+  response.items.push_back(
+      std::make_unique<MessageItem>(FOUNDRY_LOCAL_ROLE_ASSISTANT, std::move(parts)));
+
+  auto [output, output_text] = FromSessionResponse(response, "msg");
+
+  ASSERT_EQ(output.size(), 1u);
+  ASSERT_TRUE(std::holds_alternative<ReasoningOutputItem>(output.front()));
+  EXPECT_EQ(std::get<ReasoningOutputItem>(output.front()).summary.front().text, "private scratchpad");
+  EXPECT_TRUE(output_text.empty());
+}
+
+TEST(ResponseConverterTest, FromSessionResponse_InterleavedReasoningPreservesOutputOrder) {
+  Response response;
+  std::vector<std::unique_ptr<Item>> parts;
+  parts.push_back(std::make_unique<TextItem>("think one", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING));
+  parts.push_back(std::make_unique<TextItem>("answer one", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT));
+  parts.push_back(std::make_unique<TextItem>("think two", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_REASONING));
+  parts.push_back(std::make_unique<TextItem>("answer two", FOUNDRY_LOCAL_TEXT_ITEM_TYPE_DEFAULT));
+  response.items.push_back(std::make_unique<MessageItem>(FOUNDRY_LOCAL_ROLE_ASSISTANT, std::move(parts)));
+
+  auto [output, output_text] = FromSessionResponse(response, "msg");
+
+  ASSERT_EQ(output.size(), 4u);
+  EXPECT_TRUE(std::holds_alternative<ReasoningOutputItem>(output[0]));
+  EXPECT_TRUE(std::holds_alternative<ResponseOutputMessage>(output[1]));
+  EXPECT_TRUE(std::holds_alternative<ReasoningOutputItem>(output[2]));
+  EXPECT_TRUE(std::holds_alternative<ResponseOutputMessage>(output[3]));
+  EXPECT_EQ(output_text, "answer oneanswer two");
+}
+
+TEST(ResponseConverterTest, BuildFunctionCallStreamOutputEmitsCompleteLifecycle) {
+  ToolCallItem call("call_test", "get_weather", R"({"city":"Seattle"})");
+  int sequence_number = 7;
+
+  auto output = BuildFunctionCallStreamOutput(call, 3, sequence_number);
+
+  ASSERT_EQ(output.events.size(), 4u);
+  EXPECT_EQ(sequence_number, 11);
+
+  const auto& added = output.events[0];
+  EXPECT_EQ(added.type, StreamEventType::kOutputItemAdded);
+  EXPECT_EQ(added.sequence_number, 7);
+  EXPECT_EQ(added.output_index, 3);
+  ASSERT_TRUE(added.item.has_value());
+  const auto& added_item = std::get<FunctionCallOutputItem>(*added.item);
+  EXPECT_EQ(added_item.id, output.completed_item.id);
+  EXPECT_EQ(added_item.call_id, "call_test");
+  EXPECT_EQ(added_item.name, "get_weather");
+  EXPECT_TRUE(added_item.arguments.empty());
+  EXPECT_EQ(added_item.status, ResponseStatus::kInProgress);
+
+  const auto& delta = output.events[1];
+  EXPECT_EQ(delta.type, StreamEventType::kFunctionCallArgumentsDelta);
+  EXPECT_EQ(delta.sequence_number, 8);
+  EXPECT_EQ(delta.output_index, 3);
+  EXPECT_EQ(delta.item_id, output.completed_item.id);
+  EXPECT_EQ(delta.delta, R"({"city":"Seattle"})");
+  EXPECT_EQ(delta.function_call_id, "call_test");
+
+  const auto& arguments_done = output.events[2];
+  EXPECT_EQ(arguments_done.type, StreamEventType::kFunctionCallArgumentsDone);
+  EXPECT_EQ(arguments_done.sequence_number, 9);
+  EXPECT_EQ(arguments_done.output_index, 3);
+  EXPECT_EQ(arguments_done.item_id, output.completed_item.id);
+  EXPECT_EQ(arguments_done.function_name, "get_weather");
+  EXPECT_EQ(arguments_done.function_call_id, "call_test");
+  EXPECT_EQ(arguments_done.function_arguments, R"({"city":"Seattle"})");
+
+  const auto& item_done = output.events[3];
+  EXPECT_EQ(item_done.type, StreamEventType::kOutputItemDone);
+  EXPECT_EQ(item_done.sequence_number, 10);
+  EXPECT_EQ(item_done.output_index, 3);
+  ASSERT_TRUE(item_done.item.has_value());
+  const auto& completed_item = std::get<FunctionCallOutputItem>(*item_done.item);
+  EXPECT_EQ(completed_item.arguments, R"({"city":"Seattle"})");
+  EXPECT_EQ(completed_item.status, ResponseStatus::kCompleted);
+  EXPECT_EQ(output.completed_item.arguments, R"({"city":"Seattle"})");
+  EXPECT_EQ(output.completed_item.status, ResponseStatus::kCompleted);
 }
 
 // ========================================================================

--- a/sdk_v2/cpp/test/internal_api/response_store_test.cc
+++ b/sdk_v2/cpp/test/internal_api/response_store_test.cc
@@ -191,7 +191,7 @@ TEST(ResponseConverterTest, BuildResponseObjectHasRequiredFields) {
   msg.content.push_back(OutputTextContent{"hello"});
   output.push_back(msg);
 
-  TokenUsage usage{10, 5, 15};
+  TokenUsage usage{10, 5, 15, 2};
 
   auto typed = ResponseConverter::BuildResponseObject(
       "resp_123", 1700000000, "test-model", params,
@@ -213,6 +213,7 @@ TEST(ResponseConverterTest, BuildResponseObjectHasRequiredFields) {
   // Usage
   EXPECT_EQ(response["usage"]["input_tokens"], 10);
   EXPECT_EQ(response["usage"]["output_tokens"], 5);
+  EXPECT_EQ(response["usage"]["output_tokens_details"]["reasoning_tokens"], 2);
   EXPECT_EQ(response["usage"]["total_tokens"], 15);
 }
 

--- a/sdk_v2/cpp/test/internal_api/toolcalling/tool_call_stream_accumulator_test.cc
+++ b/sdk_v2/cpp/test/internal_api/toolcalling/tool_call_stream_accumulator_test.cc
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -16,14 +17,29 @@ using namespace fl;
 
 namespace {
 
-// Concatenate the visible_text from a sequence of Push results — handy for asserting that "what came through
-// the visible channel" equals what we'd have produced without tool-call extraction.
+// Concatenate text events from a sequence of Push results.
 std::string CollectVisible(const std::vector<ToolCallStreamAccumulator::Output>& outs) {
   std::string s;
   for (const auto& o : outs) {
-    s += o.visible_text;
+    for (const auto& event : o.events) {
+      if (const auto* text = std::get_if<std::string>(&event)) {
+        s += *text;
+      }
+    }
   }
   return s;
+}
+
+std::vector<ParsedToolCall> CollectCalls(std::vector<ToolCallStreamAccumulator::Output>& outs) {
+  std::vector<ParsedToolCall> calls;
+  for (auto& output : outs) {
+    for (auto& event : output.events) {
+      if (auto* call = std::get_if<ParsedToolCall>(&event)) {
+        calls.push_back(std::move(*call));
+      }
+    }
+  }
+  return calls;
 }
 
 // Run a sequence of chunks through the accumulator, calling Flush at the end. Returns one Output per chunk plus
@@ -48,16 +64,15 @@ std::vector<ToolCallStreamAccumulator::Output> RunChunks(ToolCallStreamAccumulat
 TEST(ToolCallStreamAccumulatorTest, EmptyMarkersIsPassthrough) {
   ToolCallStreamAccumulator acc("", "");
   auto out = acc.Push("any text including <tool_call> markers");
-  EXPECT_EQ(out.visible_text, "any text including <tool_call> markers");
-  EXPECT_TRUE(out.ready_calls.empty());
+  ASSERT_EQ(out.events.size(), 1u);
+  EXPECT_EQ(std::get<std::string>(out.events[0]), "any text including <tool_call> markers");
   EXPECT_FALSE(acc.InsideToolCall());
 }
 
 TEST(ToolCallStreamAccumulatorTest, EmptyChunkProducesNothing) {
   ToolCallStreamAccumulator acc("<tool_call>", "</tool_call>");
   auto out = acc.Push("");
-  EXPECT_TRUE(out.visible_text.empty());
-  EXPECT_TRUE(out.ready_calls.empty());
+  EXPECT_TRUE(out.events.empty());
 }
 
 // ========================================================================
@@ -69,7 +84,9 @@ TEST(ToolCallStreamAccumulatorTest, PlainTextPassesThroughVerbatim) {
   auto outs = RunChunks(acc, {"Hello", ", ", "world!"});
   EXPECT_EQ(CollectVisible(outs), "Hello, world!");
   for (const auto& o : outs) {
-    EXPECT_TRUE(o.ready_calls.empty());
+    EXPECT_TRUE(std::none_of(o.events.begin(), o.events.end(), [](const auto& event) {
+      return std::holds_alternative<ParsedToolCall>(event);
+    }));
   }
 }
 
@@ -84,8 +101,10 @@ TEST(ToolCallStreamAccumulatorTest, SingleToolCallInOneChunk) {
   auto outs = RunChunks(acc, {chunk});
 
   EXPECT_EQ(CollectVisible(outs), "prefix  suffix");
-  ASSERT_EQ(outs[0].ready_calls.size(), 1u);
-  EXPECT_EQ(outs[0].ready_calls[0].name, "add");
+  ASSERT_EQ(outs[0].events.size(), 3u);
+  EXPECT_EQ(std::get<std::string>(outs[0].events[0]), "prefix ");
+  EXPECT_EQ(std::get<ParsedToolCall>(outs[0].events[1]).name, "add");
+  EXPECT_EQ(std::get<std::string>(outs[0].events[2]), " suffix");
 }
 
 TEST(ToolCallStreamAccumulatorTest, SingleToolCallSplitAcrossManyChunks) {
@@ -108,13 +127,7 @@ TEST(ToolCallStreamAccumulatorTest, SingleToolCallSplitAcrossManyChunks) {
   EXPECT_EQ(CollectVisible(outs), "before  after")
       << "Marker and JSON bytes must not leak into visible text";
 
-  // Find the tool call across whichever Push produced it (it should be the one that completed the end marker).
-  std::vector<ParsedToolCall> all;
-  for (auto& o : outs) {
-    for (auto& pc : o.ready_calls) {
-      all.push_back(std::move(pc));
-    }
-  }
+  auto all = CollectCalls(outs);
   ASSERT_EQ(all.size(), 1u);
   EXPECT_EQ(all[0].name, "mul");
   EXPECT_NE(all[0].arguments.find("7"), std::string::npos);
@@ -135,12 +148,7 @@ TEST(ToolCallStreamAccumulatorTest, MarkerByteByByte) {
 
   EXPECT_TRUE(CollectVisible(outs).empty()) << "Single tool-call block with no surrounding text produces no visible";
 
-  std::vector<ParsedToolCall> all;
-  for (auto& o : outs) {
-    for (auto& pc : o.ready_calls) {
-      all.push_back(std::move(pc));
-    }
-  }
+  auto all = CollectCalls(outs);
   ASSERT_EQ(all.size(), 1u);
   EXPECT_EQ(all[0].name, "f");
 }
@@ -158,12 +166,7 @@ TEST(ToolCallStreamAccumulatorTest, TwoSequentialToolCalls) {
 
   EXPECT_EQ(CollectVisible(outs), " middle ");
 
-  std::vector<ParsedToolCall> all;
-  for (auto& o : outs) {
-    for (auto& pc : o.ready_calls) {
-      all.push_back(std::move(pc));
-    }
-  }
+  auto all = CollectCalls(outs);
   ASSERT_EQ(all.size(), 2u);
   EXPECT_EQ(all[0].name, "a");
   EXPECT_EQ(all[1].name, "b");
@@ -194,10 +197,29 @@ TEST(ToolCallStreamAccumulatorTest, UnterminatedToolCallBecomesVisibleOnFlush) {
 
   // No tool call should have been emitted — the block never closed.
   for (const auto& o : outs) {
-    EXPECT_TRUE(o.ready_calls.empty());
+    EXPECT_TRUE(std::none_of(o.events.begin(), o.events.end(), [](const auto& event) {
+      return std::holds_alternative<ParsedToolCall>(event);
+    }));
   }
 
   EXPECT_FALSE(acc.InsideToolCall()) << "Flush should leave accumulator in outside state";
+}
+
+TEST(ToolCallStreamAccumulatorTest, CompletedMalformedToolCallBecomesVisible) {
+  ToolCallStreamAccumulator acc("<tool_call>", "</tool_call>");
+  auto outs = RunChunks(acc, {"before <tool_call>not json</tool_call> after"});
+
+  EXPECT_EQ(CollectVisible(outs), "before <tool_call>not json</tool_call> after");
+  EXPECT_TRUE(CollectCalls(outs).empty());
+}
+
+TEST(ToolCallStreamAccumulatorTest, CompletedToolCallWithoutNameBecomesVisible) {
+  ToolCallStreamAccumulator acc("<tool_call>", "</tool_call>");
+  const std::string generated = R"(<tool_call>{"arguments":{"value":1}}</tool_call>)";
+  auto outs = RunChunks(acc, {generated});
+
+  EXPECT_EQ(CollectVisible(outs), generated);
+  EXPECT_TRUE(CollectCalls(outs).empty());
 }
 
 // ========================================================================
@@ -228,11 +250,12 @@ TEST(ToolCallStreamAccumulatorTest, FalseStartPrefixReleasesAfterDisambiguation)
 
   // First chunk ends with "<tool" — a real prefix of the start marker. The accumulator must hold it back.
   auto out1 = acc.Push("hello <tool");
-  EXPECT_EQ(out1.visible_text, "hello ");
+  ASSERT_EQ(out1.events.size(), 1u);
+  EXPECT_EQ(std::get<std::string>(out1.events[0]), "hello ");
 
   // Next chunk reveals the prefix was actually part of unrelated XML-ish text. The held-back "<tool" plus the new
   // bytes must flow out as visible.
   auto out2 = acc.Push("box>");
-  EXPECT_EQ(out2.visible_text, "<toolbox>");
-  EXPECT_TRUE(out2.ready_calls.empty());
+  ASSERT_EQ(out2.events.size(), 1u);
+  EXPECT_EQ(std::get<std::string>(out2.events[0]), "<toolbox>");
 }

--- a/sdk_v2/cpp/test/internal_api/toolcalling/tool_call_stream_accumulator_test.cc
+++ b/sdk_v2/cpp/test/internal_api/toolcalling/tool_call_stream_accumulator_test.cc
@@ -222,6 +222,26 @@ TEST(ToolCallStreamAccumulatorTest, CompletedToolCallWithoutNameBecomesVisible) 
   EXPECT_TRUE(CollectCalls(outs).empty());
 }
 
+TEST(ToolCallStreamAccumulatorTest, CompletedToolCallWithNonStringNameBecomesVisible) {
+  ToolCallStreamAccumulator acc("<tool_call>", "</tool_call>");
+  const std::string generated = R"(<tool_call>{"name":123,"arguments":{}}</tool_call>)";
+  auto outs = RunChunks(acc, {generated});
+
+  EXPECT_EQ(CollectVisible(outs), generated);
+  EXPECT_TRUE(CollectCalls(outs).empty());
+}
+
+TEST(ToolCallStreamAccumulatorTest, CompletedMixedValidAndInvalidArrayBecomesVisible) {
+  ToolCallStreamAccumulator acc("<tool_call>", "</tool_call>");
+  const std::string generated =
+      R"(<tool_call>[{"name":"fn1","arguments":{}},{"name":123}]</tool_call>)";
+  auto outs = RunChunks(acc, {"before ", generated, " after"});
+
+  EXPECT_EQ(CollectVisible(outs), "before " + generated + " after")
+      << "A partially-invalid block must be preserved whole, not partially parsed";
+  EXPECT_TRUE(CollectCalls(outs).empty());
+}
+
 // ========================================================================
 // InsideToolCall state machine.
 // ========================================================================

--- a/sdk_v2/cpp/test/internal_api/toolcalling/tool_call_utils_test.cc
+++ b/sdk_v2/cpp/test/internal_api/toolcalling/tool_call_utils_test.cc
@@ -133,6 +133,78 @@ TEST(ParseToolCallsTest, StringArguments) {
 }
 
 // ========================================================================
+// Atomic validation: malformed shape/type in any item rejects the whole block.
+// ========================================================================
+
+TEST(ParseToolCallsTest, NumericNameReturnsEmpty) {
+  std::string text = R"(<tc>{"name":123,"arguments":{}}</tc>)";
+  auto calls = ParseToolCalls(text, "<tc>", "</tc>");
+
+  EXPECT_TRUE(calls.empty());
+}
+
+TEST(ParseToolCallsTest, NullNameReturnsEmpty) {
+  std::string text = R"(<tc>{"name":null,"arguments":{}}</tc>)";
+  auto calls = ParseToolCalls(text, "<tc>", "</tc>");
+
+  EXPECT_TRUE(calls.empty());
+}
+
+TEST(ParseToolCallsTest, ObjectNameReturnsEmpty) {
+  std::string text = R"(<tc>{"name":{"first":"fn"},"arguments":{}}</tc>)";
+  auto calls = ParseToolCalls(text, "<tc>", "</tc>");
+
+  EXPECT_TRUE(calls.empty());
+}
+
+TEST(ParseToolCallsTest, EmptyStringNameReturnsEmpty) {
+  std::string text = R"(<tc>{"name":"","arguments":{}}</tc>)";
+  auto calls = ParseToolCalls(text, "<tc>", "</tc>");
+
+  EXPECT_TRUE(calls.empty());
+}
+
+TEST(ParseToolCallsTest, NonObjectArrayElementReturnsEmpty) {
+  std::string text = R"(<tc>[{"name":"fn1"},123]</tc>)";
+  auto calls = ParseToolCalls(text, "<tc>", "</tc>");
+
+  EXPECT_TRUE(calls.empty());
+}
+
+TEST(ParseToolCallsTest, MixedValidAndInvalidArrayReturnsEmpty) {
+  std::string text = R"(<tc>[{"name":"fn1","arguments":{}},{"name":123}]</tc>)";
+  auto calls = ParseToolCalls(text, "<tc>", "</tc>");
+
+  EXPECT_TRUE(calls.empty());
+}
+
+TEST(ParseToolCallsTest, MixedValidAndMissingNameArrayReturnsEmpty) {
+  std::string text = R"(<tc>[{"name":"fn1"},{"arguments":{"x":1}}]</tc>)";
+  auto calls = ParseToolCalls(text, "<tc>", "</tc>");
+
+  EXPECT_TRUE(calls.empty());
+}
+
+TEST(ParseToolCallsTest, ValidSingleObjectStillAccepted) {
+  std::string text = R"(<tc>{"name":"fn","arguments":{"x":1}}</tc>)";
+  auto calls = ParseToolCalls(text, "<tc>", "</tc>");
+
+  ASSERT_EQ(calls.size(), 1u);
+  EXPECT_EQ(calls[0].name, "fn");
+  EXPECT_FALSE(calls[0].id.empty());
+}
+
+TEST(ParseToolCallsTest, ValidArrayOfMultipleObjectsStillAccepted) {
+  std::string text =
+      R"(<tc>[{"name":"fn1","arguments":{}},{"name":"fn2","arguments":{"x":1}}]</tc>)";
+  auto calls = ParseToolCalls(text, "<tc>", "</tc>");
+
+  ASSERT_EQ(calls.size(), 2u);
+  EXPECT_EQ(calls[0].name, "fn1");
+  EXPECT_EQ(calls[1].name, "fn2");
+}
+
+// ========================================================================
 // ToolCallsToItems tests
 // ========================================================================
 

--- a/sdk_v2/cpp/test/sdk_api/chat_completions_from_json.cc
+++ b/sdk_v2/cpp/test/sdk_api/chat_completions_from_json.cc
@@ -46,6 +46,7 @@ void from_json(const nlohmann::json& j, ChatCompletionToolCall& tc) {
 void from_json(const nlohmann::json& j, ChatCompletionResponseMessage& m) {
   m.role = j.value("role", std::string("assistant"));
   opt_str(j, "content", m.content);
+  opt_str(j, "reasoning_content", m.reasoning_content);
   opt_str(j, "refusal", m.refusal);
   opt(j, "tool_calls", m.tool_calls);
 }
@@ -69,6 +70,7 @@ void from_json(const nlohmann::json& j, ChatCompletionResponse& r) {
 void from_json(const nlohmann::json& j, ChatCompletionDelta& d) {
   opt_str(j, "role", d.role);
   opt_str(j, "content", d.content);
+  opt_str(j, "reasoning_content", d.reasoning_content);
   opt(j, "tool_calls", d.tool_calls);
 }
 

--- a/sdk_v2/cpp/test/sdk_api/reasoning_model_test.cc
+++ b/sdk_v2/cpp/test/sdk_api/reasoning_model_test.cc
@@ -15,7 +15,10 @@
 //   * Reasoning text must be exposed on at least one turn — the model's chain-of-thought is now first-class output.
 //   * Multi-turn correctness is validated by finish reason and structural properties (turn count, usage), not by
 //     exact-string answer matching, because reasoning models often paraphrase rather than echo.
-#include "model_fixture.h"
+#include "chat_completions_from_json.h"
+#include "web_service_fixture.h"
+
+#include <sstream>
 
 namespace {
 
@@ -33,6 +36,23 @@ bool ContainsCaseInsensitive(const std::string& haystack, const std::string& nee
 }
 
 }  // namespace
+
+class ReasoningWebServiceFixture : public WebServiceFixture {
+ protected:
+  static void SetUpTestSuite() {
+    SharedTestEnv::Get().AcquireModels({SharedTestEnv::Modality::Reasoning});
+  }
+
+  void SetUp() override {
+    if (!SharedTestEnv::Get().reasoning_model()) {
+      GTEST_SKIP() << "No reasoning model available";
+    }
+  }
+
+  static const std::string& model_id() {
+    return SharedTestEnv::Get().reasoning_model_id();
+  }
+};
 
 // Single-turn: reasoning model produces a non-empty visible answer plus exposed reasoning content.
 TEST_F(ReasoningFixture, SingleTurnStripsThinkBlock) {
@@ -70,6 +90,93 @@ TEST_F(ReasoningFixture, SingleTurnStripsThinkBlock) {
 
   std::cout << "Reasoning single-turn visible: " << visible << "\n";
   std::cout << "Reasoning single-turn thoughts: " << reasoning << "\n";
+}
+
+TEST_F(ReasoningWebServiceFixture, ChatCompletionsReturnsReasoningContent) {
+  auto client = MakeClient(180);
+  json request_body = {
+      {"model", model_id()},
+      {"messages", json::array({
+                       {{"role", "user"}, {"content", "What is 2+2? Answer with just the number."}},
+                   })},
+      {"temperature", 0},
+      {"max_tokens", 1024},
+  };
+
+  auto result = client.Post("/v1/chat/completions", request_body.dump(), "application/json");
+  ASSERT_TRUE(result) << "HTTP request failed: " << httplib::to_string(result.error());
+  ASSERT_EQ(result->status, 200) << result->body;
+
+  auto response = json::parse(result->body).get<fl::ChatCompletionResponse>();
+  ASSERT_EQ(response.choices.size(), 1u);
+  const auto& message = response.choices[0].message;
+  ASSERT_TRUE(message.reasoning_content.has_value());
+  EXPECT_FALSE(message.reasoning_content->empty());
+  ASSERT_TRUE(message.content.has_value());
+  EXPECT_FALSE(message.content->empty());
+  EXPECT_EQ(message.content->find("<think>"), std::string::npos);
+  EXPECT_GT(response.usage.completion_tokens_details.reasoning_tokens, 0);
+}
+
+TEST_F(ReasoningWebServiceFixture, ChatCompletionsStreamsReasoningContent) {
+  auto client = MakeClient(180);
+  json request_body = {
+      {"model", model_id()},
+      {"messages", json::array({
+                       {{"role", "user"}, {"content", "What is 2+2? Answer with just the number."}},
+                   })},
+      {"temperature", 0},
+      {"max_tokens", 1024},
+      {"stream", true},
+      {"stream_options", {{"include_usage", true}}},
+  };
+
+  auto result = client.Post("/v1/chat/completions", request_body.dump(), "application/json");
+  ASSERT_TRUE(result) << "HTTP request failed: " << httplib::to_string(result.error());
+  ASSERT_EQ(result->status, 200) << result->body;
+
+  std::string reasoning;
+  std::string content;
+  bool got_done = false;
+  bool got_reasoning_usage = false;
+  std::istringstream stream(result->body);
+  std::string line;
+  while (std::getline(stream, line)) {
+    if (!line.empty() && line.back() == '\r') {
+      line.pop_back();
+    }
+    if (line.rfind("data: ", 0) != 0) {
+      continue;
+    }
+
+    auto data = line.substr(6);
+    if (data == "[DONE]") {
+      got_done = true;
+      break;
+    }
+
+    auto chunk = json::parse(data).get<fl::ChatCompletionChunk>();
+    if (chunk.usage.has_value()) {
+      got_reasoning_usage =
+          chunk.usage->completion_tokens_details.reasoning_tokens > 0;
+    }
+    for (const auto& choice : chunk.choices) {
+      const auto& delta = choice.delta;
+      EXPECT_FALSE(delta.reasoning_content.has_value() && delta.content.has_value());
+      if (delta.reasoning_content.has_value()) {
+        reasoning += *delta.reasoning_content;
+      }
+      if (delta.content.has_value()) {
+        content += *delta.content;
+      }
+    }
+  }
+
+  EXPECT_TRUE(got_done);
+  EXPECT_FALSE(reasoning.empty());
+  EXPECT_FALSE(content.empty());
+  EXPECT_EQ(content.find("<think>"), std::string::npos);
+  EXPECT_TRUE(got_reasoning_usage);
 }
 
 // Multi-turn: continuous decoding through a reasoning model must not crash and must produce non-empty visible output


### PR DESCRIPTION
## Summary

Adds token-aware reasoning classification and exposes reasoning separately from visible output across Chat Completions and Responses.

Reasoning boundaries are detected from ORT GenAI BOR/EOR token metadata before detokenization, which handles special markers that decode to empty strings. Decoded marker matching remains as a compatibility fallback.

## Changes

- Classifies generated output into ordered reasoning and visible-text segments using token IDs.
- Supports empty-decoded special markers, multi-token markers, decoded-text fallback, truncated reasoning, and incomplete marker metadata.
- Excludes reasoning boundary tokens and EOS/control tokens from reasoning-token usage.
- Prevents tool-call-shaped reasoning from being interpreted as a real tool call.
- Preserves generation order across reasoning, visible text, and structured tool calls.
- Returns non-streaming Chat Completions reasoning through `message.reasoning_content`.
- Streams Chat Completions reasoning through `delta.reasoning_content` while keeping visible output in `delta.content`.
- Emits typed reasoning output items and events through Responses.
- Reports reasoning tokens through Chat Completions and Responses usage details.
- Emits the complete Responses function-call streaming lifecycle, including argument delta and done events.
- Preserves malformed marker-wrapped tool output as visible text instead of dropping it.
- Preserves an assistant history boundary after reasoning-only turns.

## API behavior

Reasoning-capable Chat Completions responses may contain both `message.reasoning_content` and visible `message.content`.

Streaming chunks contain either `delta.reasoning_content` or `delta.content`, never both. Models that do not produce reasoning omit `reasoning_content`.

The field is compatible with GitHub Copilot CLI and DeepSeek-style Chat Completions clients. GitHub Copilot CLI consumes it as separate reasoning events without mixing it into visible assistant output.

## Validation

- Canonical Linux Release build succeeds.
- Focused reasoning, Chat Completions, Responses, tool-call, history, and serialization tests pass: 175/175.
- Live Qwen3 HTTP tests pass for streaming and non-streaming reasoning output.
- GitHub Copilot CLI BYOK parses `reasoning_content` into separate reasoning timeline events while visible output remains in `content`.
- Full unit validation passes apart from existing model-cache fixtures that require `FOUNDRY_TEST_DATA_DIR`.
- Independent correctness, API, quality, and test reviews completed with no remaining material findings.