### PR TITLE
Fix Rust SDK NuGet source configuration

### DIFF
--- a/sdk_v2/rust/Cargo.toml
+++ b/sdk_v2/rust/Cargo.toml
@@ -8,7 +8,15 @@ description = "Local AI model inference powered by the Foundry Local Core engine
 homepage = "https://www.foundrylocal.ai/"
 repository = "https://github.com/microsoft/Foundry-Local"
 documentation = "https://github.com/microsoft/Foundry-Local/blob/main/sdk_v2/rust/docs/api.md"
-include = ["src/**", "build.rs", "Cargo.toml", "README.md", "LICENSE.txt", "deps_versions.json"]
+include = [
+    "src/**",
+    "build.rs",
+    "build_support.rs",
+    "Cargo.toml",
+    "README.md",
+    "LICENSE.txt",
+    "deps_versions.json",
+]
 
 # docs.rs builds the documentation in an offline sandbox. The build script skips
 # native acquisition when DOCS_RS is set (see build.rs), so the hosted docs build

--- a/sdk_v2/rust/Cargo.toml
+++ b/sdk_v2/rust/Cargo.toml
@@ -12,6 +12,7 @@ include = [
     "src/**",
     "build.rs",
     "build_support.rs",
+    "http_extract.rs",
     "Cargo.toml",
     "README.md",
     "LICENSE.txt",
@@ -48,6 +49,9 @@ ureq = "3"
 zip = "2"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+zip = "2"
 
 [[example]]
 name = "chat_completion"

--- a/sdk_v2/rust/README.md
+++ b/sdk_v2/rust/README.md
@@ -555,6 +555,44 @@ runtime. The `build.rs` build script can obtain it in two ways, controlled by en
 | `FOUNDRY_LOCAL_NATIVE_BIN_DIR` | Copy native binaries from a local C++ build output directory (the dev path). Mirrors the C# `FoundryLocalNativeBinDir`. |
 | `FOUNDRY_LOCAL_RUNTIME_VERSION` | Download the Runtime NuGet package (`Microsoft.AI.Foundry.Local.Runtime`) plus ONNX Runtime / GenAI for the target RID. On Windows this package bundles the reg-free WinML 2.x runtime. |
 
+When `FOUNDRY_LOCAL_RUNTIME_VERSION` is set, the NuGet acquisition path supports three modes:
+
+- **`http` (default)** — talks to the NuGet v3 HTTP protocol directly. No external tools are
+  required, but feeds must support anonymous HTTPS access.
+- **`dotnet`** — runs `dotnet restore` against a temporary project. Use this with a
+  `NuGet.Config` or a credential provider supported by the .NET SDK.
+- **`nuget`** — runs `nuget install` once per package. Use this when authentication depends on a
+  NuGet or Visual Studio credential provider that the standalone NuGet CLI can host.
+
+| Variable | Applies to | Purpose |
+|----------|------------|---------|
+| `FOUNDRY_LOCAL_NUGET_MODE` | all | `http` (default), `dotnet`, or `nuget`. |
+| `FOUNDRY_LOCAL_NUGET_FEEDS` | all | Semicolon-separated NuGet v3 service-index URLs. Replaces the public defaults. `http` mode requires HTTPS. |
+| `FOUNDRY_LOCAL_NUGET_CONFIG` | `dotnet`, `nuget` | Path to a `NuGet.Config`. When set, the config owns package sources; no command-line sources are added. |
+| `FOUNDRY_LOCAL_DOTNET_COMMAND` | `dotnet` | Command or path for the .NET CLI. Defaults to `dotnet`. |
+| `FOUNDRY_LOCAL_NUGET_COMMAND` | `nuget` | Command or path for the NuGet CLI. Defaults to `nuget.exe` on Windows and `nuget` elsewhere. |
+
+Authentication is delegated to the standard NuGet tooling in `dotnet` and `nuget` modes. The build
+script does not read or print credentials, and it redacts query strings, fragments, and embedded
+credentials from URLs in tool errors.
+
+To use an anonymous mirror directly:
+
+```bash
+export FOUNDRY_LOCAL_RUNTIME_VERSION="x.y.z" # Replace with the runtime package version.
+export FOUNDRY_LOCAL_NUGET_FEEDS=https://mirror.example/nuget/v3/index.json
+cargo build
+```
+
+To use package sources and credentials from a `NuGet.Config`:
+
+```bash
+export FOUNDRY_LOCAL_RUNTIME_VERSION="x.y.z" # Replace with the runtime package version.
+export FOUNDRY_LOCAL_NUGET_MODE=dotnet
+export FOUNDRY_LOCAL_NUGET_CONFIG="$HOME/.nuget/NuGet/NuGet.Config"
+cargo build
+```
+
 If neither is set at build time, the library is resolved at **runtime** from (in order):
 
 1. `FoundryLocalConfig::library_path` — a path to the `foundry_local` library file or its directory.

--- a/sdk_v2/rust/build.rs
+++ b/sdk_v2/rust/build.rs
@@ -463,10 +463,10 @@ fn restore_with_nuget(
     result
 }
 
-fn copy_from_local_dir(src: &Path, out_dir: &Path) -> bool {
+fn copy_from_local_dir(src: &Path, out_dir: &Path) -> Result<bool, String> {
     let ext = native_lib_extension();
     let Ok(entries) = fs::read_dir(src) else {
-        return false;
+        return Ok(false);
     };
     let mut copied = false;
     for entry in entries.flatten() {
@@ -483,7 +483,10 @@ fn copy_from_local_dir(src: &Path, out_dir: &Path) -> bool {
             }
         }
     }
-    copied
+    if copied {
+        build_support::invalidate_package_version_markers(out_dir)?;
+    }
+    Ok(copied)
 }
 
 fn emit_native_dir(out_dir: &Path) {
@@ -525,9 +528,18 @@ fn main() {
     // 1. Local C++ build output (dev path).
     if let Ok(local) = env::var("FOUNDRY_LOCAL_NATIVE_BIN_DIR") {
         let src = Path::new(&local);
-        if src.is_dir() && copy_from_local_dir(src, &out_dir) {
-            emit_native_dir(&out_dir);
-            return;
+        if src.is_dir() {
+            match copy_from_local_dir(src, &out_dir) {
+                Ok(true) => {
+                    emit_native_dir(&out_dir);
+                    return;
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    println!("cargo:warning=local native staging failed: {error}");
+                    return;
+                }
+            }
         }
     }
 

--- a/sdk_v2/rust/build.rs
+++ b/sdk_v2/rust/build.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 mod build_support;
+mod http_extract;
 
 use build_support::{NuGetConfig, NuGetMode};
 
@@ -204,10 +205,10 @@ fn try_download(
     agent: &ureq::Agent,
     pkg: &NuGetPackage,
     rid: &str,
-    out_dir: &Path,
+    staging_dir: &Path,
     feed_url: &str,
     service_index_cache: &mut HashMap<String, String>,
-) -> Result<bool, String> {
+) -> Result<Vec<PathBuf>, String> {
     let base = resolve_base_address(agent, feed_url, service_index_cache)?;
     let name = pkg.name.to_lowercase();
     let version = pkg.version.to_lowercase();
@@ -230,38 +231,14 @@ fn try_download(
         return Err(format!("downloaded {} {} is empty", pkg.name, pkg.version));
     }
 
-    let ext = native_lib_extension();
-    let native_prefix = format!("runtimes/{rid}/native/");
-    let runtime_prefix = format!("runtimes/{rid}/");
-    let mut archive = zip::ZipArchive::new(io::Cursor::new(&bytes))
-        .map_err(|e| format!("open nupkg {}: {e}", pkg.name))?;
-
-    let mut extracted_expected_file = false;
-    for i in 0..archive.len() {
-        let mut file = archive.by_index(i).map_err(|e| format!("zip entry: {e}"))?;
-        let entry = file.name().to_string();
-        if !entry.ends_with(&format!(".{ext}")) {
-            continue;
-        }
-        let direct = entry
-            .strip_prefix(&runtime_prefix)
-            .map(|r| !r.is_empty() && !r.contains('/'))
-            .unwrap_or(false);
-        if !entry.starts_with(&native_prefix) && !direct {
-            continue;
-        }
-        let file_name = match Path::new(&entry).file_name() {
-            Some(n) => n.to_string_lossy().to_string(),
-            None => continue,
-        };
-        let dest = out_dir.join(&file_name);
-        let mut out =
-            fs::File::create(&dest).map_err(|e| format!("create {}: {e}", dest.display()))?;
-        io::copy(&mut file, &mut out).map_err(|e| format!("write {}: {e}", dest.display()))?;
-        println!("cargo:warning=  Extracted {file_name}");
-        extracted_expected_file |= file_name == pkg.expected_file;
-    }
-    Ok(extracted_expected_file)
+    http_extract::extract_package(
+        io::Cursor::new(bytes),
+        rid,
+        native_lib_extension(),
+        &pkg.expected_file,
+        staging_dir,
+    )
+    .map_err(|error| format!("extract nupkg {}: {error}", pkg.name))
 }
 
 fn download_and_extract(
@@ -278,27 +255,32 @@ fn download_and_extract(
     if pkg.version.trim().is_empty() {
         return Err(format!("no version configured for {}", pkg.name));
     }
+    let staging_dir = out_dir.join(format!(".nuget-http-{}", pkg.expected_file));
     let mut last = String::new();
     for feed in feeds {
-        build_support::invalidate_package(out_dir, &pkg.expected_file)?;
-        match try_download(agent, pkg, rid, out_dir, feed, service_index_cache) {
+        match try_download(agent, pkg, rid, &staging_dir, feed, service_index_cache) {
             // Integrity guard: a "successful" download must actually yield the
             // expected native binary (the archive opened as a valid zip and the
             // expected file landed on disk). Cryptographic SHA-512 verification
             // against the feed's published packageHash is feed-specific — the
             // registration layout differs between nuget.org and the Azure DevOps
             // feed — and is left as future hardening.
-            Ok(true) => {
+            Ok(files) => {
+                let stage_result = http_extract::stage_files(&files, out_dir);
+                http_extract::cleanup_dir(&staging_dir);
+                stage_result?;
+                for file in files {
+                    if let Some(file_name) = file.file_name() {
+                        println!("cargo:warning=  Extracted {}", file_name.to_string_lossy());
+                    }
+                }
                 build_support::record_package_version(out_dir, &pkg.expected_file, &pkg.version)?;
                 return Ok(());
             }
-            Ok(false) => {
-                last = format!(
-                    "{} {} downloaded but did not contain expected file {}",
-                    pkg.name, pkg.version, pkg.expected_file
-                )
+            Err(error) => {
+                http_extract::cleanup_dir(&staging_dir);
+                last = error;
             }
-            Err(e) => last = e,
         }
     }
     Err(format!(
@@ -567,7 +549,16 @@ fn main() {
         let packages = get_packages(&deps, &runtime_version);
         let config = build_support::read_config()
             .unwrap_or_else(|error| panic!("invalid NuGet configuration: {error}"));
-        let result = match config.mode {
+        let package_versions: Vec<_> = packages
+            .iter()
+            .map(|pkg| (pkg.expected_file.as_str(), pkg.version.as_str()))
+            .collect();
+        let result = build_support::reset_native_cache_if_stale(
+            &out_dir,
+            &package_versions,
+            native_lib_extension(),
+        )
+        .and_then(|_| match config.mode {
             NuGetMode::Http => {
                 let mut failed = false;
                 let mut service_index_cache = HashMap::new();
@@ -594,7 +585,7 @@ fn main() {
             }
             NuGetMode::Dotnet => restore_with_dotnet(&config, &packages, rid, &out_dir),
             NuGetMode::Nuget => restore_with_nuget(&config, &packages, rid, &out_dir),
-        };
+        });
         if let Err(error) = result {
             println!("cargo:warning=native package acquisition failed: {error}");
             return;

--- a/sdk_v2/rust/build.rs
+++ b/sdk_v2/rust/build.rs
@@ -595,7 +595,10 @@ fn main() {
             NuGetMode::Dotnet => restore_with_dotnet(&config, &packages, rid, &out_dir),
             NuGetMode::Nuget => restore_with_nuget(&config, &packages, rid, &out_dir),
         };
-        result.unwrap_or_else(|error| panic!("native package acquisition failed: {error}"));
+        if let Err(error) = result {
+            println!("cargo:warning=native package acquisition failed: {error}");
+            return;
+        }
         emit_native_dir(&out_dir);
         return;
     }

--- a/sdk_v2/rust/build.rs
+++ b/sdk_v2/rust/build.rs
@@ -561,6 +561,9 @@ fn main() {
         let packages = get_packages(&deps, &runtime_version);
         let config = build_support::read_config()
             .unwrap_or_else(|error| panic!("invalid NuGet configuration: {error}"));
+        if let Some(config_file) = &config.config_file {
+            println!("cargo:rerun-if-changed={config_file}");
+        }
         let package_versions: Vec<_> = packages
             .iter()
             .map(|pkg| (pkg.expected_file.as_str(), pkg.version.as_str()))

--- a/sdk_v2/rust/build.rs
+++ b/sdk_v2/rust/build.rs
@@ -207,7 +207,7 @@ fn try_download(
     out_dir: &Path,
     feed_url: &str,
     service_index_cache: &mut HashMap<String, String>,
-) -> Result<usize, String> {
+) -> Result<bool, String> {
     let base = resolve_base_address(agent, feed_url, service_index_cache)?;
     let name = pkg.name.to_lowercase();
     let version = pkg.version.to_lowercase();
@@ -236,7 +236,7 @@ fn try_download(
     let mut archive = zip::ZipArchive::new(io::Cursor::new(&bytes))
         .map_err(|e| format!("open nupkg {}: {e}", pkg.name))?;
 
-    let mut extracted = 0usize;
+    let mut extracted_expected_file = false;
     for i in 0..archive.len() {
         let mut file = archive.by_index(i).map_err(|e| format!("zip entry: {e}"))?;
         let entry = file.name().to_string();
@@ -259,9 +259,9 @@ fn try_download(
             fs::File::create(&dest).map_err(|e| format!("create {}: {e}", dest.display()))?;
         io::copy(&mut file, &mut out).map_err(|e| format!("write {}: {e}", dest.display()))?;
         println!("cargo:warning=  Extracted {file_name}");
-        extracted += 1;
+        extracted_expected_file |= file_name == pkg.expected_file;
     }
-    Ok(extracted)
+    Ok(extracted_expected_file)
 }
 
 fn download_and_extract(
@@ -280,6 +280,7 @@ fn download_and_extract(
     }
     let mut last = String::new();
     for feed in feeds {
+        build_support::invalidate_package(out_dir, &pkg.expected_file)?;
         match try_download(agent, pkg, rid, out_dir, feed, service_index_cache) {
             // Integrity guard: a "successful" download must actually yield the
             // expected native binary (the archive opened as a valid zip and the
@@ -287,11 +288,11 @@ fn download_and_extract(
             // against the feed's published packageHash is feed-specific — the
             // registration layout differs between nuget.org and the Azure DevOps
             // feed — and is left as future hardening.
-            Ok(_) if out_dir.join(&pkg.expected_file).exists() => {
+            Ok(true) => {
                 build_support::record_package_version(out_dir, &pkg.expected_file, &pkg.version)?;
                 return Ok(());
             }
-            Ok(_) => {
+            Ok(false) => {
                 last = format!(
                     "{} {} downloaded but did not contain expected file {}",
                     pkg.name, pkg.version, pkg.expected_file
@@ -350,6 +351,13 @@ fn stage_restored_package(
             pkg.name, pkg.version
         ));
     }
+    if !build_support::contains_expected_file(&files, &pkg.expected_file) {
+        return Err(format!(
+            "{} {} did not contain expected file {} for RID '{rid}'.",
+            pkg.name, pkg.version, pkg.expected_file
+        ));
+    }
+    build_support::invalidate_package(out_dir, &pkg.expected_file)?;
     for file in files {
         let file_name = file
             .file_name()

--- a/sdk_v2/rust/build.rs
+++ b/sdk_v2/rust/build.rs
@@ -12,15 +12,16 @@
 //!   3. Otherwise no-op: the library is resolved at runtime from
 //!      `FOUNDRY_LOCAL_LIB_DIR`, next to the executable, or the system path.
 
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
-const FEEDS: &[&str] = &[
-    "https://api.nuget.org/v3/index.json",
-    "https://pkgs.dev.azure.com/aiinfra/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json",
-];
+mod build_support;
+
+use build_support::{NuGetConfig, NuGetMode};
 
 struct DepsVersions {
     ort: String,
@@ -160,10 +161,23 @@ fn get_packages(deps: &DepsVersions, runtime_version: &str) -> Vec<NuGetPackage>
     ]
 }
 
-fn resolve_base_address(feed_url: &str) -> Result<String, String> {
-    let body: String = ureq::get(feed_url)
+fn resolve_base_address(
+    agent: &ureq::Agent,
+    feed_url: &str,
+    cache: &mut HashMap<String, String>,
+) -> Result<String, String> {
+    if let Some(base) = cache.get(feed_url) {
+        return Ok(base.clone());
+    }
+    let safe_feed_url = build_support::redact_url(feed_url);
+    let body: String = agent
+        .get(feed_url)
         .call()
-        .map_err(|e| format!("fetch feed index {feed_url}: {e}"))?
+        .map_err(|error| {
+            build_support::redact_urls_in_text(&format!(
+                "fetch feed index {safe_feed_url}: {error}"
+            ))
+        })?
         .body_mut()
         .read_to_string()
         .map_err(|e| format!("read feed index: {e}"))?;
@@ -172,32 +186,37 @@ fn resolve_base_address(feed_url: &str) -> Result<String, String> {
     for resource in index["resources"].as_array().ok_or("missing resources")? {
         if resource["@type"].as_str() == Some("PackageBaseAddress/3.0.0") {
             if let Some(id) = resource["@id"].as_str() {
-                return Ok(if id.ends_with('/') {
+                build_support::validate_http_package_base_address(id)?;
+                let base = if id.ends_with('/') {
                     id.to_string()
                 } else {
                     format!("{id}/")
-                });
+                };
+                cache.insert(feed_url.to_string(), base.clone());
+                return Ok(base);
             }
         }
     }
-    Err(format!("no PackageBaseAddress in {feed_url}"))
+    Err(format!("no PackageBaseAddress in {safe_feed_url}"))
 }
 
 fn try_download(
+    agent: &ureq::Agent,
     pkg: &NuGetPackage,
     rid: &str,
     out_dir: &Path,
     feed_url: &str,
+    service_index_cache: &mut HashMap<String, String>,
 ) -> Result<usize, String> {
-    let base = resolve_base_address(feed_url)?;
+    let base = resolve_base_address(agent, feed_url, service_index_cache)?;
     let name = pkg.name.to_lowercase();
     let version = pkg.version.to_lowercase();
     let url = format!("{base}{name}/{version}/{name}.{version}.nupkg");
     println!("cargo:warning=Downloading {} {}", pkg.name, pkg.version);
 
-    let mut response = ureq::get(&url)
-        .call()
-        .map_err(|e| format!("download {}: {e}", pkg.name))?;
+    let mut response = agent.get(&url).call().map_err(|error| {
+        build_support::redact_urls_in_text(&format!("download {}: {error}", pkg.name))
+    })?;
     let mut bytes = Vec::new();
     response
         .body_mut()
@@ -245,23 +264,33 @@ fn try_download(
     Ok(extracted)
 }
 
-fn download_and_extract(pkg: &NuGetPackage, rid: &str, out_dir: &Path) -> Result<(), String> {
-    if out_dir.join(&pkg.expected_file).exists() {
+fn download_and_extract(
+    agent: &ureq::Agent,
+    pkg: &NuGetPackage,
+    rid: &str,
+    out_dir: &Path,
+    feeds: &[String],
+    service_index_cache: &mut HashMap<String, String>,
+) -> Result<(), String> {
+    if build_support::package_is_current(out_dir, &pkg.expected_file, &pkg.version) {
         return Ok(());
     }
     if pkg.version.trim().is_empty() {
         return Err(format!("no version configured for {}", pkg.name));
     }
     let mut last = String::new();
-    for feed in FEEDS {
-        match try_download(pkg, rid, out_dir, feed) {
+    for feed in feeds {
+        match try_download(agent, pkg, rid, out_dir, feed, service_index_cache) {
             // Integrity guard: a "successful" download must actually yield the
             // expected native binary (the archive opened as a valid zip and the
             // expected file landed on disk). Cryptographic SHA-512 verification
             // against the feed's published packageHash is feed-specific — the
             // registration layout differs between nuget.org and the Azure DevOps
             // feed — and is left as future hardening.
-            Ok(_) if out_dir.join(&pkg.expected_file).exists() => return Ok(()),
+            Ok(_) if out_dir.join(&pkg.expected_file).exists() => {
+                build_support::record_package_version(out_dir, &pkg.expected_file, &pkg.version)?;
+                return Ok(());
+            }
             Ok(_) => {
                 last = format!(
                     "{} {} downloaded but did not contain expected file {}",
@@ -275,6 +304,173 @@ fn download_and_extract(pkg: &NuGetPackage, rid: &str, out_dir: &Path) -> Result
         "download {} {} failed: {last}",
         pkg.name, pkg.version
     ))
+}
+
+fn missing_packages<'a>(packages: &'a [NuGetPackage], out_dir: &Path) -> Vec<&'a NuGetPackage> {
+    packages
+        .iter()
+        .filter(|pkg| !build_support::package_is_current(out_dir, &pkg.expected_file, &pkg.version))
+        .collect()
+}
+
+fn reset_temp_dir(path: &Path) -> Result<(), String> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "remove temporary directory {}: {error}",
+                path.display()
+            ))
+        }
+    }
+    fs::create_dir_all(path)
+        .map_err(|error| format!("create temporary directory {}: {error}", path.display()))
+}
+
+fn cleanup_temp_dir(path: &Path) {
+    if let Err(error) = fs::remove_dir_all(path) {
+        println!(
+            "cargo:warning=Could not remove temporary directory {}: {error}",
+            path.display()
+        );
+    }
+}
+
+fn stage_restored_package(
+    pkg: &NuGetPackage,
+    package_dir: &Path,
+    rid: &str,
+    out_dir: &Path,
+) -> Result<(), String> {
+    let files = build_support::collect_native_files(package_dir, rid, native_lib_extension())?;
+    if files.is_empty() {
+        return Err(format!(
+            "No native files found for RID '{rid}' in {} {}.",
+            pkg.name, pkg.version
+        ));
+    }
+    for file in files {
+        let file_name = file
+            .file_name()
+            .ok_or_else(|| format!("native file has no file name: {}", file.display()))?;
+        fs::copy(&file, out_dir.join(file_name))
+            .map_err(|error| format!("stage {}: {error}", file.display()))?;
+        println!("cargo:warning=  Staged {}", file_name.to_string_lossy());
+    }
+    if out_dir.join(&pkg.expected_file).exists() {
+        build_support::record_package_version(out_dir, &pkg.expected_file, &pkg.version)
+    } else {
+        Err(format!(
+            "{} {} restored but did not contain expected file {}",
+            pkg.name, pkg.version, pkg.expected_file
+        ))
+    }
+}
+
+fn run_command(command: &str, args: &[std::ffi::OsString], operation: &str) -> Result<(), String> {
+    let output = Command::new(command).args(args).output().map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            format!(
+                "{operation} command not found: '{command}'. Install it or configure its \
+                     FOUNDRY_LOCAL_*_COMMAND override."
+            )
+        } else {
+            format!("start {operation}: {error}")
+        }
+    })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let detail = build_support::redact_urls_in_text(&format!("{stdout}\n{stderr}"));
+    Err(format!(
+        "{operation} failed (exit {}).\n{}",
+        output
+            .status
+            .code()
+            .map_or_else(|| "unknown".to_string(), |code| code.to_string()),
+        detail.trim()
+    ))
+}
+
+fn restore_with_dotnet(
+    config: &NuGetConfig,
+    packages: &[NuGetPackage],
+    rid: &str,
+    out_dir: &Path,
+) -> Result<(), String> {
+    let missing = missing_packages(packages, out_dir);
+    if missing.is_empty() {
+        return Ok(());
+    }
+    let temp_dir = out_dir.join("nuget-dotnet-restore");
+    reset_temp_dir(&temp_dir)?;
+    let result = (|| {
+        let project_path = temp_dir.join("restore.csproj");
+        let packages_dir = temp_dir.join("packages");
+        fs::create_dir_all(&packages_dir)
+            .map_err(|error| format!("create package directory: {error}"))?;
+        let package_refs: Vec<_> = missing
+            .iter()
+            .map(|pkg| (pkg.name.as_str(), pkg.version.as_str()))
+            .collect();
+        fs::write(
+            &project_path,
+            build_support::generate_restore_project(&package_refs),
+        )
+        .map_err(|error| format!("write restore project: {error}"))?;
+        let args = build_support::build_dotnet_restore_args(config, &project_path, &packages_dir);
+        println!("cargo:warning=Running dotnet restore for native runtime packages");
+        run_command(&config.dotnet_command, &args, "dotnet restore")?;
+        for pkg in missing {
+            let package_dir =
+                build_support::find_dotnet_package_dir(&packages_dir, &pkg.name, &pkg.version)?;
+            stage_restored_package(pkg, &package_dir, rid, out_dir)?;
+        }
+        Ok(())
+    })();
+    cleanup_temp_dir(&temp_dir);
+    result
+}
+
+fn restore_with_nuget(
+    config: &NuGetConfig,
+    packages: &[NuGetPackage],
+    rid: &str,
+    out_dir: &Path,
+) -> Result<(), String> {
+    let missing = missing_packages(packages, out_dir);
+    if missing.is_empty() {
+        return Ok(());
+    }
+    let temp_dir = out_dir.join("nuget-cli-restore");
+    reset_temp_dir(&temp_dir)?;
+    let result = (|| {
+        let packages_dir = temp_dir.join("packages");
+        fs::create_dir_all(&packages_dir)
+            .map_err(|error| format!("create package directory: {error}"))?;
+        for pkg in missing {
+            let args = build_support::build_nuget_install_args(
+                config,
+                &pkg.name,
+                &pkg.version,
+                &packages_dir,
+            );
+            println!(
+                "cargo:warning=Running nuget install for {} {}",
+                pkg.name, pkg.version
+            );
+            run_command(&config.nuget_command, &args, "nuget install")?;
+            let package_dir =
+                build_support::find_nuget_package_dir(&packages_dir, &pkg.name, &pkg.version)?;
+            stage_restored_package(pkg, &package_dir, rid, out_dir)?;
+        }
+        Ok(())
+    })();
+    cleanup_temp_dir(&temp_dir);
+    result
 }
 
 fn copy_from_local_dir(src: &Path, out_dir: &Path) -> bool {
@@ -314,6 +510,11 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=FOUNDRY_LOCAL_NATIVE_BIN_DIR");
     println!("cargo:rerun-if-env-changed=FOUNDRY_LOCAL_RUNTIME_VERSION");
+    println!("cargo:rerun-if-env-changed=FOUNDRY_LOCAL_NUGET_MODE");
+    println!("cargo:rerun-if-env-changed=FOUNDRY_LOCAL_NUGET_FEEDS");
+    println!("cargo:rerun-if-env-changed=FOUNDRY_LOCAL_NUGET_CONFIG");
+    println!("cargo:rerun-if-env-changed=FOUNDRY_LOCAL_DOTNET_COMMAND");
+    println!("cargo:rerun-if-env-changed=FOUNDRY_LOCAL_NUGET_COMMAND");
 
     // docs.rs builds run in an offline sandbox and only need the crate to
     // type-check — `cargo doc` never links or runs the native library. Skip all
@@ -356,16 +557,38 @@ fn main() {
         };
         let deps = load_deps_versions(&manifest_dir);
         let packages = get_packages(&deps, &runtime_version);
-        let mut failed = false;
-        for pkg in &packages {
-            if let Err(e) = download_and_extract(pkg, rid, &out_dir) {
-                println!("cargo:warning={e}");
-                failed = true;
+        let config = build_support::read_config()
+            .unwrap_or_else(|error| panic!("invalid NuGet configuration: {error}"));
+        let result = match config.mode {
+            NuGetMode::Http => {
+                let mut failed = false;
+                let mut service_index_cache = HashMap::new();
+                let http_config = ureq::Agent::config_builder().https_only(true).build();
+                let http_agent = ureq::Agent::new_with_config(http_config);
+                for pkg in &packages {
+                    if let Err(error) = download_and_extract(
+                        &http_agent,
+                        pkg,
+                        rid,
+                        &out_dir,
+                        &config.feeds,
+                        &mut service_index_cache,
+                    ) {
+                        println!("cargo:warning={error}");
+                        failed = true;
+                    }
+                }
+                if failed {
+                    Err("one or more native runtime packages failed to download".to_string())
+                } else {
+                    Ok(())
+                }
             }
-        }
-        if !failed {
-            emit_native_dir(&out_dir);
-        }
+            NuGetMode::Dotnet => restore_with_dotnet(&config, &packages, rid, &out_dir),
+            NuGetMode::Nuget => restore_with_nuget(&config, &packages, rid, &out_dir),
+        };
+        result.unwrap_or_else(|error| panic!("native package acquisition failed: {error}"));
+        emit_native_dir(&out_dir);
         return;
     }
 

--- a/sdk_v2/rust/build_support.rs
+++ b/sdk_v2/rust/build_support.rs
@@ -1,0 +1,387 @@
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const DEFAULT_FEEDS: &[&str] = &[
+    "https://api.nuget.org/v3/index.json",
+    "https://pkgs.dev.azure.com/aiinfra/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json",
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NuGetMode {
+    Http,
+    Dotnet,
+    Nuget,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NuGetConfig {
+    pub mode: NuGetMode,
+    pub feeds: Vec<String>,
+    pub config_file: Option<String>,
+    pub dotnet_command: String,
+    pub nuget_command: String,
+}
+
+pub fn read_config() -> Result<NuGetConfig, String> {
+    read_config_from(|name| env::var(name).ok(), cfg!(windows))
+}
+
+pub fn read_config_from<F>(get_env: F, is_windows: bool) -> Result<NuGetConfig, String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let mode_raw = get_env("FOUNDRY_LOCAL_NUGET_MODE");
+    let mode = match mode_raw.as_deref().filter(|value| !value.is_empty()) {
+        None | Some("http") => NuGetMode::Http,
+        Some("dotnet") => NuGetMode::Dotnet,
+        Some("nuget") => NuGetMode::Nuget,
+        Some(value) => {
+            return Err(format!(
+                "Invalid FOUNDRY_LOCAL_NUGET_MODE '{value}'. Expected 'http', 'dotnet', or 'nuget'."
+            ))
+        }
+    };
+
+    let feeds_raw = get_env("FOUNDRY_LOCAL_NUGET_FEEDS");
+    let feeds = match feeds_raw {
+        Some(raw) => {
+            let values: Vec<_> = raw
+                .split(';')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .collect();
+            if values.is_empty() {
+                return Err(
+                    "FOUNDRY_LOCAL_NUGET_FEEDS is set but contains no feed URLs.".to_string(),
+                );
+            }
+            values
+        }
+        None => DEFAULT_FEEDS
+            .iter()
+            .map(|feed| (*feed).to_string())
+            .collect(),
+    };
+
+    for feed in &feeds {
+        validate_feed_url(feed, mode == NuGetMode::Http)?;
+    }
+
+    let config_file = nonempty(get_env("FOUNDRY_LOCAL_NUGET_CONFIG"));
+    let dotnet_command = nonempty(get_env("FOUNDRY_LOCAL_DOTNET_COMMAND"));
+    let nuget_command = nonempty(get_env("FOUNDRY_LOCAL_NUGET_COMMAND"));
+
+    match mode {
+        NuGetMode::Http => {
+            if config_file.is_some() {
+                return Err(
+                    "FOUNDRY_LOCAL_NUGET_CONFIG is only valid when FOUNDRY_LOCAL_NUGET_MODE is \
+                     'dotnet' or 'nuget'."
+                        .to_string(),
+                );
+            }
+            if dotnet_command.is_some() {
+                return Err("FOUNDRY_LOCAL_DOTNET_COMMAND is only valid when \
+                     FOUNDRY_LOCAL_NUGET_MODE=dotnet."
+                    .to_string());
+            }
+            if nuget_command.is_some() {
+                return Err("FOUNDRY_LOCAL_NUGET_COMMAND is only valid when \
+                     FOUNDRY_LOCAL_NUGET_MODE=nuget."
+                    .to_string());
+            }
+        }
+        NuGetMode::Dotnet if nuget_command.is_some() => {
+            return Err("FOUNDRY_LOCAL_NUGET_COMMAND is only valid when \
+                 FOUNDRY_LOCAL_NUGET_MODE=nuget."
+                .to_string())
+        }
+        NuGetMode::Nuget if dotnet_command.is_some() => {
+            return Err("FOUNDRY_LOCAL_DOTNET_COMMAND is only valid when \
+                 FOUNDRY_LOCAL_NUGET_MODE=dotnet."
+                .to_string())
+        }
+        NuGetMode::Dotnet | NuGetMode::Nuget => {}
+    }
+
+    Ok(NuGetConfig {
+        mode,
+        feeds,
+        config_file,
+        dotnet_command: dotnet_command.unwrap_or_else(|| "dotnet".to_string()),
+        nuget_command: nuget_command
+            .unwrap_or_else(|| if is_windows { "nuget.exe" } else { "nuget" }.to_string()),
+    })
+}
+
+fn nonempty(value: Option<String>) -> Option<String> {
+    value.filter(|value| !value.is_empty())
+}
+
+pub fn validate_feed_url(url: &str, require_https: bool) -> Result<(), String> {
+    let (scheme, remainder) = url.split_once("://").ok_or_else(|| {
+        format!(
+            "FOUNDRY_LOCAL_NUGET_FEEDS contains an invalid URL: {}",
+            redact_url(url)
+        )
+    })?;
+    let authority = remainder
+        .split(['/', '?', '#'])
+        .next()
+        .filter(|value| !value.is_empty());
+    let valid_scheme = !scheme.is_empty()
+        && scheme
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.'));
+    if !valid_scheme || authority.is_none() || url.chars().any(char::is_whitespace) {
+        return Err(format!(
+            "FOUNDRY_LOCAL_NUGET_FEEDS contains an invalid URL: {}",
+            redact_url(url)
+        ));
+    }
+    if authority.is_some_and(|value| value.contains('@')) {
+        return Err("FOUNDRY_LOCAL_NUGET_FEEDS must not contain embedded credentials.".to_string());
+    }
+    if require_https && !scheme.eq_ignore_ascii_case("https") {
+        return Err(format!(
+            "FOUNDRY_LOCAL_NUGET_FEEDS must use HTTPS in http mode: {}",
+            redact_url(url)
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_http_package_base_address(url: &str) -> Result<(), String> {
+    validate_feed_url(url, true).map_err(|_| {
+        format!(
+            "NuGet PackageBaseAddress must use a valid HTTPS URL in http mode: {}",
+            redact_url(url)
+        )
+    })
+}
+
+pub fn redact_url(url: &str) -> String {
+    let Some((scheme, remainder)) = url.split_once("://") else {
+        return url.to_string();
+    };
+    let end = remainder.find(['/', '?', '#']).unwrap_or(remainder.len());
+    let authority = &remainder[..end];
+    let authority = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    let path = &remainder[end..];
+    let sensitive = path.find(['?', '#']).unwrap_or(path.len());
+    format!("{scheme}://{authority}{}", &path[..sensitive])
+}
+
+pub fn redact_urls_in_text(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut remaining = text;
+    while let Some(start) = find_url_start(remaining) {
+        result.push_str(&remaining[..start]);
+        let url_and_rest = &remaining[start..];
+        let end = url_and_rest
+            .find(|ch: char| ch.is_whitespace() || matches!(ch, '"' | '\'' | '<' | '>'))
+            .unwrap_or(url_and_rest.len());
+        result.push_str(&redact_url(&url_and_rest[..end]));
+        remaining = &url_and_rest[end..];
+    }
+    result.push_str(remaining);
+    result
+}
+
+fn find_url_start(value: &str) -> Option<usize> {
+    [value.find("https://"), value.find("http://")]
+        .into_iter()
+        .flatten()
+        .min()
+}
+
+pub fn package_is_current(out_dir: &Path, expected_file: &str, version: &str) -> bool {
+    out_dir.join(expected_file).is_file()
+        && fs::read_to_string(package_version_path(out_dir, expected_file))
+            .is_ok_and(|recorded| recorded.trim() == version)
+}
+
+pub fn record_package_version(
+    out_dir: &Path,
+    expected_file: &str,
+    version: &str,
+) -> Result<(), String> {
+    let marker = package_version_path(out_dir, expected_file);
+    fs::write(&marker, version)
+        .map_err(|error| format!("write package version marker {}: {error}", marker.display()))
+}
+
+fn package_version_path(out_dir: &Path, expected_file: &str) -> PathBuf {
+    out_dir.join(format!(".{expected_file}.version"))
+}
+
+pub fn generate_restore_project(packages: &[(&str, &str)]) -> String {
+    let references = packages
+        .iter()
+        .map(|(name, version)| {
+            format!(
+                "    <PackageReference Include=\"{}\" Version=\"[{}]\" />",
+                escape_xml(name),
+                escape_xml(version)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "<Project Sdk=\"Microsoft.NET.Sdk\">\n\
+         \x20 <PropertyGroup>\n\
+         \x20   <TargetFramework>net8.0</TargetFramework>\n\
+         \x20   <EnableDefaultCompileItems>false</EnableDefaultCompileItems>\n\
+         \x20   <IsPackable>false</IsPackable>\n\
+         \x20 </PropertyGroup>\n\
+         \x20 <ItemGroup>\n\
+         {references}\n\
+         \x20 </ItemGroup>\n\
+         </Project>\n"
+    )
+}
+
+fn escape_xml(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+pub fn build_dotnet_restore_args(
+    config: &NuGetConfig,
+    project_path: &Path,
+    packages_dir: &Path,
+) -> Vec<OsString> {
+    let mut args = vec![
+        "restore".into(),
+        project_path.as_os_str().to_owned(),
+        "--packages".into(),
+        packages_dir.as_os_str().to_owned(),
+        "--no-cache".into(),
+    ];
+    if let Some(config_file) = &config.config_file {
+        args.push("--configfile".into());
+        args.push(config_file.into());
+    } else {
+        for feed in &config.feeds {
+            args.push("--source".into());
+            args.push(feed.into());
+        }
+    }
+    args
+}
+
+pub fn build_nuget_install_args(
+    config: &NuGetConfig,
+    id: &str,
+    version: &str,
+    output_dir: &Path,
+) -> Vec<OsString> {
+    let mut args = vec![
+        "install".into(),
+        id.into(),
+        "-Version".into(),
+        version.into(),
+        "-OutputDirectory".into(),
+        output_dir.as_os_str().to_owned(),
+        "-NonInteractive".into(),
+        "-DirectDownload".into(),
+        "-DependencyVersion".into(),
+        "Ignore".into(),
+    ];
+    if let Some(config_file) = &config.config_file {
+        args.push("-ConfigFile".into());
+        args.push(config_file.into());
+    } else {
+        for feed in &config.feeds {
+            args.push("-Source".into());
+            args.push(feed.into());
+        }
+    }
+    args
+}
+
+pub fn find_dotnet_package_dir(
+    packages_dir: &Path,
+    id: &str,
+    version: &str,
+) -> Result<PathBuf, String> {
+    let path = packages_dir
+        .join(id.to_lowercase())
+        .join(version.to_lowercase());
+    if path.is_dir() {
+        Ok(path)
+    } else {
+        Err(format!(
+            "Restored package not found at expected path: {}",
+            path.display()
+        ))
+    }
+}
+
+pub fn find_nuget_package_dir(
+    output_dir: &Path,
+    id: &str,
+    version: &str,
+) -> Result<PathBuf, String> {
+    let expected = format!("{id}.{version}").to_lowercase();
+    let entries = fs::read_dir(output_dir)
+        .map_err(|error| format!("read package directory {}: {error}", output_dir.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("read package directory entry: {error}"))?;
+        if entry
+            .file_type()
+            .map_err(|error| format!("read package entry type: {error}"))?
+            .is_dir()
+            && entry.file_name().to_string_lossy().to_lowercase() == expected
+        {
+            return Ok(entry.path());
+        }
+    }
+    Err(format!(
+        "Restored package not found under {} (expected {id}.{version}).",
+        output_dir.display()
+    ))
+}
+
+pub fn collect_native_files(
+    package_dir: &Path,
+    rid: &str,
+    extension: &str,
+) -> Result<Vec<PathBuf>, String> {
+    let runtime_dir = package_dir.join("runtimes").join(rid);
+    let native_dir = runtime_dir.join("native");
+    let mut files = collect_matching_files(&native_dir, extension)?;
+    files.extend(collect_matching_files(&runtime_dir, extension)?);
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+fn collect_matching_files(directory: &Path, extension: &str) -> Result<Vec<PathBuf>, String> {
+    if !directory.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut files = Vec::new();
+    for entry in fs::read_dir(directory)
+        .map_err(|error| format!("read native directory {}: {error}", directory.display()))?
+    {
+        let entry = entry.map_err(|error| format!("read native directory entry: {error}"))?;
+        if entry
+            .file_type()
+            .map_err(|error| format!("read native entry type: {error}"))?
+            .is_file()
+            && entry.path().extension().and_then(|value| value.to_str()) == Some(extension)
+        {
+            files.push(entry.path());
+        }
+    }
+    Ok(files)
+}

--- a/sdk_v2/rust/build_support.rs
+++ b/sdk_v2/rust/build_support.rs
@@ -194,10 +194,41 @@ pub fn redact_urls_in_text(text: &str) -> String {
 }
 
 fn find_url_start(value: &str) -> Option<usize> {
-    [value.find("https://"), value.find("http://")]
-        .into_iter()
-        .flatten()
-        .min()
+    let bytes = value.as_bytes();
+    [
+        bytes
+            .windows(b"https://".len())
+            .position(|window| window.eq_ignore_ascii_case(b"https://")),
+        bytes
+            .windows(b"http://".len())
+            .position(|window| window.eq_ignore_ascii_case(b"http://")),
+    ]
+    .into_iter()
+    .flatten()
+    .min()
+}
+
+pub fn invalidate_package(out_dir: &Path, expected_file: &str) -> Result<(), String> {
+    remove_file_if_present(&out_dir.join(expected_file))?;
+    remove_file_if_present(&package_version_path(out_dir, expected_file))
+}
+
+fn remove_file_if_present(path: &Path) -> Result<(), String> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "remove stale package file {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+pub fn contains_expected_file(files: &[PathBuf], expected_file: &str) -> bool {
+    files.iter().any(|file| {
+        file.file_name()
+            .is_some_and(|file_name| file_name == expected_file)
+    })
 }
 
 pub fn package_is_current(out_dir: &Path, expected_file: &str, version: &str) -> bool {

--- a/sdk_v2/rust/build_support.rs
+++ b/sdk_v2/rust/build_support.rs
@@ -213,6 +213,26 @@ pub fn invalidate_package(out_dir: &Path, expected_file: &str) -> Result<(), Str
     remove_file_if_present(&package_version_path(out_dir, expected_file))
 }
 
+pub fn invalidate_package_version_markers(out_dir: &Path) -> Result<(), String> {
+    for entry in fs::read_dir(out_dir)
+        .map_err(|error| format!("read native cache {}: {error}", out_dir.display()))?
+    {
+        let entry = entry.map_err(|error| format!("read native cache entry: {error}"))?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        if entry
+            .file_type()
+            .map_err(|error| format!("read native cache entry type: {error}"))?
+            .is_file()
+            && file_name.starts_with('.')
+            && file_name.ends_with(".version")
+        {
+            remove_file_if_present(&entry.path())?;
+        }
+    }
+    Ok(())
+}
+
 fn remove_file_if_present(path: &Path) -> Result<(), String> {
     match fs::remove_file(path) {
         Ok(()) => Ok(()),

--- a/sdk_v2/rust/build_support.rs
+++ b/sdk_v2/rust/build_support.rs
@@ -251,6 +251,37 @@ fn package_version_path(out_dir: &Path, expected_file: &str) -> PathBuf {
     out_dir.join(format!(".{expected_file}.version"))
 }
 
+pub fn reset_native_cache_if_stale(
+    out_dir: &Path,
+    packages: &[(&str, &str)],
+    extension: &str,
+) -> Result<bool, String> {
+    if packages
+        .iter()
+        .all(|(expected_file, version)| package_is_current(out_dir, expected_file, version))
+    {
+        return Ok(false);
+    }
+
+    for entry in fs::read_dir(out_dir)
+        .map_err(|error| format!("read native cache {}: {error}", out_dir.display()))?
+    {
+        let entry = entry.map_err(|error| format!("read native cache entry: {error}"))?;
+        if entry
+            .file_type()
+            .map_err(|error| format!("read native cache entry type: {error}"))?
+            .is_file()
+            && entry.path().extension().and_then(|value| value.to_str()) == Some(extension)
+        {
+            remove_file_if_present(&entry.path())?;
+        }
+    }
+    for (expected_file, _) in packages {
+        remove_file_if_present(&package_version_path(out_dir, expected_file))?;
+    }
+    Ok(true)
+}
+
 pub fn generate_restore_project(packages: &[(&str, &str)]) -> String {
     let references = packages
         .iter()

--- a/sdk_v2/rust/http_extract.rs
+++ b/sdk_v2/rust/http_extract.rs
@@ -1,0 +1,105 @@
+use std::fs;
+use std::io::{self, Read, Seek};
+use std::path::{Path, PathBuf};
+
+pub fn extract_package<R: Read + Seek>(
+    reader: R,
+    rid: &str,
+    extension: &str,
+    expected_file: &str,
+    staging_dir: &Path,
+) -> Result<Vec<PathBuf>, String> {
+    reset_dir(staging_dir)?;
+    let result = extract_package_inner(reader, rid, extension, expected_file, staging_dir);
+    if result.is_err() {
+        cleanup_dir(staging_dir);
+    }
+    result
+}
+
+fn extract_package_inner<R: Read + Seek>(
+    reader: R,
+    rid: &str,
+    extension: &str,
+    expected_file: &str,
+    staging_dir: &Path,
+) -> Result<Vec<PathBuf>, String> {
+    let native_prefix = format!("runtimes/{rid}/native/");
+    let runtime_prefix = format!("runtimes/{rid}/");
+    let mut archive =
+        zip::ZipArchive::new(reader).map_err(|error| format!("open nupkg: {error}"))?;
+    let mut extracted = Vec::new();
+
+    for index in 0..archive.len() {
+        let mut file = archive
+            .by_index(index)
+            .map_err(|error| format!("read zip entry: {error}"))?;
+        let entry = file.name().to_string();
+        if !entry.ends_with(&format!(".{extension}")) {
+            continue;
+        }
+        let direct = entry
+            .strip_prefix(&runtime_prefix)
+            .is_some_and(|relative| !relative.is_empty() && !relative.contains('/'));
+        if !entry.starts_with(&native_prefix) && !direct {
+            continue;
+        }
+        let Some(file_name) = Path::new(&entry).file_name() else {
+            continue;
+        };
+        let destination = staging_dir.join(file_name);
+        let mut output = fs::File::create(&destination)
+            .map_err(|error| format!("create {}: {error}", destination.display()))?;
+        io::copy(&mut file, &mut output)
+            .map_err(|error| format!("write {}: {error}", destination.display()))?;
+        extracted.push(destination);
+    }
+
+    if extracted
+        .iter()
+        .any(|path| path.file_name().is_some_and(|name| name == expected_file))
+    {
+        Ok(extracted)
+    } else {
+        Err(format!(
+            "archive did not contain expected file {expected_file}"
+        ))
+    }
+}
+
+pub fn stage_files(files: &[PathBuf], out_dir: &Path) -> Result<(), String> {
+    for file in files {
+        let file_name = file
+            .file_name()
+            .ok_or_else(|| format!("native file has no file name: {}", file.display()))?;
+        fs::copy(file, out_dir.join(file_name))
+            .map_err(|error| format!("stage {}: {error}", file.display()))?;
+    }
+    Ok(())
+}
+
+pub fn cleanup_dir(path: &Path) {
+    if let Err(error) = fs::remove_dir_all(path) {
+        if error.kind() != io::ErrorKind::NotFound {
+            println!(
+                "cargo:warning=Could not remove temporary directory {}: {error}",
+                path.display()
+            );
+        }
+    }
+}
+
+fn reset_dir(path: &Path) -> Result<(), String> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "remove temporary directory {}: {error}",
+                path.display()
+            ));
+        }
+    }
+    fs::create_dir_all(path)
+        .map_err(|error| format!("create temporary directory {}: {error}", path.display()))
+}

--- a/sdk_v2/rust/tests/build_support_test.rs
+++ b/sdk_v2/rust/tests/build_support_test.rs
@@ -428,3 +428,50 @@ fn expected_file_check_uses_the_current_package_file_list() {
         "missing.dll"
     ));
 }
+
+#[test]
+fn stale_package_resets_all_managed_native_files() {
+    let root = test_dir("reset-native-cache");
+    fs::create_dir_all(&root).unwrap();
+    create_file(&root.join("runtime.dll"));
+    create_file(&root.join("stale-companion.dll"));
+    create_file(&root.join("ort.dll"));
+    create_file(&root.join("keep.txt"));
+    build_support::record_package_version(&root, "runtime.dll", "1.0.0").unwrap();
+    build_support::record_package_version(&root, "ort.dll", "2.0.0").unwrap();
+
+    let reset = build_support::reset_native_cache_if_stale(
+        &root,
+        &[("runtime.dll", "1.1.0"), ("ort.dll", "2.0.0")],
+        "dll",
+    )
+    .unwrap();
+
+    assert!(reset);
+    assert!(!root.join("runtime.dll").exists());
+    assert!(!root.join("stale-companion.dll").exists());
+    assert!(!root.join("ort.dll").exists());
+    assert!(root.join("keep.txt").exists());
+    assert!(!build_support::package_is_current(
+        &root, "ort.dll", "2.0.0"
+    ));
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn current_native_cache_is_left_untouched() {
+    let root = test_dir("keep-native-cache");
+    fs::create_dir_all(&root).unwrap();
+    create_file(&root.join("runtime.dll"));
+    create_file(&root.join("companion.dll"));
+    build_support::record_package_version(&root, "runtime.dll", "1.0.0").unwrap();
+
+    let reset =
+        build_support::reset_native_cache_if_stale(&root, &[("runtime.dll", "1.0.0")], "dll")
+            .unwrap();
+
+    assert!(!reset);
+    assert!(root.join("runtime.dll").exists());
+    assert!(root.join("companion.dll").exists());
+    fs::remove_dir_all(root).unwrap();
+}

--- a/sdk_v2/rust/tests/build_support_test.rs
+++ b/sdk_v2/rust/tests/build_support_test.rs
@@ -475,3 +475,49 @@ fn current_native_cache_is_left_untouched() {
     assert!(root.join("companion.dll").exists());
     fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn local_staging_invalidates_nuget_cache_identity() {
+    let root = test_dir("local-source-transition");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("runtime.dll"), b"nuget").unwrap();
+    fs::write(root.join("ort.dll"), b"nuget").unwrap();
+    build_support::record_package_version(&root, "runtime.dll", "1.0.0").unwrap();
+    build_support::record_package_version(&root, "ort.dll", "2.0.0").unwrap();
+
+    fs::write(root.join("runtime.dll"), b"local").unwrap();
+    build_support::invalidate_package_version_markers(&root).unwrap();
+
+    assert_eq!(fs::read(root.join("runtime.dll")).unwrap(), b"local");
+    assert!(!build_support::package_is_current(
+        &root,
+        "runtime.dll",
+        "1.0.0"
+    ));
+    assert!(!build_support::package_is_current(
+        &root, "ort.dll", "2.0.0"
+    ));
+    assert!(build_support::reset_native_cache_if_stale(
+        &root,
+        &[("runtime.dll", "1.0.0"), ("ort.dll", "2.0.0")],
+        "dll",
+    )
+    .unwrap());
+    assert!(!root.join("runtime.dll").exists());
+    assert!(!root.join("ort.dll").exists());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn marker_invalidation_is_a_noop_without_package_markers() {
+    let root = test_dir("no-package-markers");
+    fs::create_dir_all(&root).unwrap();
+    create_file(&root.join("runtime.dll"));
+    create_file(&root.join(".unrelated"));
+
+    build_support::invalidate_package_version_markers(&root).unwrap();
+
+    assert!(root.join("runtime.dll").exists());
+    assert!(root.join(".unrelated").exists());
+    fs::remove_dir_all(root).unwrap();
+}

--- a/sdk_v2/rust/tests/build_support_test.rs
+++ b/sdk_v2/rust/tests/build_support_test.rs
@@ -1,0 +1,386 @@
+#[allow(dead_code)]
+#[path = "../build_support.rs"]
+mod build_support;
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use build_support::{NuGetConfig, NuGetMode, DEFAULT_FEEDS};
+
+fn config_from(values: &[(&str, &str)], is_windows: bool) -> Result<NuGetConfig, String> {
+    let values: HashMap<_, _> = values
+        .iter()
+        .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+        .collect();
+    build_support::read_config_from(|name| values.get(name).cloned(), is_windows)
+}
+
+fn args_as_strings(args: Vec<OsString>) -> Vec<String> {
+    args.into_iter()
+        .map(|value| value.to_string_lossy().into_owned())
+        .collect()
+}
+
+fn test_dir(name: &str) -> PathBuf {
+    static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "foundry-rust-build-support-{name}-{}-{id}",
+        std::process::id()
+    ))
+}
+
+fn create_file(path: &Path) {
+    fs::create_dir_all(path.parent().expect("test file must have a parent")).unwrap();
+    fs::write(path, []).unwrap();
+}
+
+#[test]
+fn config_defaults_to_http_and_public_feeds() {
+    let config = config_from(&[], false).unwrap();
+    assert_eq!(config.mode, NuGetMode::Http);
+    assert_eq!(
+        config.feeds,
+        DEFAULT_FEEDS
+            .iter()
+            .map(|feed| (*feed).to_string())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(config.dotnet_command, "dotnet");
+    assert_eq!(config.nuget_command, "nuget");
+}
+
+#[test]
+fn config_accepts_each_mode_and_windows_nuget_default() {
+    assert_eq!(
+        config_from(&[("FOUNDRY_LOCAL_NUGET_MODE", "http")], false)
+            .unwrap()
+            .mode,
+        NuGetMode::Http
+    );
+    assert_eq!(
+        config_from(&[("FOUNDRY_LOCAL_NUGET_MODE", "dotnet")], false)
+            .unwrap()
+            .mode,
+        NuGetMode::Dotnet
+    );
+    let config = config_from(&[("FOUNDRY_LOCAL_NUGET_MODE", "nuget")], true).unwrap();
+    assert_eq!(config.mode, NuGetMode::Nuget);
+    assert_eq!(config.nuget_command, "nuget.exe");
+}
+
+#[test]
+fn config_rejects_invalid_mode() {
+    let error = config_from(&[("FOUNDRY_LOCAL_NUGET_MODE", "ftp")], false).unwrap_err();
+    assert!(error.contains("Invalid FOUNDRY_LOCAL_NUGET_MODE"));
+}
+
+#[test]
+fn custom_feeds_replace_defaults_and_ignore_empty_entries() {
+    let config = config_from(
+        &[(
+            "FOUNDRY_LOCAL_NUGET_FEEDS",
+            " https://one.example/v3/index.json ; ; https://two.example/v3/index.json ",
+        )],
+        false,
+    )
+    .unwrap();
+    assert_eq!(
+        config.feeds,
+        [
+            "https://one.example/v3/index.json",
+            "https://two.example/v3/index.json"
+        ]
+    );
+    assert!(!config
+        .feeds
+        .iter()
+        .any(|feed| DEFAULT_FEEDS.contains(&feed.as_str())));
+}
+
+#[test]
+fn config_rejects_empty_invalid_insecure_and_credentialed_http_feeds() {
+    for feed in [
+        "",
+        " ; ",
+        "not-a-url",
+        "http://feed.example/v3/index.json",
+        "https://user:secret@feed.example/v3/index.json",
+    ] {
+        assert!(
+            config_from(&[("FOUNDRY_LOCAL_NUGET_FEEDS", feed)], false).is_err(),
+            "feed should have been rejected: {feed}"
+        );
+    }
+}
+
+#[test]
+fn tool_modes_allow_non_https_feeds() {
+    for mode in ["dotnet", "nuget"] {
+        let config = config_from(
+            &[
+                ("FOUNDRY_LOCAL_NUGET_MODE", mode),
+                (
+                    "FOUNDRY_LOCAL_NUGET_FEEDS",
+                    "http://trusted-intranet.example/v3/index.json",
+                ),
+            ],
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            config.feeds,
+            ["http://trusted-intranet.example/v3/index.json"]
+        );
+    }
+}
+
+#[test]
+fn http_package_base_address_must_be_https() {
+    assert!(
+        build_support::validate_http_package_base_address("https://packages.example/v3/flat/")
+            .is_ok()
+    );
+    assert!(
+        build_support::validate_http_package_base_address("http://packages.example/v3/flat/")
+            .is_err()
+    );
+}
+
+#[test]
+fn config_rejects_mode_incompatible_variables() {
+    let cases = [
+        vec![("FOUNDRY_LOCAL_NUGET_CONFIG", "NuGet.Config")],
+        vec![("FOUNDRY_LOCAL_DOTNET_COMMAND", "dotnet-custom")],
+        vec![("FOUNDRY_LOCAL_NUGET_COMMAND", "nuget-custom")],
+        vec![
+            ("FOUNDRY_LOCAL_NUGET_MODE", "dotnet"),
+            ("FOUNDRY_LOCAL_NUGET_COMMAND", "nuget-custom"),
+        ],
+        vec![
+            ("FOUNDRY_LOCAL_NUGET_MODE", "nuget"),
+            ("FOUNDRY_LOCAL_DOTNET_COMMAND", "dotnet-custom"),
+        ],
+    ];
+    for values in cases {
+        assert!(config_from(&values, false).is_err());
+    }
+}
+
+#[test]
+fn config_accepts_config_file_and_mode_specific_commands() {
+    let dotnet = config_from(
+        &[
+            ("FOUNDRY_LOCAL_NUGET_MODE", "dotnet"),
+            ("FOUNDRY_LOCAL_NUGET_CONFIG", "/tmp/NuGet.Config"),
+            ("FOUNDRY_LOCAL_DOTNET_COMMAND", "dotnet-custom"),
+        ],
+        false,
+    )
+    .unwrap();
+    assert_eq!(dotnet.config_file.as_deref(), Some("/tmp/NuGet.Config"));
+    assert_eq!(dotnet.dotnet_command, "dotnet-custom");
+
+    let nuget = config_from(
+        &[
+            ("FOUNDRY_LOCAL_NUGET_MODE", "nuget"),
+            ("FOUNDRY_LOCAL_NUGET_CONFIG", "/tmp/NuGet.Config"),
+            ("FOUNDRY_LOCAL_NUGET_COMMAND", "nuget-custom"),
+        ],
+        false,
+    )
+    .unwrap();
+    assert_eq!(nuget.config_file.as_deref(), Some("/tmp/NuGet.Config"));
+    assert_eq!(nuget.nuget_command, "nuget-custom");
+}
+
+#[test]
+fn dotnet_args_use_config_without_sources() {
+    let config = config_from(
+        &[
+            ("FOUNDRY_LOCAL_NUGET_MODE", "dotnet"),
+            ("FOUNDRY_LOCAL_NUGET_CONFIG", "/tmp/NuGet.Config"),
+        ],
+        false,
+    )
+    .unwrap();
+    let args = args_as_strings(build_support::build_dotnet_restore_args(
+        &config,
+        Path::new("restore.csproj"),
+        Path::new("packages"),
+    ));
+    assert_eq!(
+        args,
+        [
+            "restore",
+            "restore.csproj",
+            "--packages",
+            "packages",
+            "--no-cache",
+            "--configfile",
+            "/tmp/NuGet.Config"
+        ]
+    );
+    assert!(!args.iter().any(|arg| arg == "--source"));
+    assert!(!args.iter().any(|arg| arg == "--runtime"));
+}
+
+#[test]
+fn dotnet_args_use_each_feed_without_config() {
+    let config = config_from(
+        &[
+            ("FOUNDRY_LOCAL_NUGET_MODE", "dotnet"),
+            (
+                "FOUNDRY_LOCAL_NUGET_FEEDS",
+                "https://one.example/v3/index.json;https://two.example/v3/index.json",
+            ),
+        ],
+        false,
+    )
+    .unwrap();
+    let args = args_as_strings(build_support::build_dotnet_restore_args(
+        &config,
+        Path::new("restore.csproj"),
+        Path::new("packages"),
+    ));
+    assert_eq!(args.iter().filter(|arg| *arg == "--source").count(), 2);
+    assert!(args.contains(&"https://one.example/v3/index.json".to_string()));
+    assert!(args.contains(&"https://two.example/v3/index.json".to_string()));
+}
+
+#[test]
+fn nuget_args_use_exact_install_flags_and_config_without_sources() {
+    let config = config_from(
+        &[
+            ("FOUNDRY_LOCAL_NUGET_MODE", "nuget"),
+            ("FOUNDRY_LOCAL_NUGET_CONFIG", "/tmp/NuGet.Config"),
+        ],
+        false,
+    )
+    .unwrap();
+    let args = args_as_strings(build_support::build_nuget_install_args(
+        &config,
+        "Microsoft.ML.OnnxRuntime",
+        "1.2.3",
+        Path::new("packages"),
+    ));
+    assert_eq!(
+        args,
+        [
+            "install",
+            "Microsoft.ML.OnnxRuntime",
+            "-Version",
+            "1.2.3",
+            "-OutputDirectory",
+            "packages",
+            "-NonInteractive",
+            "-DirectDownload",
+            "-DependencyVersion",
+            "Ignore",
+            "-ConfigFile",
+            "/tmp/NuGet.Config"
+        ]
+    );
+    assert!(!args.iter().any(|arg| arg == "-Source"));
+}
+
+#[test]
+fn generated_restore_project_pins_exact_versions_and_escapes_xml() {
+    let project = build_support::generate_restore_project(&[
+        ("Package.One", "1.2.3"),
+        ("Package<&Two", "4.5.6"),
+    ]);
+    assert!(project.contains(r#"Include="Package.One" Version="[1.2.3]""#));
+    assert!(project.contains(r#"Include="Package&lt;&amp;Two" Version="[4.5.6]""#));
+    assert!(project.contains("<TargetFramework>net8.0</TargetFramework>"));
+}
+
+#[test]
+fn package_discovery_handles_dotnet_and_nuget_layouts() {
+    let root = test_dir("package-layouts");
+    let dotnet_dir = root
+        .join("dotnet")
+        .join("microsoft.ml.onnxruntime")
+        .join("1.2.3");
+    fs::create_dir_all(&dotnet_dir).unwrap();
+    assert_eq!(
+        build_support::find_dotnet_package_dir(
+            &root.join("dotnet"),
+            "Microsoft.ML.OnnxRuntime",
+            "1.2.3"
+        )
+        .unwrap(),
+        dotnet_dir
+    );
+
+    let nuget_dir = root.join("nuget").join("microsoft.ml.onnxruntime.1.2.3");
+    fs::create_dir_all(&nuget_dir).unwrap();
+    assert_eq!(
+        build_support::find_nuget_package_dir(
+            &root.join("nuget"),
+            "Microsoft.ML.OnnxRuntime",
+            "1.2.3"
+        )
+        .unwrap(),
+        nuget_dir
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn native_collection_matches_http_mode_layout_and_extension_filter() {
+    let root = test_dir("native-files");
+    let native_dir = root.join("runtimes").join("linux-x64").join("native");
+    let runtime_dir = root.join("runtimes").join("linux-x64");
+    create_file(&native_dir.join("libfoundry_local.so"));
+    create_file(&native_dir.join("readme.txt"));
+    create_file(&runtime_dir.join("libonnxruntime-genai.so"));
+    create_file(&runtime_dir.join("libonnxruntime.so.1"));
+    create_file(&runtime_dir.join("nested").join("ignored.so"));
+
+    let files = build_support::collect_native_files(&root, "linux-x64", "so").unwrap();
+    assert_eq!(
+        files,
+        [
+            runtime_dir.join("libonnxruntime-genai.so"),
+            native_dir.join("libfoundry_local.so")
+        ]
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn url_redaction_removes_credentials_queries_and_fragments() {
+    let text = "failed https://user:secret@example.test/package?sig=secret#fragment then retry";
+    let redacted = build_support::redact_urls_in_text(text);
+    assert_eq!(redacted, "failed https://example.test/package then retry");
+    assert!(!redacted.contains("secret"));
+}
+
+#[test]
+fn package_cache_requires_a_matching_version_marker() {
+    let root = test_dir("package-version");
+    fs::create_dir_all(&root).unwrap();
+    create_file(&root.join("native.dll"));
+    assert!(!build_support::package_is_current(
+        &root,
+        "native.dll",
+        "1.0.0"
+    ));
+
+    build_support::record_package_version(&root, "native.dll", "1.0.0").unwrap();
+    assert!(build_support::package_is_current(
+        &root,
+        "native.dll",
+        "1.0.0"
+    ));
+    assert!(!build_support::package_is_current(
+        &root,
+        "native.dll",
+        "2.0.0"
+    ));
+    fs::remove_dir_all(root).unwrap();
+}

--- a/sdk_v2/rust/tests/build_support_test.rs
+++ b/sdk_v2/rust/tests/build_support_test.rs
@@ -361,6 +361,19 @@ fn url_redaction_removes_credentials_queries_and_fragments() {
 }
 
 #[test]
+fn url_redaction_recognizes_mixed_case_schemes() {
+    let text =
+        "failed HTTPS://user:secret@example.test/package?sig=secret then Http://other.test/#token";
+    let redacted = build_support::redact_urls_in_text(text);
+    assert_eq!(
+        redacted,
+        "failed HTTPS://example.test/package then Http://other.test/"
+    );
+    assert!(!redacted.contains("secret"));
+    assert!(!redacted.contains("token"));
+}
+
+#[test]
 fn package_cache_requires_a_matching_version_marker() {
     let root = test_dir("package-version");
     fs::create_dir_all(&root).unwrap();
@@ -383,4 +396,35 @@ fn package_cache_requires_a_matching_version_marker() {
         "2.0.0"
     ));
     fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn package_invalidation_removes_binary_and_version_marker() {
+    let root = test_dir("package-invalidation");
+    fs::create_dir_all(&root).unwrap();
+    create_file(&root.join("native.dll"));
+    build_support::record_package_version(&root, "native.dll", "1.0.0").unwrap();
+
+    build_support::invalidate_package(&root, "native.dll").unwrap();
+
+    assert!(!root.join("native.dll").exists());
+    assert!(!build_support::package_is_current(
+        &root,
+        "native.dll",
+        "1.0.0"
+    ));
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn expected_file_check_uses_the_current_package_file_list() {
+    let files = vec![
+        PathBuf::from("runtimes/win-x64/native/helper.dll"),
+        PathBuf::from("runtimes/win-x64/native/native.dll"),
+    ];
+    assert!(build_support::contains_expected_file(&files, "native.dll"));
+    assert!(!build_support::contains_expected_file(
+        &files,
+        "missing.dll"
+    ));
 }

--- a/sdk_v2/rust/tests/http_extract_test.rs
+++ b/sdk_v2/rust/tests/http_extract_test.rs
@@ -1,0 +1,90 @@
+#[path = "../http_extract.rs"]
+mod http_extract;
+
+use std::fs;
+use std::io::{Cursor, Write};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn test_dir(name: &str) -> PathBuf {
+    static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "foundry-rust-http-extract-{name}-{}-{id}",
+        std::process::id()
+    ))
+}
+
+fn archive(entries: &[(&str, &[u8])]) -> Cursor<Vec<u8>> {
+    let mut bytes = Cursor::new(Vec::new());
+    {
+        let mut writer = zip::ZipWriter::new(&mut bytes);
+        for (name, contents) in entries {
+            writer
+                .start_file(*name, zip::write::SimpleFileOptions::default())
+                .unwrap();
+            writer.write_all(contents).unwrap();
+        }
+        writer.finish().unwrap();
+    }
+    bytes.set_position(0);
+    bytes
+}
+
+#[test]
+fn rejected_archive_does_not_contaminate_shared_output() {
+    let root = test_dir("rejected");
+    let staging = root.join("staging");
+    let output = root.join("output");
+    fs::create_dir_all(&output).unwrap();
+
+    let result = http_extract::extract_package(
+        archive(&[("runtimes/win-x64/native/companion.dll", b"stale")]),
+        "win-x64",
+        "dll",
+        "expected.dll",
+        &staging,
+    );
+
+    assert!(result.is_err());
+    assert!(!output.join("companion.dll").exists());
+    assert!(!staging.exists());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn failed_attempt_cannot_contaminate_later_success() {
+    let root = test_dir("retry");
+    let staging = root.join("staging");
+    let output = root.join("output");
+    fs::create_dir_all(&output).unwrap();
+
+    assert!(http_extract::extract_package(
+        archive(&[("runtimes/win-x64/native/failed-only.dll", b"failed")]),
+        "win-x64",
+        "dll",
+        "expected.dll",
+        &staging,
+    )
+    .is_err());
+    let files = http_extract::extract_package(
+        archive(&[
+            ("runtimes/win-x64/native/expected.dll", b"expected"),
+            ("runtimes/win-x64/native/companion.dll", b"companion"),
+        ]),
+        "win-x64",
+        "dll",
+        "expected.dll",
+        &staging,
+    )
+    .unwrap();
+    http_extract::stage_files(&files, &output).unwrap();
+
+    assert_eq!(fs::read(output.join("expected.dll")).unwrap(), b"expected");
+    assert_eq!(
+        fs::read(output.join("companion.dll")).unwrap(),
+        b"companion"
+    );
+    assert!(!output.join("failed-only.dll").exists());
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
## Why

The Rust SDK build script downloaded native packages directly from hard-coded public NuGet feeds. That prevented developers behind authenticated feeds, mirrors, or enterprise proxies from using their existing `NuGet.Config` and credential-provider setup.

## What changed

This PR brings Rust native-package acquisition in line with the JavaScript SDK while keeping direct HTTPS downloads as the default.

| Mode | Behavior |
| --- | --- |
| `http` | Downloads from configurable HTTPS v3 feeds without invoking external tools. |
| `dotnet` | Restores exact package versions with `dotnet restore`, honoring `NuGet.Config` and standard authentication. |
| `nuget` | Restores exact package versions with the NuGet CLI, also honoring `NuGet.Config` and standard authentication. |

The build script now supports feed, config-file, and executable overrides; redacts sensitive URLs; prevents HTTPS downgrade redirects; and preserves the existing warning-plus-runtime-fallback behavior when acquisition fails. Native packages are staged through isolated temporary directories, and version/source transitions invalidate stale cache state before reuse. Cargo also watches the configured `NuGet.Config`, so editing a failed feed or credential configuration triggers another acquisition attempt.

## Validation

- 26 focused, network-free tests covering configuration, command construction, URL redaction, package discovery, cache transitions, archive rejection, and isolated staging
- Rust formatting and Clippy with warnings denied
- Published-crate content verification for the shared build-support and extraction modules
- Live `dotnet` and `nuget` restores through the machine proxy-only NuGet configuration

## Follow-up

#1050 tracks independent SHA-512 pins for additional HTTP-mode package-integrity hardening.

Closes #1033