### PR TITLE
pipelines fixes for 2.0.0 release

### DIFF
--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -267,4 +267,3 @@ extends:
         ortVersion: $(cppOrtVersion)
         genaiVersion: $(cppGenaiVersion)
         winmlVersion: $(cppWinmlVersion)
-        isRelease: ${{ parameters.isRelease }}

--- a/.pipelines/v2/templates/stages-build-native.yml
+++ b/.pipelines/v2/templates/stages-build-native.yml
@@ -18,8 +18,6 @@ parameters:
   type: string
 - name: winmlVersion
   type: string
-- name: isRelease
-  type: boolean
 
 stages:
 
@@ -194,7 +192,6 @@ stages:
           ortVersion: ${{ parameters.ortVersion }}
           genaiVersion: ${{ parameters.genaiVersion }}
           runTests: true
-          isRelease: ${{ parameters.isRelease }}
 
   # ====================================================================
   # Pack — C++ SDK tgz bundles (base platforms)
@@ -296,7 +293,6 @@ stages:
         parameters:
           ortVersion: ${{ parameters.ortVersion }}
           genaiVersion: ${{ parameters.genaiVersion }}
-          isRelease: ${{ parameters.isRelease }}
 
   # ====================================================================
   # Package test — consume the Windows x64 C++ SDK bundle

--- a/.pipelines/v2/templates/stages-build-native.yml
+++ b/.pipelines/v2/templates/stages-build-native.yml
@@ -296,6 +296,7 @@ stages:
         parameters:
           ortVersion: ${{ parameters.ortVersion }}
           genaiVersion: ${{ parameters.genaiVersion }}
+          isRelease: ${{ parameters.isRelease }}
 
   # ====================================================================
   # Package test — consume the Windows x64 C++ SDK bundle

--- a/.pipelines/v2/templates/stages-js.yml
+++ b/.pipelines/v2/templates/stages-js.yml
@@ -13,10 +13,6 @@
 #
 # Tests run on the same platform as the build.
 
-parameters:
-- name: isRelease
-  type: boolean
-
 stages:
 
 # =====================================================================
@@ -34,8 +30,7 @@ stages:
       name: onnxruntime-Win-CPU-2022
       os: windows
     variables:
-    - ${{ if eq(parameters.isRelease, true) }}:
-      - group: FoundryLocal-ESRP-Signing
+    - group: FoundryLocal-ESRP-Signing
     templateContext:
       inputs:
       - input: pipelineArtifact
@@ -56,7 +51,7 @@ stages:
         rid: 'win-x64'
         nativeArtifactDir: '$(Pipeline.Workspace)/cpp-native-win-x64'
         outputDir: '$(Build.ArtifactStagingDirectory)/js-prebuild'
-        signWindows: ${{ parameters.isRelease }}
+        signWindows: true
 
 - stage: js_build_win_arm64
   displayName: 'JS SDK: Build Windows ARM64'
@@ -70,8 +65,7 @@ stages:
       os: windows
       hostArchitecture: arm64
     variables:
-    - ${{ if eq(parameters.isRelease, true) }}:
-      - group: FoundryLocal-ESRP-Signing
+    - group: FoundryLocal-ESRP-Signing
     templateContext:
       inputs:
       - input: pipelineArtifact
@@ -92,7 +86,7 @@ stages:
         rid: 'win-arm64'
         nativeArtifactDir: '$(Pipeline.Workspace)/cpp-native-win-arm64'
         outputDir: '$(Build.ArtifactStagingDirectory)/js-prebuild'
-        signWindows: ${{ parameters.isRelease }}
+        signWindows: true
 
 - stage: js_build_linux_x64
   displayName: 'JS SDK: Build Linux x64'
@@ -170,8 +164,7 @@ stages:
       demands:
       - ImageOverride -equals ACES_VM_SharedPool_Sequoia
     variables:
-    - ${{ if eq(parameters.isRelease, true) }}:
-      - group: FoundryLocal-ESRP-Signing
+    - group: FoundryLocal-ESRP-Signing
     templateContext:
       inputs:
       - input: pipelineArtifact
@@ -192,7 +185,7 @@ stages:
         rid: 'osx-arm64'
         nativeArtifactDir: '$(Pipeline.Workspace)/cpp-native-osx-arm64'
         outputDir: '$(Build.ArtifactStagingDirectory)/js-prebuild'
-        signMac: ${{ parameters.isRelease }}
+        signMac: true
 
 # ================================================================
 # Test stages - same platform only.

--- a/.pipelines/v2/templates/stages-sdk-v2.yml
+++ b/.pipelines/v2/templates/stages-sdk-v2.yml
@@ -22,8 +22,6 @@ parameters:
   type: string
 - name: winmlVersion
   type: string
-- name: isRelease
-  type: boolean
 
 stages:
 
@@ -34,7 +32,6 @@ stages:
     ortVersion: ${{ parameters.ortVersion }}
     genaiVersion: ${{ parameters.genaiVersion }}
     winmlVersion: ${{ parameters.winmlVersion }}
-    isRelease: ${{ parameters.isRelease }}
 
 # ── C# SDK ──
 - template: stages-cs.yml
@@ -44,8 +41,6 @@ stages:
 
 # ── JS SDK (single multi-platform tarball) ──
 - template: stages-js.yml
-  parameters:
-    isRelease: ${{ parameters.isRelease }}
 
 # ── Rust SDK (single platform-independent crate) ──
 # Needs the ORT/GenAI versions to assemble a runnable native dir for its

--- a/.pipelines/v2/templates/steps-build-cs.yml
+++ b/.pipelines/v2/templates/steps-build-cs.yml
@@ -109,6 +109,7 @@ steps:
 # Pattern is a recursive glob so every TFM output directory is covered.
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
   displayName: 'Sign SDK DLLs'
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   inputs:
     ConnectedServiceName: 'OnnxrunTimeCodeSign_20240611'
     UseMSIAuthentication: true
@@ -149,6 +150,7 @@ steps:
 # Sign the produced nupkg(s).
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
   displayName: 'Sign SDK NuGet package'
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   inputs:
     ConnectedServiceName: 'OnnxrunTimeCodeSign_20240611'
     UseMSIAuthentication: true

--- a/.pipelines/v2/templates/steps-build-js.yml
+++ b/.pipelines/v2/templates/steps-build-js.yml
@@ -243,6 +243,7 @@ steps:
 - ${{ if eq(parameters.signWindows, true) }}:
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
     displayName: 'Sign Windows JS addon (.node) + foundry_local.dll'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     inputs:
       ConnectedServiceName: 'OnnxrunTimeCodeSign_20240611'
       UseMSIAuthentication: true
@@ -272,10 +273,12 @@ steps:
       rm -f foundry_local_node_addons.zip
       zip foundry_local_node_addons.zip foundry_local_node.node foundry_local_preload.node
     displayName: 'Zip macOS JS addons for signing'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     workingDirectory: '${{ parameters.outputDir }}/prebuilds/$(prebuildDir)'
 
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
     displayName: 'Sign macOS JS addon ZIP'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     inputs:
       ConnectedServiceName: 'OnnxrunTimeCodeSign_20240611'
       UseMSIAuthentication: true
@@ -298,6 +301,7 @@ steps:
       unzip -o foundry_local_node_addons.zip
       rm -- foundry_local_node_addons.zip
     displayName: 'Extract signed macOS JS addons'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     workingDirectory: '${{ parameters.outputDir }}/prebuilds/$(prebuildDir)'
 
   - bash: |
@@ -312,3 +316,4 @@ steps:
         grep -q '^Timestamp=' <<<"$signature"
       done
     displayName: 'Verify macOS JS addon signatures'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/.pipelines/v2/templates/steps-build-macos.yml
+++ b/.pipelines/v2/templates/steps-build-macos.yml
@@ -12,8 +12,6 @@ parameters:
 - name: runTests
   type: boolean
   default: false
-- name: isRelease
-  type: boolean
 
 steps:
 
@@ -115,53 +113,56 @@ steps:
 
   displayName: 'Stage native artifacts'
 
-- ${{ if eq(parameters.isRelease, true) }}:
-  - bash: |
-      set -euo pipefail
-      rm -f libfoundry_local_dylib.zip
-      zip libfoundry_local_dylib.zip libfoundry_local.dylib
-    displayName: 'Zip libfoundry_local.dylib for signing'
-    workingDirectory: '$(Build.ArtifactStagingDirectory)/native'
+- bash: |
+    set -euo pipefail
+    rm -f libfoundry_local_dylib.zip
+    zip libfoundry_local_dylib.zip libfoundry_local.dylib
+  displayName: 'Zip libfoundry_local.dylib for signing'
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  workingDirectory: '$(Build.ArtifactStagingDirectory)/native'
 
-  # ESRP requires a ZIP or DMG transport for macOS signing. The C++ SDK archive,
-  # runtime NuGet/C# SDK, Python wheel, and JS prebuild all consume the signed
-  # staged dylib restored from this archive.
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
-    displayName: 'Sign libfoundry_local.dylib ZIP'
-    inputs:
-      ConnectedServiceName: 'OnnxrunTimeCodeSign_20240611'
-      UseMSIAuthentication: true
-      AppRegistrationClientId: '$(esrpClientId)'
-      AppRegistrationTenantId: '$(esrpTenantId)'
-      EsrpClientId: '$(esrpClientId)'
-      AuthAKVName: '$(esrpAkvName)'
-      AuthSignCertName: '$(esrpSignCertName)'
-      FolderPath: '$(Build.ArtifactStagingDirectory)/native'
-      Pattern: 'libfoundry_local_dylib.zip'
-      SessionTimeout: 90
-      ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
-      MaxConcurrency: 25
-      signConfigType: inlineSignParams
-      inlineOperation: |
-        [{"keyCode":"CP-401337-Apple","operationSetCode":"MacAppDeveloperSign","parameters":[{"parameterName":"Hardening","parameterValue":"--options=runtime"}],"toolName":"sign","toolVersion":"6.2.9304.0"}]
+# ESRP requires a ZIP or DMG transport for macOS signing. The C++ SDK archive,
+# runtime NuGet/C# SDK, Python wheel, and JS prebuild all consume the signed
+# staged dylib restored from this archive.
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+  displayName: 'Sign libfoundry_local.dylib ZIP'
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  inputs:
+    ConnectedServiceName: 'OnnxrunTimeCodeSign_20240611'
+    UseMSIAuthentication: true
+    AppRegistrationClientId: '$(esrpClientId)'
+    AppRegistrationTenantId: '$(esrpTenantId)'
+    EsrpClientId: '$(esrpClientId)'
+    AuthAKVName: '$(esrpAkvName)'
+    AuthSignCertName: '$(esrpSignCertName)'
+    FolderPath: '$(Build.ArtifactStagingDirectory)/native'
+    Pattern: 'libfoundry_local_dylib.zip'
+    SessionTimeout: 90
+    ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
+    MaxConcurrency: 25
+    signConfigType: inlineSignParams
+    inlineOperation: |
+      [{"keyCode":"CP-401337-Apple","operationSetCode":"MacAppDeveloperSign","parameters":[{"parameterName":"Hardening","parameterValue":"--options=runtime"}],"toolName":"sign","toolVersion":"6.2.9304.0"}]
 
-  - bash: |
-      set -euo pipefail
-      unzip -o libfoundry_local_dylib.zip
-      rm -- libfoundry_local_dylib.zip
-    displayName: 'Extract signed libfoundry_local.dylib'
-    workingDirectory: '$(Build.ArtifactStagingDirectory)/native'
+- bash: |
+    set -euo pipefail
+    unzip -o libfoundry_local_dylib.zip
+    rm -- libfoundry_local_dylib.zip
+  displayName: 'Extract signed libfoundry_local.dylib'
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  workingDirectory: '$(Build.ArtifactStagingDirectory)/native'
 
-  - bash: |
-      set -euo pipefail
-      dylib='$(Build.ArtifactStagingDirectory)/native/libfoundry_local.dylib'
-      codesign --verify --strict --verbose=2 "$dylib"
-      signature=$(codesign --display --verbose=4 "$dylib" 2>&1)
-      echo "$signature"
-      grep -q '^Authority=Developer ID Application:' <<<"$signature"
-      grep -Eq '^CodeDirectory .*flags=.*\(.*runtime.*\)' <<<"$signature"
-      grep -q '^Timestamp=' <<<"$signature"
-    displayName: 'Verify libfoundry_local.dylib signature'
+- bash: |
+    set -euo pipefail
+    dylib='$(Build.ArtifactStagingDirectory)/native/libfoundry_local.dylib'
+    codesign --verify --strict --verbose=2 "$dylib"
+    signature=$(codesign --display --verbose=4 "$dylib" 2>&1)
+    echo "$signature"
+    grep -q '^Authority=Developer ID Application:' <<<"$signature"
+    grep -Eq '^CodeDirectory .*flags=.*\(.*runtime.*\)' <<<"$signature"
+    grep -q '^Timestamp=' <<<"$signature"
+  displayName: 'Verify libfoundry_local.dylib signature'
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
 # Stage debug symbols into a separate artifact so they can be published
 # independently without being bundled into the Python wheel (which consumes

--- a/.pipelines/v2/templates/steps-pack-nuget.yml
+++ b/.pipelines/v2/templates/steps-pack-nuget.yml
@@ -13,8 +13,6 @@ parameters:
   type: string
 - name: genaiVersion
   type: string
-- name: isRelease
-  type: boolean
 
 steps:
 
@@ -80,24 +78,24 @@ steps:
       Write-Host "Generated packages:"
       Get-ChildItem $outDir -Filter '*.nupkg' | ForEach-Object { Write-Host "  $($_.Name)" }
 
-# Sign and verify release Runtime packages before they are published as
-# pipeline artifacts. PR builds still produce unsigned validation packages.
-- ${{ if eq(parameters.isRelease, true) }}:
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
-    displayName: 'Sign Runtime NuGet package'
-    inputs:
-      ConnectedServiceName: 'OnnxrunTimeCodeSign_20240611'
-      UseMSIAuthentication: true
-      AppRegistrationClientId: '$(esrpClientId)'
-      AppRegistrationTenantId: '$(esrpTenantId)'
-      EsrpClientId: '$(esrpClientId)'
-      AuthAKVName: '$(esrpAkvName)'
-      AuthSignCertName: '$(esrpSignCertName)'
-      FolderPath: '$(Build.ArtifactStagingDirectory)/nuget'
-      Pattern: '*.nupkg'
-      SessionTimeout: 90
-      ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
-      MaxConcurrency: 25
-      signConfigType: inlineSignParams
-      inlineOperation: |
-        [{"keyCode":"CP-401405","operationSetCode":"NuGetSign","parameters":[],"toolName":"sign","toolVersion":"6.2.9304.0"},{"keyCode":"CP-401405","operationSetCode":"NuGetVerify","parameters":[],"toolName":"sign","toolVersion":"6.2.9304.0"}]
+# Sign and verify Runtime packages from non-PR builds before they are published
+# as pipeline artifacts. PR builds still produce unsigned validation packages.
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+  displayName: 'Sign Runtime NuGet package'
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  inputs:
+    ConnectedServiceName: 'OnnxrunTimeCodeSign_20240611'
+    UseMSIAuthentication: true
+    AppRegistrationClientId: '$(esrpClientId)'
+    AppRegistrationTenantId: '$(esrpTenantId)'
+    EsrpClientId: '$(esrpClientId)'
+    AuthAKVName: '$(esrpAkvName)'
+    AuthSignCertName: '$(esrpSignCertName)'
+    FolderPath: '$(Build.ArtifactStagingDirectory)/nuget'
+    Pattern: '*.nupkg'
+    SessionTimeout: 90
+    ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
+    MaxConcurrency: 25
+    signConfigType: inlineSignParams
+    inlineOperation: |
+      [{"keyCode":"CP-401405","operationSetCode":"NuGetSign","parameters":[],"toolName":"sign","toolVersion":"6.2.9304.0"},{"keyCode":"CP-401405","operationSetCode":"NuGetVerify","parameters":[],"toolName":"sign","toolVersion":"6.2.9304.0"}]

--- a/.pipelines/v2/templates/steps-pack-nuget.yml
+++ b/.pipelines/v2/templates/steps-pack-nuget.yml
@@ -77,3 +77,24 @@ steps:
 
       Write-Host "Generated packages:"
       Get-ChildItem $outDir -Filter '*.nupkg' | ForEach-Object { Write-Host "  $($_.Name)" }
+
+# Sign and verify the produced Runtime package before it is published as a
+# pipeline artifact or consumed by downstream SDK builds.
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+  displayName: 'Sign Runtime NuGet package'
+  inputs:
+    ConnectedServiceName: 'OnnxrunTimeCodeSign_20240611'
+    UseMSIAuthentication: true
+    AppRegistrationClientId: '$(esrpClientId)'
+    AppRegistrationTenantId: '$(esrpTenantId)'
+    EsrpClientId: '$(esrpClientId)'
+    AuthAKVName: '$(esrpAkvName)'
+    AuthSignCertName: '$(esrpSignCertName)'
+    FolderPath: '$(Build.ArtifactStagingDirectory)/nuget'
+    Pattern: '*.nupkg'
+    SessionTimeout: 90
+    ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
+    MaxConcurrency: 25
+    signConfigType: inlineSignParams
+    inlineOperation: |
+      [{"keyCode":"CP-401405","operationSetCode":"NuGetSign","parameters":[],"toolName":"sign","toolVersion":"6.2.9304.0"},{"keyCode":"CP-401405","operationSetCode":"NuGetVerify","parameters":[],"toolName":"sign","toolVersion":"6.2.9304.0"}]

--- a/.pipelines/v2/templates/steps-pack-nuget.yml
+++ b/.pipelines/v2/templates/steps-pack-nuget.yml
@@ -13,6 +13,8 @@ parameters:
   type: string
 - name: genaiVersion
   type: string
+- name: isRelease
+  type: boolean
 
 steps:
 
@@ -78,23 +80,24 @@ steps:
       Write-Host "Generated packages:"
       Get-ChildItem $outDir -Filter '*.nupkg' | ForEach-Object { Write-Host "  $($_.Name)" }
 
-# Sign and verify the produced Runtime package before it is published as a
-# pipeline artifact or consumed by downstream SDK builds.
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
-  displayName: 'Sign Runtime NuGet package'
-  inputs:
-    ConnectedServiceName: 'OnnxrunTimeCodeSign_20240611'
-    UseMSIAuthentication: true
-    AppRegistrationClientId: '$(esrpClientId)'
-    AppRegistrationTenantId: '$(esrpTenantId)'
-    EsrpClientId: '$(esrpClientId)'
-    AuthAKVName: '$(esrpAkvName)'
-    AuthSignCertName: '$(esrpSignCertName)'
-    FolderPath: '$(Build.ArtifactStagingDirectory)/nuget'
-    Pattern: '*.nupkg'
-    SessionTimeout: 90
-    ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
-    MaxConcurrency: 25
-    signConfigType: inlineSignParams
-    inlineOperation: |
-      [{"keyCode":"CP-401405","operationSetCode":"NuGetSign","parameters":[],"toolName":"sign","toolVersion":"6.2.9304.0"},{"keyCode":"CP-401405","operationSetCode":"NuGetVerify","parameters":[],"toolName":"sign","toolVersion":"6.2.9304.0"}]
+# Sign and verify release Runtime packages before they are published as
+# pipeline artifacts. PR builds still produce unsigned validation packages.
+- ${{ if eq(parameters.isRelease, true) }}:
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+    displayName: 'Sign Runtime NuGet package'
+    inputs:
+      ConnectedServiceName: 'OnnxrunTimeCodeSign_20240611'
+      UseMSIAuthentication: true
+      AppRegistrationClientId: '$(esrpClientId)'
+      AppRegistrationTenantId: '$(esrpTenantId)'
+      EsrpClientId: '$(esrpClientId)'
+      AuthAKVName: '$(esrpAkvName)'
+      AuthSignCertName: '$(esrpSignCertName)'
+      FolderPath: '$(Build.ArtifactStagingDirectory)/nuget'
+      Pattern: '*.nupkg'
+      SessionTimeout: 90
+      ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
+      MaxConcurrency: 25
+      signConfigType: inlineSignParams
+      inlineOperation: |
+        [{"keyCode":"CP-401405","operationSetCode":"NuGetSign","parameters":[],"toolName":"sign","toolVersion":"6.2.9304.0"},{"keyCode":"CP-401405","operationSetCode":"NuGetVerify","parameters":[],"toolName":"sign","toolVersion":"6.2.9304.0"}]


### PR DESCRIPTION
- adds cpp nupkg signing
- gates signing behind Build.Reason != pull request so only official builds perform signing