### PR TITLE
Build Linux SDK packages with manylinux 2.28 compatibility

### DIFF
--- a/.pipelines/v2/docker/manylinux/Dockerfile
+++ b/.pipelines/v2/docker/manylinux/Dockerfile
@@ -1,6 +1,24 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-RUN dnf install -y zip \
+RUN dnf install -y \
+        bzip2 \
+        bzip2-devel \
+        expat-devel \
+        glibc-langpack-en \
+        glibc-locale-source \
+        kernel-headers \
+        make \
+        openssl-devel \
+        perl-core \
+        perl-IPC-Cmd \
+        readline-devel \
+        redhat-lsb-core \
+        tar \
+        unzip \
+        wget \
+        which \
+        zip \
+        zlib-devel \
     && dnf clean all \
     && rm -rf /var/cache/dnf

--- a/.pipelines/v2/docker/manylinux/Dockerfile
+++ b/.pipelines/v2/docker/manylinux/Dockerfile
@@ -2,23 +2,10 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 RUN dnf install -y \
-        bzip2 \
-        bzip2-devel \
-        expat-devel \
-        glibc-langpack-en \
-        glibc-locale-source \
         kernel-headers \
         make \
-        openssl-devel \
         perl-core \
         perl-IPC-Cmd \
-        readline-devel \
-        redhat-lsb-core \
-        tar \
-        unzip \
-        wget \
-        which \
         zip \
-        zlib-devel \
     && dnf clean all \
     && rm -rf /var/cache/dnf

--- a/.pipelines/v2/docker/manylinux/Dockerfile
+++ b/.pipelines/v2/docker/manylinux/Dockerfile
@@ -1,0 +1,6 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN dnf install -y zip \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf

--- a/.pipelines/v2/sdk_v2-pipeline-plan.md
+++ b/.pipelines/v2/sdk_v2-pipeline-plan.md
@@ -336,11 +336,11 @@ Windows ARM64 adds `--arm64`. macOS expects `cmake`/`ninja`/`pkg-config` and
 falls back to Homebrew if any are missing.
 
 Linux x64 and ARM64 run the same `build.py` command inside the matching
-`quay.io/pypa/manylinux_2_28_<arch>` container. The native-build stage adds
-the `zip` utility required by vcpkg bootstrap in a small derived image. Python
-wheels are also built in the policy container and passed through `auditwheel
-repair`; ORT and GenAI shared libraries remain external because their declared
-pip dependencies provide them.
+`quay.io/pypa/manylinux_2_28_<arch>` container. The native-build stage uses a
+small derived image with the vcpkg and OpenSSL build prerequisites also used by
+ORT/GenAI's manylinux images. Python wheels are built in the policy container
+and passed through `auditwheel repair`; ORT and GenAI shared libraries remain
+external because their declared pip dependencies provide them.
 
 Build output directories follow `build.py`'s convention:
 `sdk_v2/cpp/build/<Windows|Linux|macOS>/<Config>/...`.

--- a/.pipelines/v2/sdk_v2-pipeline-plan.md
+++ b/.pipelines/v2/sdk_v2-pipeline-plan.md
@@ -32,8 +32,8 @@ are gated separately via `.pipelines/v1/templates/stages-sdk-v1.yml`.
 |-----------------|-----------------------------------|-------|------|-----------------------------------------|
 | Windows x64     | `onnxruntime-Win-CPU-2022`        | ✅    | ✅   | Also stages public headers              |
 | Windows ARM64   | `onnxruntime-Win-CPU-2022`        | ✅    | ❌   | Cross-compiled from x64 host            |
-| Linux x64       | `onnxruntime-Ubuntu2404-AMD-CPU`  | ✅    | ✅   | Native CPU-only build                   |
-| Linux ARM64     | `onnxruntime-linux-ARM64-CPU-2019`| ✅    | ✅   | Native CPU-only build                   |
+| Linux x64       | `onnxruntime-Ubuntu2404-AMD-CPU`  | ✅    | ✅   | manylinux 2.28 container, CPU-only      |
+| Linux ARM64     | `onnxruntime-linux-ARM64-CPU-2019`| ✅    | ✅   | manylinux 2.28 container, CPU-only      |
 | macOS ARM64     | `AcesShared` (Sequoia)            | ✅    | ✅   | Native                                  |
 
 ## Architectural decisions (locked)
@@ -335,6 +335,11 @@ Windows x64 explicitly passes `--cmake_generator "Visual Studio 17 2022"`.
 Windows ARM64 adds `--arm64`. macOS expects `cmake`/`ninja`/`pkg-config` and
 falls back to Homebrew if any are missing.
 
+Linux x64 and ARM64 run the same `build.py` command inside the matching
+`quay.io/pypa/manylinux_2_28_<arch>` container. Python wheels are also built
+there and passed through `auditwheel repair`; ORT and GenAI shared libraries
+remain external because their declared pip dependencies provide them.
+
 Build output directories follow `build.py`'s convention:
 `sdk_v2/cpp/build/<Windows|Linux|macOS>/<Config>/...`.
 
@@ -371,10 +376,8 @@ Build output directories follow `build.py`'s convention:
 - **Local-dev `_native/<rid>/` cleanup.** `build.py` populates the in-tree
   staging dir but doesn't prune stale ORT DLLs from prior runs. Pipeline
   is unaffected; only impacts inner-loop devs.
-- **Linux/macOS auditwheel/delocate.** Not needed today (the only non-system
-  shared deps are the bundled vcpkg libs, which already sit beside
-  `libfoundry_local`). Revisit if `manylinux` compliance becomes a
-  publishing gate.
+- **macOS delocate.** Revisit if macOS wheel publishing introduces a
+  compatibility or dependency-bundling requirement.
 
 ## Files
 

--- a/.pipelines/v2/sdk_v2-pipeline-plan.md
+++ b/.pipelines/v2/sdk_v2-pipeline-plan.md
@@ -252,9 +252,7 @@ the same string that appears in the `.nupkg` filename. Each platform build
 stage:
 
 1. Depends on `compute_version` and downloads the `version-info` artifact.
-2. Reads `sdkVersion.txt` and appends
-   `"FOUNDRY_LOCAL_VERSION_STRING=<version>"` to `cmakeFetchDefines` after
-   the NuGet prefetch step.
+2. Reads `sdkVersion.txt` and sets `FOUNDRY_LOCAL_VERSION_STRING`.
 3. Passes the combined defines to `build.py --cmake_extra_defines`.
 
 Local developer builds (no `-D` override) use the `PROJECT_VERSION` from
@@ -295,9 +293,9 @@ These must be kept in sync with the cmake defaults and with
 in the same PR.
 
 The shared download logic is in `steps-prefetch-nuget.yml` and exposes both
-a PowerShell (Windows) and a bash (Linux/macOS) implementation behind a
-`shell` parameter. It emits a single pipeline variable `cmakeFetchDefines`
-containing the quoted `KEY=PATH` pairs to splice into the build command.
+a PowerShell and a bash implementation behind a `shell` parameter. The
+PowerShell build steps consume its `cmakeFetchDefines` variable; Linux
+container builds use the downloaded package paths directly.
 
 WinML downloads `Microsoft.Windows.AI.MachineLearning` directly from
 nuget.org as a single self-contained reg-free package — no transitive
@@ -337,10 +335,10 @@ falls back to Homebrew if any are missing.
 
 Linux x64 and ARM64 run the same `build.py` command inside the matching
 `quay.io/pypa/manylinux_2_28_<arch>` container. The native-build stage uses a
-small derived image with the vcpkg and OpenSSL build prerequisites also used by
-ORT/GenAI's manylinux images. Python wheels are built in the policy container
-and passed through `auditwheel repair`; ORT and GenAI shared libraries remain
-external because their declared pip dependencies provide them.
+small derived image with the required native build prerequisites. Python
+wheels are built in the policy container and passed through `auditwheel repair`;
+ORT and GenAI shared libraries remain external because their declared pip
+dependencies provide them.
 
 Build output directories follow `build.py`'s convention:
 `sdk_v2/cpp/build/<Windows|Linux|macOS>/<Config>/...`.

--- a/.pipelines/v2/sdk_v2-pipeline-plan.md
+++ b/.pipelines/v2/sdk_v2-pipeline-plan.md
@@ -336,9 +336,11 @@ Windows ARM64 adds `--arm64`. macOS expects `cmake`/`ninja`/`pkg-config` and
 falls back to Homebrew if any are missing.
 
 Linux x64 and ARM64 run the same `build.py` command inside the matching
-`quay.io/pypa/manylinux_2_28_<arch>` container. Python wheels are also built
-there and passed through `auditwheel repair`; ORT and GenAI shared libraries
-remain external because their declared pip dependencies provide them.
+`quay.io/pypa/manylinux_2_28_<arch>` container. The native-build stage adds
+the `zip` utility required by vcpkg bootstrap in a small derived image. Python
+wheels are also built in the policy container and passed through `auditwheel
+repair`; ORT and GenAI shared libraries remain external because their declared
+pip dependencies provide them.
 
 Build output directories follow `build.py`'s convention:
 `sdk_v2/cpp/build/<Windows|Linux|macOS>/<Config>/...`.

--- a/.pipelines/v2/templates/steps-build-linux.yml
+++ b/.pipelines/v2/templates/steps-build-linux.yml
@@ -109,6 +109,7 @@ steps:
         --env "HOME=$(Build.BinariesDirectory)/manylinux-home" \
         --env "VCPKG_ROOT=$(Build.BinariesDirectory)/vcpkg" \
         --env "FOUNDRY_TEST_DATA_DIR=$(Agent.BuildDirectory)/test-data-shared" \
+        --env "TF_BUILD=true" \
         --workdir "$(Build.SourcesDirectory)/sdk_v2/cpp" \
         "$(manylinuxImage)" \
         "$(Build.BinariesDirectory)/manylinux-home/venv/bin/python" build.py --test \

--- a/.pipelines/v2/templates/steps-build-linux.yml
+++ b/.pipelines/v2/templates/steps-build-linux.yml
@@ -2,9 +2,8 @@
 #
 # Supports both linux-x64 (pool: onnxruntime-Ubuntu2404-AMD-CPU) and
 # linux-arm64 (pool: onnxruntime-linux-ARM64-CPU-2019) via the `arch`
-# parameter. Each pool has the toolchain pre-installed; we still bootstrap
-# vcpkg and pre-download NuGet packages from the aiinfra feed for version
-# pinning.
+# parameter. Native compilation runs in the matching manylinux_2_28
+# container so all downstream packages have a glibc 2.28 baseline.
 
 parameters:
 - name: arch
@@ -25,9 +24,19 @@ steps:
 
 - bash: |
     set -euo pipefail
-    git clone https://github.com/microsoft/vcpkg.git "$(Build.BinariesDirectory)/vcpkg"
-    "$(Build.BinariesDirectory)/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
-  displayName: 'Bootstrap vcpkg'
+    case '${{ parameters.arch }}' in
+      x64)
+        image='quay.io/pypa/manylinux_2_28_x86_64@sha256:4dc41da7df20400310c80d162a2fe2d2c2f3d9734d8dec20f6b9843711618deb'
+        ;;
+      arm64)
+        image='quay.io/pypa/manylinux_2_28_aarch64@sha256:29a6ceb78de5b00494e6e7456a72782a4cb54238de102e7491d15fe47789b4d1'
+        ;;
+      *) echo "Unsupported architecture: ${{ parameters.arch }}" >&2; exit 1 ;;
+    esac
+    docker version
+    docker pull "$image"
+    echo "##vso[task.setvariable variable=manylinuxImage]$image"
+  displayName: 'Pull manylinux 2.28 build image'
 
 - template: steps-prefetch-nuget.yml
   parameters:
@@ -37,16 +46,6 @@ steps:
     includeWinml: false
     shell: bash
 
-# Bake the pipeline-computed version into the binary so FoundryLocalGetVersionString()
-# matches the .nupkg version instead of the cmake default.
-- bash: |
-    set -euo pipefail
-    version=$(cat "$(Pipeline.Workspace)/version-info/sdkVersion.txt" | tr -d '[:space:]')
-    defines="$(cmakeFetchDefines) \"FOUNDRY_LOCAL_VERSION_STRING=$version\""
-    echo "##vso[task.setvariable variable=cmakeFetchDefines]$defines"
-    echo "cmakeFetchDefines = $defines"
-  displayName: 'Append version define'
-
 - ${{ if eq(parameters.runTests, true) }}:
   - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
     parameters:
@@ -54,23 +53,58 @@ steps:
 
 - bash: |
     set -euo pipefail
-    python3 build.py --configure --build \
-      --config ${{ parameters.buildConfig }} \
-      --cmake_extra_defines $(cmakeFetchDefines)
-  displayName: 'Configure and build'
-  workingDirectory: $(Build.SourcesDirectory)/sdk_v2/cpp
-  env:
-    VCPKG_ROOT: $(Build.BinariesDirectory)/vcpkg
+    version=$(tr -d '[:space:]' < "$(Pipeline.Workspace)/version-info/sdkVersion.txt")
+    home_dir="$(Build.BinariesDirectory)/manylinux-home"
+    mkdir -p "$home_dir"
+
+    docker run --rm \
+      --user "$(id -u):$(id -g)" \
+      --volume "$(Build.SourcesDirectory):$(Build.SourcesDirectory)" \
+      --volume "$(Build.BinariesDirectory):$(Build.BinariesDirectory)" \
+      --env "HOME=$home_dir" \
+      --env "VCPKG_ROOT=$(Build.BinariesDirectory)/vcpkg" \
+      --env "NUGET_CACHE=$(Build.BinariesDirectory)/nuget_packages" \
+      --env "SDK_VERSION=$version" \
+      --workdir "$(Build.SourcesDirectory)/sdk_v2/cpp" \
+      "$(manylinuxImage)" \
+      bash -c '
+        set -euo pipefail
+        /opt/python/cp312-cp312/bin/python3.12 -m venv "$HOME/venv"
+        python="$HOME/venv/bin/python"
+        "$python" -m pip install --upgrade "cmake==3.31.6"
+        if [ ! -d "$VCPKG_ROOT/.git" ]; then
+          git clone https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT"
+        fi
+        "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
+        "$python" build.py --configure --build \
+          --config ${{ parameters.buildConfig }} \
+          --cmake_path "$HOME/venv/bin/cmake" \
+          --ctest_path "$HOME/venv/bin/ctest" \
+          --cmake_extra_defines \
+            "GENAI_FETCH_URL=$NUGET_CACHE/genai.nupkg" \
+            "ORT_FETCH_URL=$NUGET_CACHE/ort.nupkg" \
+            "FOUNDRY_LOCAL_VERSION_STRING=$SDK_VERSION"
+      '
+  displayName: 'Configure and build in manylinux 2.28'
 
 - ${{ if eq(parameters.runTests, true) }}:
   - bash: |
       set -euo pipefail
-      python3 build.py --test --config ${{ parameters.buildConfig }}
-    displayName: 'Run tests'
-    workingDirectory: $(Build.SourcesDirectory)/sdk_v2/cpp
-    env:
-      VCPKG_ROOT: $(Build.BinariesDirectory)/vcpkg
-      FOUNDRY_TEST_DATA_DIR: $(Agent.BuildDirectory)/test-data-shared
+      docker run --rm \
+        --user "$(id -u):$(id -g)" \
+        --volume "$(Build.SourcesDirectory):$(Build.SourcesDirectory)" \
+        --volume "$(Build.BinariesDirectory):$(Build.BinariesDirectory)" \
+        --volume "$(Agent.BuildDirectory)/test-data-shared:$(Agent.BuildDirectory)/test-data-shared:ro" \
+        --env "HOME=$(Build.BinariesDirectory)/manylinux-home" \
+        --env "VCPKG_ROOT=$(Build.BinariesDirectory)/vcpkg" \
+        --env "FOUNDRY_TEST_DATA_DIR=$(Agent.BuildDirectory)/test-data-shared" \
+        --workdir "$(Build.SourcesDirectory)/sdk_v2/cpp" \
+        "$(manylinuxImage)" \
+        "$(Build.BinariesDirectory)/manylinux-home/venv/bin/python" build.py --test \
+          --config ${{ parameters.buildConfig }} \
+          --cmake_path "$(Build.BinariesDirectory)/manylinux-home/venv/bin/cmake" \
+          --ctest_path "$(Build.BinariesDirectory)/manylinux-home/venv/bin/ctest"
+    displayName: 'Run tests in manylinux 2.28'
 
 - bash: |
     echo "=== vcpkg buildtrees error logs ==="

--- a/.pipelines/v2/templates/steps-build-linux.yml
+++ b/.pipelines/v2/templates/steps-build-linux.yml
@@ -35,13 +35,16 @@ steps:
     esac
     docker version
     docker pull "$image"
-    build_image="foundry-local-manylinux-2.28-${{ parameters.arch }}:$(Build.BuildId)"
+    build_image="foundry-local-manylinux-2.28:${{ parameters.arch }}"
+    image_id_file="$(Build.BinariesDirectory)/manylinux-${{ parameters.arch }}.iid"
     docker build \
       --build-arg "BASE_IMAGE=$image" \
       --file "$(Build.SourcesDirectory)/.pipelines/v2/docker/manylinux/Dockerfile" \
+      --iidfile "$image_id_file" \
       --tag "$build_image" \
       "$(Build.SourcesDirectory)/.pipelines/v2/docker/manylinux"
-    echo "##vso[task.setvariable variable=manylinuxImage]$build_image"
+    read -r image_id < "$image_id_file"
+    echo "##vso[task.setvariable variable=manylinuxImage]$image_id"
   displayName: 'Prepare manylinux 2.28 build image'
 
 - template: steps-prefetch-nuget.yml
@@ -62,9 +65,11 @@ steps:
     version=$(tr -d '[:space:]' < "$(Pipeline.Workspace)/version-info/sdkVersion.txt")
     home_dir="$(Build.BinariesDirectory)/manylinux-home"
     mkdir -p "$home_dir"
+    user_id=$(id -u)
+    group_id=$(id -g)
 
     docker run --rm \
-      --user "$(id -u):$(id -g)" \
+      --user "$user_id:$group_id" \
       --volume "$(Build.SourcesDirectory):$(Build.SourcesDirectory)" \
       --volume "$(Build.BinariesDirectory):$(Build.BinariesDirectory)" \
       --env "HOME=$home_dir" \
@@ -78,9 +83,7 @@ steps:
         /opt/python/cp312-cp312/bin/python3.12 -m venv "$HOME/venv"
         python="$HOME/venv/bin/python"
         "$python" -m pip install --upgrade "cmake==3.31.6"
-        if [ ! -d "$VCPKG_ROOT/.git" ]; then
-          git clone https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT"
-        fi
+        git clone https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT"
         "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
         "$python" build.py --configure --build \
           --config ${{ parameters.buildConfig }} \
@@ -96,8 +99,10 @@ steps:
 - ${{ if eq(parameters.runTests, true) }}:
   - bash: |
       set -euo pipefail
+      user_id=$(id -u)
+      group_id=$(id -g)
       docker run --rm \
-        --user "$(id -u):$(id -g)" \
+        --user "$user_id:$group_id" \
         --volume "$(Build.SourcesDirectory):$(Build.SourcesDirectory)" \
         --volume "$(Build.BinariesDirectory):$(Build.BinariesDirectory)" \
         --volume "$(Agent.BuildDirectory)/test-data-shared:$(Agent.BuildDirectory)/test-data-shared:ro" \

--- a/.pipelines/v2/templates/steps-build-linux.yml
+++ b/.pipelines/v2/templates/steps-build-linux.yml
@@ -35,8 +35,14 @@ steps:
     esac
     docker version
     docker pull "$image"
-    echo "##vso[task.setvariable variable=manylinuxImage]$image"
-  displayName: 'Pull manylinux 2.28 build image'
+    build_image="foundry-local-manylinux-2.28-${{ parameters.arch }}:$(Build.BuildId)"
+    docker build \
+      --build-arg "BASE_IMAGE=$image" \
+      --file "$(Build.SourcesDirectory)/.pipelines/v2/docker/manylinux/Dockerfile" \
+      --tag "$build_image" \
+      "$(Build.SourcesDirectory)/.pipelines/v2/docker/manylinux"
+    echo "##vso[task.setvariable variable=manylinuxImage]$build_image"
+  displayName: 'Prepare manylinux 2.28 build image'
 
 - template: steps-prefetch-nuget.yml
   parameters:

--- a/.pipelines/v2/templates/steps-build-linux.yml
+++ b/.pipelines/v2/templates/steps-build-linux.yml
@@ -43,7 +43,7 @@ steps:
       --iidfile "$image_id_file" \
       --tag "$build_image" \
       "$(Build.SourcesDirectory)/.pipelines/v2/docker/manylinux"
-    read -r image_id < "$image_id_file"
+    IFS= read -r image_id < "$image_id_file" || [ -n "$image_id" ]
     echo "##vso[task.setvariable variable=manylinuxImage]$image_id"
   displayName: 'Prepare manylinux 2.28 build image'
 

--- a/.pipelines/v2/templates/steps-build-python.yml
+++ b/.pipelines/v2/templates/steps-build-python.yml
@@ -169,7 +169,7 @@ steps:
     script: |
         python -m pip install --upgrade pip
         $buildTools = @('build', 'setuptools', 'wheel', 'cffi>=1.16')
-        if ('${{ parameters.rid }}' -like 'linux-*') {
+        if ('${{ parameters.rid }}' -eq 'linux-arm64') {
             $buildTools += 'auditwheel>=6.8'
         }
         python -m pip install --upgrade @buildTools
@@ -226,7 +226,6 @@ steps:
         New-Item -ItemType Directory -Force -Path $outDir | Out-Null
         $extraArgs = @()
         $platformTag = switch ('${{ parameters.rid }}') {
-            'linux-x64'   { 'manylinux_2_28_x86_64' }
             'linux-arm64' { 'manylinux_2_28_aarch64' }
             'osx-arm64'   { 'macosx_11_0_arm64' }
             default       { $null }
@@ -254,7 +253,7 @@ steps:
             Pop-Location
         }
 
-- ${{ if startsWith(parameters.rid, 'linux-') }}:
+- ${{ if eq(parameters.rid, 'linux-arm64') }}:
   - task: PowerShell@2
     displayName: 'Audit Linux ABI compatibility'
     inputs:
@@ -283,7 +282,7 @@ steps:
             throw "Wheel does not have a manylinux-compatible symbol baseline: $($report.sym_tag)"
         }
 
-        $expectedArchitecture = if ('${{ parameters.rid }}' -eq 'linux-arm64') { 'aarch64' } else { 'x86_64' }
+        $expectedArchitecture = 'aarch64'
         if ($Matches[3] -ne $expectedArchitecture) {
             throw "Wheel architecture is $($Matches[3]); expected $expectedArchitecture"
         }
@@ -328,7 +327,7 @@ steps:
         switch ('${{ parameters.rid }}') {
             'win-x64'     { $tags = @('win_amd64');                 $lib = 'foundry_local.dll' }
             'win-arm64'   { $tags = @('win_arm64');                 $lib = 'foundry_local.dll' }
-            'linux-x64'   { $tags = @('manylinux_2_28_x86_64');     $lib = 'libfoundry_local.so' }
+            'linux-x64'   { $tags = @('linux_x86_64');              $lib = 'libfoundry_local.so' }
             'linux-arm64' { $tags = @('manylinux_2_28_aarch64');    $lib = 'libfoundry_local.so' }
             'osx-arm64'   { $tags = @('macosx', 'arm64');           $lib = 'libfoundry_local.dylib' }
             default       { throw "Unknown rid: ${{ parameters.rid }}" }

--- a/.pipelines/v2/templates/steps-build-python.yml
+++ b/.pipelines/v2/templates/steps-build-python.yml
@@ -226,7 +226,7 @@ steps:
         New-Item -ItemType Directory -Force -Path $outDir | Out-Null
         $extraArgs = @()
         $platformTag = switch ('${{ parameters.rid }}') {
-            'linux-arm64' { 'manylinux_2_28_aarch64' }
+            'linux-arm64' { 'manylinux_2_38_aarch64' }
             'osx-arm64'   { 'macosx_11_0_arm64' }
             default       { $null }
         }
@@ -288,8 +288,8 @@ steps:
         }
 
         $requiredPolicy = [version]"$($Matches[1]).$($Matches[2])"
-        if ($requiredPolicy -gt [version]'2.28') {
-            throw "Wheel requires $($report.sym_tag), which exceeds the manylinux_2_28 target"
+        if ($requiredPolicy -gt [version]'2.38') {
+            throw "Wheel requires $($report.sym_tag), which exceeds the manylinux_2_38 target"
         }
 
         # ORT and GenAI are intentionally supplied by the wheel's declared pip
@@ -328,7 +328,7 @@ steps:
             'win-x64'     { $tags = @('win_amd64');                 $lib = 'foundry_local.dll' }
             'win-arm64'   { $tags = @('win_arm64');                 $lib = 'foundry_local.dll' }
             'linux-x64'   { $tags = @('linux_x86_64');              $lib = 'libfoundry_local.so' }
-            'linux-arm64' { $tags = @('manylinux_2_28_aarch64');    $lib = 'libfoundry_local.so' }
+            'linux-arm64' { $tags = @('manylinux_2_38_aarch64');    $lib = 'libfoundry_local.so' }
             'osx-arm64'   { $tags = @('macosx', 'arm64');           $lib = 'libfoundry_local.dylib' }
             default       { throw "Unknown rid: ${{ parameters.rid }}" }
         }

--- a/.pipelines/v2/templates/steps-build-python.yml
+++ b/.pipelines/v2/templates/steps-build-python.yml
@@ -168,9 +168,10 @@ steps:
     pwsh: ${{ ne(parameters.rid, 'win-arm64') }}
     script: |
         python -m pip install --upgrade pip
-        $buildTools = @('build', 'setuptools', 'wheel', 'cffi>=1.16')
         if ('${{ parameters.rid }}' -like 'linux-*') {
-            $buildTools += 'auditwheel==6.8.1'
+            $buildTools = @('auditwheel==6.8.1')
+        } else {
+            $buildTools = @('build', 'setuptools', 'wheel', 'cffi>=1.16')
         }
         python -m pip install --upgrade @buildTools
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -265,15 +266,17 @@ steps:
       esac
 
       platform_tag="manylinux_2_28_${manylinux_arch}"
-      raw_dir="$(Build.ArtifactStagingDirectory)/python-sdk-raw"
+      raw_dir="$(Agent.TempDirectory)/python-sdk-raw"
       out_dir="${{ parameters.outputDir }}"
       home_dir="$(Agent.TempDirectory)/manylinux-python-home"
       mkdir -p "$raw_dir" "$out_dir" "$home_dir"
+      user_id=$(id -u)
+      group_id=$(id -g)
       docker version
       docker pull "$image"
 
       docker run --rm \
-        --user "$(id -u):$(id -g)" \
+        --user "$user_id:$group_id" \
         --volume "$(Build.SourcesDirectory):$(Build.SourcesDirectory)" \
         --volume "$(Build.ArtifactStagingDirectory):$(Build.ArtifactStagingDirectory)" \
         --volume "$(Agent.TempDirectory):$(Agent.TempDirectory)" \
@@ -282,7 +285,6 @@ steps:
         --env "RAW_WHEEL_DIR=$raw_dir" \
         --env "WHEEL_DIR=$out_dir" \
         --env "AUDITWHEEL_PLAT=$platform_tag" \
-        --env "LD_LIBRARY_PATH=${{ parameters.nativeArtifactDir }}" \
         --workdir "$(Build.SourcesDirectory)/sdk_v2/python" \
         "$image" \
         bash -c '

--- a/.pipelines/v2/templates/steps-build-python.yml
+++ b/.pipelines/v2/templates/steps-build-python.yml
@@ -169,8 +169,8 @@ steps:
     script: |
         python -m pip install --upgrade pip
         $buildTools = @('build', 'setuptools', 'wheel', 'cffi>=1.16')
-        if ('${{ parameters.rid }}' -eq 'linux-arm64') {
-            $buildTools += 'auditwheel>=6.8'
+        if ('${{ parameters.rid }}' -like 'linux-*') {
+            $buildTools += 'auditwheel==6.8.1'
         }
         python -m pip install --upgrade @buildTools
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -216,27 +216,23 @@ steps:
           Write-Host "vcvarsall.bat: $vcvars"
           Write-Host "##vso[task.setvariable variable=vcvarsAllPath]$vcvars"
 
-- task: PowerShell@2
-  displayName: 'Build wheel'
-  inputs:
-    targetType: inline
-    pwsh: ${{ ne(parameters.rid, 'win-arm64') }}
-    script: |
+- ${{ if not(startsWith(parameters.rid, 'linux-')) }}:
+  - task: PowerShell@2
+    displayName: 'Build wheel'
+    inputs:
+      targetType: inline
+      pwsh: ${{ ne(parameters.rid, 'win-arm64') }}
+      script: |
         $outDir = "${{ parameters.outputDir }}"
         New-Item -ItemType Directory -Force -Path $outDir | Out-Null
         $extraArgs = @()
-        $platformTag = switch ('${{ parameters.rid }}') {
-            'linux-arm64' { 'manylinux_2_38_aarch64' }
-            'osx-arm64'   { 'macosx_11_0_arm64' }
-            default       { $null }
-        }
-        if ($platformTag) {
-            $extraArgs += "--config-setting=--build-option=--plat-name=$platformTag"
-            Write-Host "Forcing wheel plat tag $platformTag"
+        if ('${{ parameters.rid }}' -eq 'osx-arm64') {
+            $extraArgs += '--config-setting=--build-option=--plat-name=macosx_11_0_arm64'
+            Write-Host "Forcing wheel plat tag macosx_11_0_arm64"
         }
         Push-Location "$(Build.SourcesDirectory)/sdk_v2/python"
         try {
-        if ('${{ parameters.rid }}' -eq 'win-arm64') {
+            if ('${{ parameters.rid }}' -eq 'win-arm64') {
                 $vcvars = "$(vcvarsAllPath)"
                 if (-not $vcvars) { throw "vcvarsAllPath pipeline variable is empty" }
                 $buildArgs = @('-m', 'build', '--wheel', '--outdir', $outDir) + $extraArgs
@@ -253,7 +249,56 @@ steps:
             Pop-Location
         }
 
-- ${{ if eq(parameters.rid, 'linux-arm64') }}:
+- ${{ if startsWith(parameters.rid, 'linux-') }}:
+  - bash: |
+      set -euo pipefail
+      case '${{ parameters.rid }}' in
+        linux-x64)
+          manylinux_arch='x86_64'
+          image='quay.io/pypa/manylinux_2_28_x86_64@sha256:4dc41da7df20400310c80d162a2fe2d2c2f3d9734d8dec20f6b9843711618deb'
+          ;;
+        linux-arm64)
+          manylinux_arch='aarch64'
+          image='quay.io/pypa/manylinux_2_28_aarch64@sha256:29a6ceb78de5b00494e6e7456a72782a4cb54238de102e7491d15fe47789b4d1'
+          ;;
+        *) echo "Unsupported Linux RID: ${{ parameters.rid }}" >&2; exit 1 ;;
+      esac
+
+      platform_tag="manylinux_2_28_${manylinux_arch}"
+      raw_dir="$(Build.ArtifactStagingDirectory)/python-sdk-raw"
+      out_dir="${{ parameters.outputDir }}"
+      home_dir="$(Agent.TempDirectory)/manylinux-python-home"
+      mkdir -p "$raw_dir" "$out_dir" "$home_dir"
+      docker version
+      docker pull "$image"
+
+      docker run --rm \
+        --user "$(id -u):$(id -g)" \
+        --volume "$(Build.SourcesDirectory):$(Build.SourcesDirectory)" \
+        --volume "$(Build.ArtifactStagingDirectory):$(Build.ArtifactStagingDirectory)" \
+        --volume "$(Agent.TempDirectory):$(Agent.TempDirectory)" \
+        --volume "${{ parameters.nativeArtifactDir }}:${{ parameters.nativeArtifactDir }}:ro" \
+        --env "HOME=$home_dir" \
+        --env "RAW_WHEEL_DIR=$raw_dir" \
+        --env "WHEEL_DIR=$out_dir" \
+        --env "AUDITWHEEL_PLAT=$platform_tag" \
+        --env "LD_LIBRARY_PATH=${{ parameters.nativeArtifactDir }}" \
+        --workdir "$(Build.SourcesDirectory)/sdk_v2/python" \
+        "$image" \
+        bash -c '
+          set -euo pipefail
+          /opt/python/cp312-cp312/bin/python3.12 -m venv "$HOME/venv"
+          python="$HOME/venv/bin/python"
+          "$python" -m pip install --upgrade build setuptools wheel "cffi>=1.16" "auditwheel==6.8.1"
+          "$python" -m build --wheel --outdir "$RAW_WHEEL_DIR"
+          "$HOME/venv/bin/auditwheel" repair "$RAW_WHEEL_DIR"/*.whl \
+            --wheel-dir "$WHEEL_DIR" \
+            --plat "$AUDITWHEEL_PLAT" \
+            --exclude "libonnxruntime.so*" \
+            --exclude "libonnxruntime-genai.so*"
+        '
+    displayName: 'Build and repair manylinux 2.28 wheel'
+
   - task: PowerShell@2
     displayName: 'Audit Linux ABI compatibility'
     inputs:
@@ -282,14 +327,14 @@ steps:
             throw "Wheel does not have a manylinux-compatible symbol baseline: $($report.sym_tag)"
         }
 
-        $expectedArchitecture = 'aarch64'
+        $expectedArchitecture = if ('${{ parameters.rid }}' -eq 'linux-arm64') { 'aarch64' } else { 'x86_64' }
         if ($Matches[3] -ne $expectedArchitecture) {
             throw "Wheel architecture is $($Matches[3]); expected $expectedArchitecture"
         }
 
         $requiredPolicy = [version]"$($Matches[1]).$($Matches[2])"
-        if ($requiredPolicy -gt [version]'2.38') {
-            throw "Wheel requires $($report.sym_tag), which exceeds the manylinux_2_38 target"
+        if ($requiredPolicy -gt [version]'2.28') {
+            throw "Wheel requires $($report.sym_tag), which exceeds the manylinux_2_28 target"
         }
 
         # ORT and GenAI are intentionally supplied by the wheel's declared pip
@@ -327,8 +372,8 @@ steps:
         switch ('${{ parameters.rid }}') {
             'win-x64'     { $tags = @('win_amd64');                 $lib = 'foundry_local.dll' }
             'win-arm64'   { $tags = @('win_arm64');                 $lib = 'foundry_local.dll' }
-            'linux-x64'   { $tags = @('linux_x86_64');              $lib = 'libfoundry_local.so' }
-            'linux-arm64' { $tags = @('manylinux_2_38_aarch64');    $lib = 'libfoundry_local.so' }
+            'linux-x64'   { $tags = @('manylinux_2_28_x86_64');     $lib = 'libfoundry_local.so' }
+            'linux-arm64' { $tags = @('manylinux_2_28_aarch64');    $lib = 'libfoundry_local.so' }
             'osx-arm64'   { $tags = @('macosx', 'arm64');           $lib = 'libfoundry_local.dylib' }
             default       { throw "Unknown rid: ${{ parameters.rid }}" }
         }
@@ -351,9 +396,20 @@ steps:
         $code = @'
         import sys, zipfile
 
-        whl, expected = sys.argv[1], sys.argv[2]
+        whl, expected, rid = sys.argv[1], sys.argv[2], sys.argv[3]
         with zipfile.ZipFile(whl) as wheel:
             names = wheel.namelist()
+
+        if rid.startswith("linux-"):
+            bundled_ort = [
+                name for name in names
+                if name.rsplit("/", 1)[-1].startswith("libonnxruntime") and ".so" in name
+            ]
+            if bundled_ort:
+                print("ERROR: ORT libraries must come from declared pip dependencies:")
+                for name in bundled_ort:
+                    print("  " + name)
+                sys.exit(1)
 
         hits = [name for name in names if name.endswith(expected)]
         if not hits:
@@ -365,6 +421,6 @@ steps:
 
         print("OK: found " + hits[0])
         '@
-        $code | python - "$($whl.FullName)" "$expected"
+        $code | python - "$($whl.FullName)" "$expected" "${{ parameters.rid }}"
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         Write-Host "Wheel validation passed."

--- a/.pipelines/v2/templates/steps-build-python.yml
+++ b/.pipelines/v2/templates/steps-build-python.yml
@@ -296,6 +296,7 @@ steps:
           "$HOME/venv/bin/auditwheel" repair "$RAW_WHEEL_DIR"/*.whl \
             --wheel-dir "$WHEEL_DIR" \
             --plat "$AUDITWHEEL_PLAT" \
+            --exclude "libfoundry_local.so" \
             --exclude "libonnxruntime.so*" \
             --exclude "libonnxruntime-genai.so*"
         '
@@ -339,19 +340,19 @@ steps:
             throw "Wheel requires $($report.sym_tag), which exceeds the manylinux_2_28 target"
         }
 
-        # ORT and GenAI are intentionally supplied by the wheel's declared pip
-        # dependencies and preloaded by lib_loader.py rather than bundled here.
+        # libfoundry_local is already bundled in the RID directory. ORT and GenAI
+        # are supplied by declared pip dependencies and preloaded by lib_loader.py.
         $externalLibraries = @($report.external_libs.PSObject.Properties.Name)
         $unexpectedLibraries = @(
             $externalLibraries | Where-Object {
-                $_ -notmatch '^libonnxruntime(?:-genai)?\.so(?:\..*)?$'
+                $_ -notmatch '^(?:libfoundry_local|libonnxruntime(?:-genai)?)\.so(?:\..*)?$'
             }
         )
         if ($unexpectedLibraries.Count -gt 0) {
             throw "Wheel has unexpected external shared libraries: $($unexpectedLibraries -join ', ')"
         }
         if ($externalLibraries.Count -gt 0) {
-            Write-Host "Expected pip-provided shared libraries: $($externalLibraries -join ', ')"
+            Write-Host "Expected external library references: $($externalLibraries -join ', ')"
         }
 
 - task: PowerShell@2

--- a/.pipelines/v2/templates/steps-build-python.yml
+++ b/.pipelines/v2/templates/steps-build-python.yml
@@ -256,7 +256,7 @@ steps:
 
 - ${{ if startsWith(parameters.rid, 'linux-') }}:
   - task: PowerShell@2
-    displayName: 'Validate manylinux compatibility'
+    displayName: 'Audit Linux ABI compatibility'
     inputs:
       targetType: inline
       pwsh: true
@@ -272,10 +272,15 @@ steps:
             throw "auditwheel failed with exit code $LASTEXITCODE"
         }
         $report = $json | ConvertFrom-Json
-        Write-Host "auditwheel platform: $($report.overall_tag)"
+        Write-Host "auditwheel overall platform: $($report.overall_tag)"
+        Write-Host "auditwheel symbol platform: $($report.sym_tag)"
 
-        if ($report.overall_tag -notmatch '^manylinux_(\d+)_(\d+)_(x86_64|aarch64)$') {
-            throw "Wheel is not manylinux compatible: $($report.overall_tag)"
+        if ($report.pyfpe -or $report.ucs2 -or $report.unsupported_isa) {
+            throw "Wheel uses unsupported Linux ABI features"
+        }
+
+        if ($report.sym_tag -notmatch '^manylinux_(\d+)_(\d+)_(x86_64|aarch64)$') {
+            throw "Wheel does not have a manylinux-compatible symbol baseline: $($report.sym_tag)"
         }
 
         $expectedArchitecture = if ('${{ parameters.rid }}' -eq 'linux-arm64') { 'aarch64' } else { 'x86_64' }
@@ -285,7 +290,22 @@ steps:
 
         $requiredPolicy = [version]"$($Matches[1]).$($Matches[2])"
         if ($requiredPolicy -gt [version]'2.28') {
-            throw "Wheel requires $($report.overall_tag), which exceeds the manylinux_2_28 target"
+            throw "Wheel requires $($report.sym_tag), which exceeds the manylinux_2_28 target"
+        }
+
+        # ORT and GenAI are intentionally supplied by the wheel's declared pip
+        # dependencies and preloaded by lib_loader.py rather than bundled here.
+        $externalLibraries = @($report.external_libs.PSObject.Properties.Name)
+        $unexpectedLibraries = @(
+            $externalLibraries | Where-Object {
+                $_ -notmatch '^libonnxruntime(?:-genai)?\.so(?:\..*)?$'
+            }
+        )
+        if ($unexpectedLibraries.Count -gt 0) {
+            throw "Wheel has unexpected external shared libraries: $($unexpectedLibraries -join ', ')"
+        }
+        if ($externalLibraries.Count -gt 0) {
+            Write-Host "Expected pip-provided shared libraries: $($externalLibraries -join ', ')"
         }
 
 - task: PowerShell@2

--- a/sdk_v2/cpp/examples/realtime_audio/CMakeLists.txt
+++ b/sdk_v2/cpp/examples/realtime_audio/CMakeLists.txt
@@ -1,9 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-# This example uses std::thread directly (see main.cc), which requires linking
-# against the platform thread library. On glibc < 2.34 (e.g. manylinux_2_28),
-# pthread symbols live in a separate libpthread.so and are not implicitly
-# available, so we must link them explicitly via CMake's Threads package.
+# std::thread requires an explicit pthread link on glibc < 2.34.
 find_package(Threads REQUIRED)
 
 add_executable(realtime_audio_example main.cc)

--- a/sdk_v2/cpp/examples/realtime_audio/CMakeLists.txt
+++ b/sdk_v2/cpp/examples/realtime_audio/CMakeLists.txt
@@ -1,4 +1,10 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+# This example uses std::thread directly (see main.cc), which requires linking
+# against the platform thread library. On glibc < 2.34 (e.g. manylinux_2_28),
+# pthread symbols live in a separate libpthread.so and are not implicitly
+# available, so we must link them explicitly via CMake's Threads package.
+find_package(Threads REQUIRED)
+
 add_executable(realtime_audio_example main.cc)
-target_link_libraries(realtime_audio_example PRIVATE foundry_local_cpp)
+target_link_libraries(realtime_audio_example PRIVATE foundry_local_cpp Threads::Threads)

--- a/sdk_v2/cpp/src/catalog/base_model_catalog.cc
+++ b/sdk_v2/cpp/src/catalog/base_model_catalog.cc
@@ -186,26 +186,48 @@ void BaseModelCatalog::RebuildIndex() const {
   }
 
   // Atomic swap — readers holding the old shared_ptr keep it alive until they're done.
-  // Suppress C++20 deprecation warning for std::atomic_store/load free functions.
-  // We can't use std::atomic<std::shared_ptr<>> due to missing XCode support (see header).
+  // release: publishes the fully-built *new_index to any reader whose GetIndex() acquire-load
+  // observes this store (see GetIndex()).
+#if defined(__cpp_lib_atomic_shared_ptr)
+  index_.store(std::move(new_index), std::memory_order_release);
+#else
+  // Fallback for toolchains without the atomic<shared_ptr> specialization (older libc++/Xcode).
+  // Suppress the C++20 deprecation warning for the atomic_store/atomic_load free functions.
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4996)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-  std::atomic_store(&index_, std::shared_ptr<const ModelIndex>(std::move(new_index)));
+  std::atomic_store_explicit(&index_, std::shared_ptr<const ModelIndex>(std::move(new_index)),
+                              std::memory_order_release);
 #if defined(_MSC_VER)
 #pragma warning(pop)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 }
 
 std::shared_ptr<const BaseModelCatalog::ModelIndex> BaseModelCatalog::GetIndex() const {
+#if defined(__cpp_lib_atomic_shared_ptr)
+  return index_.load(std::memory_order_acquire);
+#else
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4996)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-  return std::atomic_load(&index_);
+  auto index = std::atomic_load_explicit(&index_, std::memory_order_acquire);
 #if defined(_MSC_VER)
 #pragma warning(pop)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+  return index;
 #endif
 }
 

--- a/sdk_v2/cpp/src/catalog/base_model_catalog.cc
+++ b/sdk_v2/cpp/src/catalog/base_model_catalog.cc
@@ -185,14 +185,7 @@ void BaseModelCatalog::RebuildIndex() const {
     }
   }
 
-  // Atomic swap — readers holding the old shared_ptr keep it alive until they're done.
-  // release: publishes the fully-built *new_index to any reader whose GetIndex() acquire-load
-  // observes this store (see GetIndex()).
-#if defined(__cpp_lib_atomic_shared_ptr)
-  index_->store(std::move(new_index), std::memory_order_release);
-#else
-  // Fallback for toolchains without the atomic<shared_ptr> specialization (older libc++/Xcode).
-  // Suppress the C++20 deprecation warning for the atomic_store/atomic_load free functions.
+  // Readers holding the previous shared_ptr keep that snapshot alive.
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4996)
@@ -201,19 +194,15 @@ void BaseModelCatalog::RebuildIndex() const {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
   std::atomic_store_explicit(&index_, std::shared_ptr<const ModelIndex>(std::move(new_index)),
-                              std::memory_order_release);
+                             std::memory_order_release);
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
-#endif
 }
 
 std::shared_ptr<const BaseModelCatalog::ModelIndex> BaseModelCatalog::GetIndex() const {
-#if defined(__cpp_lib_atomic_shared_ptr)
-  return index_->load(std::memory_order_acquire);
-#else
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4996)
@@ -228,7 +217,6 @@ std::shared_ptr<const BaseModelCatalog::ModelIndex> BaseModelCatalog::GetIndex()
 #pragma GCC diagnostic pop
 #endif
   return index;
-#endif
 }
 
 void BaseModelCatalog::InvalidateCache() {

--- a/sdk_v2/cpp/src/catalog/base_model_catalog.cc
+++ b/sdk_v2/cpp/src/catalog/base_model_catalog.cc
@@ -189,7 +189,7 @@ void BaseModelCatalog::RebuildIndex() const {
   // release: publishes the fully-built *new_index to any reader whose GetIndex() acquire-load
   // observes this store (see GetIndex()).
 #if defined(__cpp_lib_atomic_shared_ptr)
-  index_.store(std::move(new_index), std::memory_order_release);
+  index_->store(std::move(new_index), std::memory_order_release);
 #else
   // Fallback for toolchains without the atomic<shared_ptr> specialization (older libc++/Xcode).
   // Suppress the C++20 deprecation warning for the atomic_store/atomic_load free functions.
@@ -212,7 +212,7 @@ void BaseModelCatalog::RebuildIndex() const {
 
 std::shared_ptr<const BaseModelCatalog::ModelIndex> BaseModelCatalog::GetIndex() const {
 #if defined(__cpp_lib_atomic_shared_ptr)
-  return index_.load(std::memory_order_acquire);
+  return index_->load(std::memory_order_acquire);
 #else
 #if defined(_MSC_VER)
 #pragma warning(push)

--- a/sdk_v2/cpp/src/catalog/base_model_catalog.h
+++ b/sdk_v2/cpp/src/catalog/base_model_catalog.h
@@ -87,31 +87,9 @@ class BaseModelCatalog : public ICatalog {
   /// Models are only appended, never removed — external Model* pointers remain valid.
   mutable std::vector<std::unique_ptr<Model>> models_;
 
-  /// Lookup indices, rebuilt on each populate/refresh.
-  ///
-  /// std::atomic<std::shared_ptr<T>> (C++20, __cpp_lib_atomic_shared_ptr) gives readers
-  /// a consistent snapshot: the swap after RebuildIndex() is atomic, so a concurrent
-  /// reader never observes a partially-built index, and the shared_ptr returned by
-  /// GetIndex() keeps that snapshot alive even if a later refresh replaces index_.
-  ///
-  /// Falls back to a plain shared_ptr guarded by the (C++20-deprecated) free functions
-  /// std::atomic_load/atomic_store on toolchains that don't yet implement the
-  /// specialization (older libc++/Xcode).
-  ///
-  /// Held behind a unique_ptr rather than by value: MSVC's atomic<shared_ptr<T>>
-  /// specialization has an internal over-alignment requirement (for its lock-free
-  /// CAS storage) that, if embedded directly, forces the compiler to pad
-  /// BaseModelCatalog -- and every class deriving from it -- to satisfy that
-  /// alignment (MSVC C4324, treated as an error). Storing it on the heap keeps the
-  /// member's footprint here to an ordinary pointer, so no padding is introduced in
-  /// this class or in any derived catalog, while the pointer is fixed for the
-  /// object's lifetime (only the pointee's value changes, via atomic store/load).
-#if defined(__cpp_lib_atomic_shared_ptr)
-  mutable std::unique_ptr<std::atomic<std::shared_ptr<const ModelIndex>>> index_ =
-      std::make_unique<std::atomic<std::shared_ptr<const ModelIndex>>>();
-#else
+  /// Atomically replaced after each index rebuild so readers always observe a complete snapshot.
+  /// The free functions avoid atomic<shared_ptr> availability and alignment differences across standard libraries.
   mutable std::shared_ptr<const ModelIndex> index_;
-#endif
 
   /// Atomically grab the current index snapshot. Callers hold the returned shared_ptr
   /// for the duration of their lookup, keeping the index alive if a refresh swaps it out.

--- a/sdk_v2/cpp/src/catalog/base_model_catalog.h
+++ b/sdk_v2/cpp/src/catalog/base_model_catalog.h
@@ -97,8 +97,18 @@ class BaseModelCatalog : public ICatalog {
   /// Falls back to a plain shared_ptr guarded by the (C++20-deprecated) free functions
   /// std::atomic_load/atomic_store on toolchains that don't yet implement the
   /// specialization (older libc++/Xcode).
+  ///
+  /// Held behind a unique_ptr rather than by value: MSVC's atomic<shared_ptr<T>>
+  /// specialization has an internal over-alignment requirement (for its lock-free
+  /// CAS storage) that, if embedded directly, forces the compiler to pad
+  /// BaseModelCatalog -- and every class deriving from it -- to satisfy that
+  /// alignment (MSVC C4324, treated as an error). Storing it on the heap keeps the
+  /// member's footprint here to an ordinary pointer, so no padding is introduced in
+  /// this class or in any derived catalog, while the pointer is fixed for the
+  /// object's lifetime (only the pointee's value changes, via atomic store/load).
 #if defined(__cpp_lib_atomic_shared_ptr)
-  mutable std::atomic<std::shared_ptr<const ModelIndex>> index_;
+  mutable std::unique_ptr<std::atomic<std::shared_ptr<const ModelIndex>>> index_ =
+      std::make_unique<std::atomic<std::shared_ptr<const ModelIndex>>>();
 #else
   mutable std::shared_ptr<const ModelIndex> index_;
 #endif

--- a/sdk_v2/cpp/src/catalog/base_model_catalog.h
+++ b/sdk_v2/cpp/src/catalog/base_model_catalog.h
@@ -5,6 +5,7 @@
 #include "catalog.h"
 #include "logger.h"
 
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <mutex>
@@ -87,11 +88,20 @@ class BaseModelCatalog : public ICatalog {
   mutable std::vector<std::unique_ptr<Model>> models_;
 
   /// Lookup indices, rebuilt on each populate/refresh.
-  /// Guarded by std::atomic_load/store free functions so readers get a consistent
-  /// snapshot — the swap after rebuild is atomic, so a concurrent reader never sees
-  /// a partially-built index.
-  /// Can't use std::atomic<std::shared_ptr<>> due to lack of implemention in XCode (macOS)
+  ///
+  /// std::atomic<std::shared_ptr<T>> (C++20, __cpp_lib_atomic_shared_ptr) gives readers
+  /// a consistent snapshot: the swap after RebuildIndex() is atomic, so a concurrent
+  /// reader never observes a partially-built index, and the shared_ptr returned by
+  /// GetIndex() keeps that snapshot alive even if a later refresh replaces index_.
+  ///
+  /// Falls back to a plain shared_ptr guarded by the (C++20-deprecated) free functions
+  /// std::atomic_load/atomic_store on toolchains that don't yet implement the
+  /// specialization (older libc++/Xcode).
+#if defined(__cpp_lib_atomic_shared_ptr)
+  mutable std::atomic<std::shared_ptr<const ModelIndex>> index_;
+#else
   mutable std::shared_ptr<const ModelIndex> index_;
+#endif
 
   /// Atomically grab the current index snapshot. Callers hold the returned shared_ptr
   /// for the duration of their lookup, keeping the index alive if a refresh swaps it out.

--- a/sdk_v2/cpp/src/download/blob_downloader.cc
+++ b/sdk_v2/cpp/src/download/blob_downloader.cc
@@ -25,10 +25,7 @@
 #include <azure/core/context.hpp>
 #include <azure/storage/blobs.hpp>
 
-// The Azure Storage SDK builds its own libcurl transport, which — like our other curl transports —
-// does not honor SSL_CERT_FILE. On Android we install a CurlTransport preconfigured with CAInfo
-// (see MakeBlobClientOptions below); every other platform uses the SDK's default transport.
-#if defined(ANDROID)
+#if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
 #include "http/curl_transport.h"
 
 #include <azure/core/http/curl_transport.hpp>
@@ -43,15 +40,10 @@ namespace {
 /// memory at this many bytes regardless of chunk size.
 constexpr size_t kStreamingBufferBytes = 64 * 1024;
 
-/// Builds BlobClientOptions with the CA bundle wired into the transport. The Azure Storage SDK
-/// constructs its own libcurl transport internally, which does not consult SSL_CERT_FILE, so blob
-/// downloads would otherwise fail TLS verification on Android with "unable to get local issuer
-/// certificate". On Android we install a CurlTransport preconfigured with CAInfo so verification
-/// uses the caller-provided trust store; every other platform resolves trust through its default
-/// transport (system CA store on Linux/macOS, WinHTTP OS store on Windows) and is left untouched.
+/// Uses the same resolved CA bundle as the SDK's other curl transports.
 Azure::Storage::Blobs::BlobClientOptions MakeBlobClientOptions() {
   Azure::Storage::Blobs::BlobClientOptions options;
-#if defined(ANDROID)
+#if !defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
   // Only override the Storage SDK's default transport when a CA bundle is configured.
   auto curl_options = fl::http::MakeCurlTransportOptions();
   if (!curl_options.CAInfo.empty()) {

--- a/sdk_v2/cpp/src/http/curl_transport.cc
+++ b/sdk_v2/cpp/src/http/curl_transport.cc
@@ -13,11 +13,9 @@ namespace http {
 
 Azure::Core::Http::CurlTransportOptions MakeCurlTransportOptions() {
   Azure::Core::Http::CurlTransportOptions options;
-#if defined(ANDROID)
   if (const std::string& ca_bundle = CABundleFilePath(); !ca_bundle.empty()) {
     options.CAInfo = ca_bundle;
   }
-#endif
 
   return options;
 }

--- a/sdk_v2/cpp/src/http/curl_transport.h
+++ b/sdk_v2/cpp/src/http/curl_transport.h
@@ -12,8 +12,7 @@
 namespace fl {
 namespace http {
 
-/// Creates libcurl transport options with `CAInfo` set from `CABundleFilePath` (Android only; empty
-/// elsewhere, so libcurl falls back to the system default CA store).
+/// Creates curl transport options with CAInfo set when CABundleFilePath() resolves one.
 Azure::Core::Http::CurlTransportOptions MakeCurlTransportOptions();
 
 }  // namespace http

--- a/sdk_v2/cpp/src/http/http_client.cc
+++ b/sdk_v2/cpp/src/http/http_client.cc
@@ -23,9 +23,14 @@
 #include <azure/core/http/curl_transport.hpp>
 #endif
 
+#include <array>
 #include <chrono>
+#include <filesystem>
+#include <optional>
 #include <random>
 #include <string>
+#include <string_view>
+#include <system_error>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -33,13 +38,48 @@
 namespace fl {
 namespace http {
 
+namespace {
+
+// Well-known CA bundle locations across Linux distributions, most common first.
+constexpr std::array<std::string_view, 6> kLinuxCaBundleCandidates = {
+    "/etc/ssl/certs/ca-certificates.crt",                 // Debian/Ubuntu/Gentoo/Arch Linux
+    "/etc/pki/tls/certs/ca-bundle.crt",                   // Fedora/RHEL/CentOS/AlmaLinux/Rocky Linux
+    "/etc/ssl/ca-bundle.pem",                             // openSUSE
+    "/etc/pki/tls/cacert.pem",                            // OpenELEC
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",  // CentOS/RHEL 7+ (update-ca-trust output)
+    "/etc/ssl/cert.pem",                                  // Alpine Linux
+};
+
+}  // namespace
+
+std::string ResolveLinuxCaBundle(const std::function<std::optional<std::string>(const char*)>& get_env,
+                                 const std::function<bool(std::string_view)>& path_exists) {
+  if (auto cert_file = get_env("SSL_CERT_FILE"); cert_file && !cert_file->empty()) {
+    return std::move(*cert_file);
+  }
+
+  for (const std::string_view candidate : kLinuxCaBundleCandidates) {
+    if (path_exists(candidate)) {
+      return std::string(candidate);
+    }
+  }
+
+  return {};
+}
+
 const std::string& CABundleFilePath() {
   static const std::string ca_bundle = [] {
 #if defined(ANDROID)
-    // Gated to Android: it is the only platform where the bundled libcurl has no default CA store
-    // and where we own the process environment (the Android host sets SSL_CERT_FILE itself).
     auto cert_file = Utils::GetEnv("SSL_CERT_FILE");
     return (cert_file && !cert_file->empty()) ? std::move(*cert_file) : std::string();
+#elif defined(__linux__)
+    // Static curl/OpenSSL builds can carry a CA path that is absent on the host distribution.
+    return ResolveLinuxCaBundle(
+        [](const char* name) { return Utils::GetEnv(name); },
+        [](std::string_view path) {
+          std::error_code ec;
+          return std::filesystem::is_regular_file(path, ec);
+        });
 #else
     return std::string();
 #endif
@@ -65,9 +105,6 @@ HttpRawResult HttpRequestRaw(const Azure::Core::Http::HttpMethod& method,
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
   WinHttpTransport transport;
 #else
-  // On Android, libcurl has no valid default CA path, so MakeCurlTransportOptions() supplies the CA
-  // bundle via CAInfo; on other curl platforms it returns empty options and libcurl uses the system
-  // default trust store (see http/curl_transport.h).
   CurlTransport transport(MakeCurlTransportOptions());
 #endif
 

--- a/sdk_v2/cpp/src/http/http_client.h
+++ b/sdk_v2/cpp/src/http/http_client.h
@@ -7,7 +7,9 @@
 #include <chrono>
 #include <functional>
 #include <map>
+#include <optional>
 #include <string>
+#include <string_view>
 
 namespace fl {
 namespace http {
@@ -27,10 +29,11 @@ struct HttpRequestOptions {
   bool close_connection = false;
 };
 
-/// Returns the CA bundle path from `SSL_CERT_FILE` (read once, cached for the process lifetime), or
-/// empty when unset. The bundled libcurl does not consult `SSL_CERT_FILE` itself, so libcurl-based
-/// transports must pass this explicitly as `CAInfo`. Gated to Android; empty everywhere else, where
-/// the system default CA store (or WinHTTP on Windows) is used instead.
+/// Resolves SSL_CERT_FILE or a well-known Linux CA bundle path.
+std::string ResolveLinuxCaBundle(const std::function<std::optional<std::string>(const char*)>& get_env,
+                                 const std::function<bool(std::string_view)>& path_exists);
+
+/// Returns SSL_CERT_FILE, a known Linux CA bundle, or empty when the platform default should be used.
 const std::string& CABundleFilePath();
 
 /// Perform an HTTP POST and return status, headers, and body without throwing on non-2xx responses.

--- a/sdk_v2/cpp/src/http/http_download.cc
+++ b/sdk_v2/cpp/src/http/http_download.cc
@@ -77,9 +77,6 @@ bool HttpDownloadFile(const std::string& url, const std::filesystem::path& desti
 #if defined(FOUNDRY_LOCAL_USE_WINHTTP_TRANSPORT)
   WinHttpTransport transport;
 #else
-  // On Android, libcurl has no valid default CA path, so MakeCurlTransportOptions() supplies the CA
-  // bundle via CAInfo; on other curl platforms it returns empty options and libcurl uses the system
-  // default trust store (see http/curl_transport.h).
   CurlTransport transport(http::MakeCurlTransportOptions());
 #endif
   Request request(HttpMethod::Get, Url(url));

--- a/sdk_v2/cpp/test/CMakeLists.txt
+++ b/sdk_v2/cpp/test/CMakeLists.txt
@@ -6,15 +6,13 @@ find_package(httplib CONFIG REQUIRED)
 # whose Linux implementation calls getaddrinfo_a/gai_suspend/gai_cancel/gai_error.
 # On glibc < 2.34 (e.g. manylinux_2_28's glibc 2.28) those symbols live in libanl,
 # which the header-only httplib::httplib target does not pull in automatically.
-# Link it alongside httplib::httplib wherever the latter is used; find_library
-# yields NOTFOUND (silently omitted below) on newer glibc, where libanl was
-# folded into libc.
+# Link it alongside httplib::httplib wherever the latter is used. Requiring
+# the library makes a missing glibc development package fail at configure time
+# instead of reproducing the less actionable executable link failure.
 set(FOUNDRY_LOCAL_HTTPLIB_LIBS httplib::httplib)
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    find_library(ANL_LIBRARY anl)
-    if(ANL_LIBRARY)
-        list(APPEND FOUNDRY_LOCAL_HTTPLIB_LIBS ${ANL_LIBRARY})
-    endif()
+    find_library(ANL_LIBRARY anl REQUIRED)
+    list(APPEND FOUNDRY_LOCAL_HTTPLIB_LIBS ${ANL_LIBRARY})
 endif()
 
 # ==========================================================================

--- a/sdk_v2/cpp/test/CMakeLists.txt
+++ b/sdk_v2/cpp/test/CMakeLists.txt
@@ -2,6 +2,21 @@
 
 find_package(httplib CONFIG REQUIRED)
 
+# The vcpkg cpp-httplib port enables CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO,
+# whose Linux implementation calls getaddrinfo_a/gai_suspend/gai_cancel/gai_error.
+# On glibc < 2.34 (e.g. manylinux_2_28's glibc 2.28) those symbols live in libanl,
+# which the header-only httplib::httplib target does not pull in automatically.
+# Link it alongside httplib::httplib wherever the latter is used; find_library
+# yields NOTFOUND (silently omitted below) on newer glibc, where libanl was
+# folded into libc.
+set(FOUNDRY_LOCAL_HTTPLIB_LIBS httplib::httplib)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    find_library(ANL_LIBRARY anl)
+    if(ANL_LIBRARY)
+        list(APPEND FOUNDRY_LOCAL_HTTPLIB_LIBS ${ANL_LIBRARY})
+    endif()
+endif()
+
 # ==========================================================================
 # Internal tests — test the implementation directly
 # Links against the static library with access to internal src/ headers.
@@ -80,7 +95,7 @@ target_link_libraries(foundry_local_tests
     PRIVATE
         foundry_local_static
         GTest::gtest
-        httplib::httplib
+        ${FOUNDRY_LOCAL_HTTPLIB_LIBS}
         ZLIB::ZLIB
 )
 
@@ -179,7 +194,7 @@ target_link_libraries(sdk_integration_tests
         foundry_local_cpp
         GTest::gtest
         nlohmann_json::nlohmann_json
-        httplib::httplib
+        ${FOUNDRY_LOCAL_HTTPLIB_LIBS}
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/sdk_v2/cpp/test/CMakeLists.txt
+++ b/sdk_v2/cpp/test/CMakeLists.txt
@@ -2,13 +2,7 @@
 
 find_package(httplib CONFIG REQUIRED)
 
-# The vcpkg cpp-httplib port enables CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO,
-# whose Linux implementation calls getaddrinfo_a/gai_suspend/gai_cancel/gai_error.
-# On glibc < 2.34 (e.g. manylinux_2_28's glibc 2.28) those symbols live in libanl,
-# which the header-only httplib::httplib target does not pull in automatically.
-# Link it alongside httplib::httplib wherever the latter is used. Requiring
-# the library makes a missing glibc development package fail at configure time
-# instead of reproducing the less actionable executable link failure.
+# cpp-httplib's non-blocking resolver uses getaddrinfo_a, which lives in libanl on glibc < 2.34.
 set(FOUNDRY_LOCAL_HTTPLIB_LIBS httplib::httplib)
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     find_library(ANL_LIBRARY anl REQUIRED)
@@ -47,6 +41,7 @@ add_executable(foundry_local_tests
     internal_api/file_uri_test.cc
     internal_api/file_writer_test.cc
     internal_api/genai_config_test.cc
+    internal_api/http_ca_bundle_test.cc
     internal_api/http_download_test.cc
     internal_api/http_retry_test.cc
     internal_api/item_test.cc

--- a/sdk_v2/cpp/test/internal_api/ep_detector_test.cc
+++ b/sdk_v2/cpp/test/internal_api/ep_detector_test.cc
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <string>

--- a/sdk_v2/cpp/test/internal_api/http_ca_bundle_test.cc
+++ b/sdk_v2/cpp/test/internal_api/http_ca_bundle_test.cc
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Unit tests for Linux CA bundle resolution.
+#include "http/http_client.h"
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <initializer_list>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <string_view>
+#include <utility>
+
+using namespace fl::http;
+
+namespace {
+
+/// Builds a `get_env` callable backed by an in-memory map, mirroring `Utils::GetEnv`'s
+/// `std::optional<std::string>` signature (nullopt = unset).
+std::function<std::optional<std::string>(const char*)> FakeEnv(
+    std::initializer_list<std::pair<const char*, const char*>> vars) {
+  auto table = std::make_shared<std::map<std::string, std::string>>();
+  for (const auto& [key, value] : vars) {
+    (*table)[key] = value;
+  }
+
+  return [table](const char* name) -> std::optional<std::string> {
+    auto it = table->find(name);
+    return it == table->end() ? std::nullopt : std::optional<std::string>(it->second);
+  };
+}
+
+/// Builds a `path_exists` callable backed by an in-memory set of "present" paths.
+std::function<bool(std::string_view)> FakeFilesystem(std::set<std::string> present_paths) {
+  auto present = std::make_shared<std::set<std::string>>(std::move(present_paths));
+  return [present](std::string_view path) { return present->count(std::string(path)) != 0; };
+}
+
+}  // namespace
+
+TEST(ResolveLinuxCaBundleTest, PrefersExplicitSslCertFile) {
+  auto get_env = FakeEnv({{"SSL_CERT_FILE", "/custom/ca.pem"}});
+  auto path_exists = FakeFilesystem({"/etc/ssl/certs/ca-certificates.crt"});
+
+  EXPECT_EQ(ResolveLinuxCaBundle(get_env, path_exists), "/custom/ca.pem");
+}
+
+TEST(ResolveLinuxCaBundleTest, IgnoresEmptyEnvOverridesAndFallsBackToProbing) {
+  auto get_env = FakeEnv({{"SSL_CERT_FILE", ""}});
+  auto path_exists = FakeFilesystem({"/etc/ssl/certs/ca-certificates.crt"});
+
+  EXPECT_EQ(ResolveLinuxCaBundle(get_env, path_exists), "/etc/ssl/certs/ca-certificates.crt");
+}
+
+TEST(ResolveLinuxCaBundleTest, ProbesWellKnownDistroPathsInPriorityOrder) {
+  // Simulate an AlmaLinux/RHEL-style host: no Debian/Ubuntu bundle, but the Fedora/RHEL one exists.
+  auto get_env = FakeEnv({});
+  auto path_exists = FakeFilesystem({"/etc/pki/tls/certs/ca-bundle.crt"});
+
+  EXPECT_EQ(ResolveLinuxCaBundle(get_env, path_exists), "/etc/pki/tls/certs/ca-bundle.crt");
+}
+
+TEST(ResolveLinuxCaBundleTest, PrefersDebianPathOverRhelPathWhenBothExist) {
+  auto get_env = FakeEnv({});
+  auto path_exists = FakeFilesystem({
+      "/etc/ssl/certs/ca-certificates.crt",
+      "/etc/pki/tls/certs/ca-bundle.crt",
+  });
+
+  EXPECT_EQ(ResolveLinuxCaBundle(get_env, path_exists), "/etc/ssl/certs/ca-certificates.crt");
+}
+
+TEST(ResolveLinuxCaBundleTest, ReturnsEmptyWhenNoOverrideAndNoKnownPathExists) {
+  auto get_env = FakeEnv({});
+  auto path_exists = FakeFilesystem({});
+
+  EXPECT_EQ(ResolveLinuxCaBundle(get_env, path_exists), "");
+}

--- a/sdk_v2/python/.gitignore
+++ b/sdk_v2/python/.gitignore
@@ -38,5 +38,9 @@ src/foundry_local_sdk/_native/_cffi_bindings*.c
 src/foundry_local_sdk/_native/win-x64/
 src/foundry_local_sdk/_native/win-arm64/
 src/foundry_local_sdk/_native/linux-x64/
+src/foundry_local_sdk/_native/linux-arm64/
 src/foundry_local_sdk/_native/osx-x64/
 src/foundry_local_sdk/_native/osx-arm64/
+src/foundry_local_sdk/_native/_cffi_bindings*.so
+src/foundry_local_sdk/_native/_cffi_bindings*.pyd
+src/foundry_local_sdk/_native/_cffi_bindings*.dylib


### PR DESCRIPTION
Builds the Linux x64 and ARM64 native runtime and Python wheels in pinned manylinux 2.28 containers.

This change:

- Produces publishable `manylinux_2_28_x86_64` and `manylinux_2_28_aarch64` wheels.
- Uses `auditwheel` to repair and validate wheel compatibility.
- Keeps ORT and GenAI libraries supplied by their declared Python dependencies.
- Resolves Linux CA bundles at runtime across common distributions.
- Adds the explicit Linux link dependencies exposed by glibc 2.28.