### PR TITLE
Use newer ort-genai nightly in foundry-local ci build

### DIFF
--- a/.pipelines/foundry-local-packaging.yml
+++ b/.pipelines/foundry-local-packaging.yml
@@ -53,12 +53,17 @@ parameters:
 
 variables:
 - group: FoundryLocal-ESRP-Signing
-# C++ SDK (sdk_v2/cpp) native dependency versions. Must match cmake defaults
-# in sdk_v2/deps_versions.json.
+# C++ SDK (sdk_v2/cpp) native dependency versions. Release builds use the
+# stable pins from sdk_v2/deps_versions.json; non-release CI validates the
+# selected GenAI nightly before it becomes a stable SDK default.
 - name: cppOrtVersion
   value: '1.28.0'
-- name: cppGenaiVersion
-  value: '0.15.2'
+- ${{ if eq(parameters.isRelease, true) }}:
+  - name: cppGenaiVersion
+    value: '0.15.2'
+- ${{ else }}:
+  - name: cppGenaiVersion
+    value: '0.16.0-dev1001400138'
 - name: cppWinmlVersion
   value: '2.1.70'
 - name: cppBuildConfig

--- a/.pipelines/v2/sdk_v2-pipeline-plan.md
+++ b/.pipelines/v2/sdk_v2-pipeline-plan.md
@@ -285,7 +285,8 @@ purposes:
 Versions are pipeline-level variables, currently:
 
 * `ortVersion`        `1.28.0`   (`Microsoft.ML.OnnxRuntime`)
-* `genaiVersion`      `0.15.2`   (`Microsoft.ML.OnnxRuntimeGenAI.Foundry`)
+* `genaiVersion`      `0.15.2` for releases; selected ORT-Nightly version for non-release CI
+  (`Microsoft.ML.OnnxRuntimeGenAI.Foundry`)
 * `winmlVersion`      `2.1.70`    (`Microsoft.Windows.AI.MachineLearning`, WinML 2.x reg-free)
 
 These must be kept in sync with the cmake defaults and with

--- a/.pipelines/v2/templates/stages-rust.yml
+++ b/.pipelines/v2/templates/stages-rust.yml
@@ -15,12 +15,6 @@
 #
 # The pack stage emits the `rust-sdk-v2` pipeline artifact (the `.crate`).
 
-parameters:
-- name: ortVersion
-  type: string
-- name: genaiVersion
-  type: string
-
 stages:
 
 # =====================================================================
@@ -54,8 +48,6 @@ stages:
         rid: 'win-x64'
         nativeArtifactDir: '$(Pipeline.Workspace)/cpp-native-win-x64'
         runTests: true
-        ortVersion: ${{ parameters.ortVersion }}
-        genaiVersion: ${{ parameters.genaiVersion }}
         testDataSharedDir: '$(Build.SourcesDirectory)/test-data-shared'
 
 - stage: rust_build_win_arm64
@@ -113,8 +105,6 @@ stages:
         rid: 'linux-x64'
         nativeArtifactDir: '$(Pipeline.Workspace)/cpp-native-linux-x64'
         runTests: true
-        ortVersion: ${{ parameters.ortVersion }}
-        genaiVersion: ${{ parameters.genaiVersion }}
         testDataSharedDir: '$(Build.SourcesDirectory)/test-data-shared'
 
 - stage: rust_build_linux_arm64
@@ -146,8 +136,6 @@ stages:
         rid: 'linux-arm64'
         nativeArtifactDir: '$(Pipeline.Workspace)/cpp-native-linux-arm64'
         runTests: true
-        ortVersion: ${{ parameters.ortVersion }}
-        genaiVersion: ${{ parameters.genaiVersion }}
         testDataSharedDir: '$(Build.SourcesDirectory)/test-data-shared'
 
 - stage: rust_build_osx_arm64
@@ -180,8 +168,6 @@ stages:
         rid: 'osx-arm64'
         nativeArtifactDir: '$(Pipeline.Workspace)/cpp-native-osx-arm64'
         runTests: true
-        ortVersion: ${{ parameters.ortVersion }}
-        genaiVersion: ${{ parameters.genaiVersion }}
         testDataSharedDir: '$(Build.SourcesDirectory)/test-data-shared'
 
 # ================================================================

--- a/.pipelines/v2/templates/stages-sdk-v2.yml
+++ b/.pipelines/v2/templates/stages-sdk-v2.yml
@@ -43,9 +43,5 @@ stages:
 - template: stages-js.yml
 
 # ── Rust SDK (single platform-independent crate) ──
-# Needs the ORT/GenAI versions to assemble a runnable native dir for its
-# integration tests (the cpp-native artifacts ship foundry_local only).
+# Rust integration tests consume the complete matching cpp-native artifact.
 - template: stages-rust.yml
-  parameters:
-    ortVersion: ${{ parameters.ortVersion }}
-    genaiVersion: ${{ parameters.genaiVersion }}

--- a/.pipelines/v2/templates/steps-build-linux.yml
+++ b/.pipelines/v2/templates/steps-build-linux.yml
@@ -53,7 +53,6 @@ steps:
     genaiVersion: ${{ parameters.genaiVersion }}
     winmlVersion: ''
     includeWinml: false
-    shell: bash
 
 - ${{ if eq(parameters.runTests, true) }}:
   - template: ../../templates/fetch-models-from-artifacts-feed.yml@self
@@ -90,8 +89,9 @@ steps:
           --cmake_path "$HOME/venv/bin/cmake" \
           --ctest_path "$HOME/venv/bin/ctest" \
           --cmake_extra_defines \
-            "GENAI_FETCH_URL=$NUGET_CACHE/genai.nupkg" \
-            "ORT_FETCH_URL=$NUGET_CACHE/ort.nupkg" \
+            "GENAI_FETCH_URL=$NUGET_CACHE/genai.zip" \
+            "ORT_GENAI_VERSION=${{ parameters.genaiVersion }}" \
+            "ORT_FETCH_URL=$NUGET_CACHE/ort.zip" \
             "FOUNDRY_LOCAL_VERSION_STRING=$SDK_VERSION"
       '
   displayName: 'Configure and build in manylinux 2.28'

--- a/.pipelines/v2/templates/steps-build-macos.yml
+++ b/.pipelines/v2/templates/steps-build-macos.yml
@@ -38,7 +38,6 @@ steps:
     genaiVersion: ${{ parameters.genaiVersion }}
     winmlVersion: ''
     includeWinml: false
-    shell: bash
 
 # Bake the pipeline-computed version into the binary so FoundryLocalGetVersionString()
 # matches the .nupkg version instead of the cmake default.

--- a/.pipelines/v2/templates/steps-build-rust.yml
+++ b/.pipelines/v2/templates/steps-build-rust.yml
@@ -6,11 +6,9 @@
 #   1. Install a stable Rust toolchain (clippy + rustfmt), plus the cross target
 #      when `crossTarget` is set (win-arm64 is cross-compiled from an x64 host).
 #   2. Assemble a native runtime directory:
-#        * `foundry_local` (+ the reg-free WinML DLL on Windows) taken from the
-#          `cpp-native-<rid>` pipeline artifact, and
-#        * ONNX Runtime + GenAI extracted from the pinned public NuGet packages
-#          (only when `runTests` — the SDK compiles without them, but loading a
-#          model at runtime needs them next to `foundry_local`).
+#        * `foundry_local`, ONNX Runtime, and GenAI taken from the matching
+#          `cpp-native-<rid>` pipeline artifact
+#        * the reg-free WinML DLL included by the Windows native artifacts
 #      The directory is handed to build.rs via `FOUNDRY_LOCAL_NATIVE_BIN_DIR`,
 #      which copies every platform library into OUT_DIR and bakes the path into
 #      the crate, so both unit and integration tests resolve the native by that
@@ -32,7 +30,7 @@ parameters:
   # win-x64 | win-arm64 | linux-x64 | linux-arm64 | osx-arm64
 - name: nativeArtifactDir
   type: string
-  # Downloaded `cpp-native-<rid>` artifact (carries foundry_local, + WinML on Windows).
+  # Downloaded `cpp-native-<rid>` artifact containing the complete native runtime.
 - name: runTests
   type: boolean
   default: false
@@ -40,12 +38,6 @@ parameters:
   type: string
   default: ''
   # e.g. 'aarch64-pc-windows-msvc' for the win-arm64 cross build; '' for native.
-- name: ortVersion
-  type: string
-  default: ''
-- name: genaiVersion
-  type: string
-  default: ''
 - name: testDataSharedDir
   type: string
   default: ''
@@ -124,45 +116,6 @@ steps:
       foreach ($f in $nativeFiles) {
         Copy-Item $f.FullName (Join-Path $assembled $f.Name) -Force
         Write-Host "  native : $($f.Name)"
-      }
-
-      # 2b. ONNX Runtime + GenAI from the pinned public NuGet packages — needed
-      #     only to *run* a model (integration tests). The versions come from the
-      #     same pipeline literals that drive the C++ native build, which
-      #     steps-prefetch-nuget.yml asserts against sdk_v2/deps_versions.json.
-      $ortVersion   = '${{ parameters.ortVersion }}'
-      $genaiVersion = '${{ parameters.genaiVersion }}'
-      if ($ortVersion -ne '' -and $genaiVersion -ne '') {
-        $feed = 'https://www.nuget.org/api/v2/package'
-        $tmp  = Join-Path '$(Build.BinariesDirectory)' 'rt-nupkg'
-        if (Test-Path $tmp) { Remove-Item -Recurse -Force $tmp }
-        New-Item -ItemType Directory -Force -Path $tmp | Out-Null
-
-        $pkgs = @(
-          @{ id = 'Microsoft.ML.OnnxRuntime';              version = $ortVersion   },
-          @{ id = 'Microsoft.ML.OnnxRuntimeGenAI.Foundry'; version = $genaiVersion }
-        )
-        foreach ($p in $pkgs) {
-          $zip = Join-Path $tmp "$($p.id).$($p.version).zip"
-          $out = Join-Path $tmp $p.id
-          Write-Host "Downloading $($p.id) $($p.version)"
-          Invoke-WebRequest -Uri "$feed/$($p.id)/$($p.version)" -OutFile $zip -UseBasicParsing
-          Expand-Archive -Path $zip -DestinationPath $out -Force
-
-          $nativeDir = Join-Path $out "runtimes/$rid/native"
-          if (-not (Test-Path $nativeDir)) {
-            throw "runtimes/$rid/native not found in $($p.id) $($p.version)."
-          }
-          $libs = @(Get-ChildItem -Path $nativeDir -File |
-            Where-Object { $_.Extension -eq ".$ext" })
-          if ($libs.Count -eq 0) {
-            throw "No *.$ext libraries under runtimes/$rid/native for $($p.id)."
-          }
-          foreach ($lib in $libs) {
-            Copy-Item $lib.FullName (Join-Path $assembled $lib.Name) -Force
-            Write-Host "  runtime: $($lib.Name)"
-          }
-        }
       }
 
       Write-Host "Assembled native dir: $assembled"

--- a/.pipelines/v2/templates/steps-build-windows.yml
+++ b/.pipelines/v2/templates/steps-build-windows.yml
@@ -61,7 +61,6 @@ steps:
     genaiVersion: ${{ parameters.genaiVersion }}
     winmlVersion: ${{ parameters.winmlVersion }}
     includeWinml: true
-    shell: pwsh
 
 # Bake the pipeline-computed version into the binary so FoundryLocalGetVersionString()
 # matches the .nupkg version (e.g. 0.1.0-dev.202605111234) instead of the cmake default.

--- a/.pipelines/v2/templates/steps-prefetch-nuget.yml
+++ b/.pipelines/v2/templates/steps-prefetch-nuget.yml
@@ -9,7 +9,6 @@
 #   genaiVersion   – Microsoft.ML.OnnxRuntimeGenAI.Foundry version
 #   winmlVersion   – Microsoft.Windows.AI.MachineLearning version (Windows only)
 #   includeWinml   – Download WinML and emit WINML_EP_CATALOG_FETCH_URL
-#   shell          – 'pwsh' (Windows/macOS) or 'bash' (Linux)
 
 parameters:
 - name: ortVersion
@@ -22,14 +21,12 @@ parameters:
 - name: includeWinml
   type: boolean
   default: false
-- name: shell
-  type: string
-  values: ['pwsh', 'bash']
 
 steps:
 
-# Fail fast if the pipeline-pinned versions drift from the cmake source of
-# truth in sdk_v2/deps_versions.json.
+# Stable pipeline versions must match sdk_v2/deps_versions.json. Non-release
+# CI intentionally overrides GenAI with a prerelease from the existing
+# AIFoundryLocal_PublicPackages feed, which has ORT-Nightly as an upstream.
 - task: PowerShell@2
   displayName: 'Validate pinned versions match deps_versions.json'
   inputs:
@@ -42,7 +39,9 @@ steps:
       $deps = Get-Content $depsFile -Raw | ConvertFrom-Json
       $expected = @{
         'onnxruntime'                = '${{ parameters.ortVersion }}'
-        'onnxruntime-genai'          = '${{ parameters.genaiVersion }}'
+      }
+      if ('${{ parameters.genaiVersion }}' -notmatch '-dev') {
+        $expected['onnxruntime-genai'] = '${{ parameters.genaiVersion }}'
       }
       if ('${{ parameters.winmlVersion }}' -ne '') {
         $expected['windows-ai-machinelearning'] = '${{ parameters.winmlVersion }}'
@@ -61,96 +60,89 @@ steps:
       }
       Write-Host "Pinned versions agree with sdk_v2/deps_versions.json."
 
-- ${{ if eq(parameters.shell, 'pwsh') }}:
-  - task: PowerShell@2
-    displayName: 'Pre-download NuGet packages'
-    inputs:
-      targetType: inline
-      pwsh: true
-      script: |
-        $ErrorActionPreference = 'Stop'
-        $cacheDir = "$(Build.BinariesDirectory)/nuget_packages"
-        New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+- task: UseDotNet@2
+  displayName: 'Use .NET 10 SDK for NuGet restore'
+  inputs:
+    packageType: sdk
+    version: '10.0.x'
 
-        # These packages are public on nuget.org. Foundry Local Core's
-        # nuget.config maps everything except Microsoft.Telemetry* to nuget.org
-        # (see .pipelines/templates/build-core-steps.yml), so we follow the
-        # same source of truth here.
-        $feed = "https://www.nuget.org/api/v2/package"
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate NuGet feeds'
 
-        $packages = @(
-          @{ key = 'genai'; id = 'Microsoft.ML.OnnxRuntimeGenAI.Foundry'; version = '${{ parameters.genaiVersion }}' },
-          @{ key = 'ort';   id = 'Microsoft.ML.OnnxRuntime';             version = '${{ parameters.ortVersion }}'   }
-        )
+- task: PowerShell@2
+  displayName: 'Restore native packages'
+  inputs:
+    targetType: inline
+    pwsh: true
+    script: |
+      $ErrorActionPreference = 'Stop'
+      $cacheDir = "$(Build.BinariesDirectory)/nuget_packages"
+      $restoreDir = Join-Path $cacheDir "restore"
+      $packagesDir = Join-Path $restoreDir "packages"
+      New-Item -ItemType Directory -Force -Path $restoreDir | Out-Null
 
-        $defines = @()
-        foreach ($pkg in $packages) {
-          $url = "$feed/$($pkg.id)/$($pkg.version)"
-          $out = "$cacheDir/$($pkg.key).nupkg"
-          Write-Host "Downloading $($pkg.id) $($pkg.version)"
-          Invoke-WebRequest -Uri $url -OutFile $out -UseBasicParsing
-          if (-not (Test-Path $out)) { throw "$($pkg.key) download failed" }
-          Write-Host "  -> $out ($((Get-Item $out).Length) bytes)"
-
-          switch ($pkg.key) {
-            'genai' { $defines += "GENAI_FETCH_URL=$out" }
-            'ort'   { $defines += "ORT_FETCH_URL=$out" }
-          }
-        }
-
-        if ($${{ parameters.includeWinml }}) {
-          # WinML 2.x (Microsoft.Windows.AI.MachineLearning) is reg-free — a single self-contained
-          # native package with no transitive Windows App SDK Foundation dependency to resolve.
-          $winmlUrl = "$feed/Microsoft.Windows.AI.MachineLearning/${{ parameters.winmlVersion }}"
-          $winmlOut = "$cacheDir/winml.nupkg"
-          Write-Host "Downloading Microsoft.Windows.AI.MachineLearning ${{ parameters.winmlVersion }}"
-          Invoke-WebRequest -Uri $winmlUrl -OutFile $winmlOut
-          if (-not (Test-Path $winmlOut)) { throw "WinML download failed" }
-          Write-Host "  -> $winmlOut ($((Get-Item $winmlOut).Length) bytes)"
-          $defines += "WINML_EP_CATALOG_FETCH_URL=$winmlOut"
-        }
-
-        $joined = ($defines | ForEach-Object { "`"$_`"" }) -join ' '
-        Write-Host "##vso[task.setvariable variable=cmakeFetchDefines]$joined"
-        Write-Host "cmakeFetchDefines = $joined"
-
-- ${{ if eq(parameters.shell, 'bash') }}:
-  - bash: |
-      set -euo pipefail
-      cacheDir="$(Build.BinariesDirectory)/nuget_packages"
-      mkdir -p "$cacheDir"
-
-      # These packages are public on nuget.org. Foundry Local Core's
-      # nuget.config maps everything except Microsoft.Telemetry* to nuget.org
-      # (see .pipelines/templates/build-core-steps.yml), so we follow the
-      # same source of truth here.
-      feed="https://www.nuget.org/api/v2/package"
-
-      declare -a entries=(
-        "genai:Microsoft.ML.OnnxRuntimeGenAI.Foundry:${{ parameters.genaiVersion }}"
-        "ort:Microsoft.ML.OnnxRuntime:${{ parameters.ortVersion }}"
+      $packages = @(
+        @{ key = 'genai'; id = 'Microsoft.ML.OnnxRuntimeGenAI.Foundry'; version = '${{ parameters.genaiVersion }}' },
+        @{ key = 'ort'; id = 'Microsoft.ML.OnnxRuntime'; version = '${{ parameters.ortVersion }}' }
       )
-      if [ "${{ parameters.includeWinml }}" = "True" ]; then
-        # WinML is Windows-only; the bash branch should never receive includeWinml=true.
-        echo "ERROR: includeWinml=true is not supported on the bash prefetch branch (WinML is Windows-only)." >&2
-        exit 1
-      fi
-      defines=()
-      for entry in "${entries[@]}"; do
-        IFS=: read -r key id version <<< "$entry"
-        out="$cacheDir/${key}.nupkg"
-        url="$feed/${id}/${version}"
-        echo "Downloading $id $version"
-        curl -fSL -o "$out" "$url"
-        echo "  -> $out ($(stat -c%s "$out" 2>/dev/null || stat -f%z "$out") bytes)"
+      if ($${{ parameters.includeWinml }}) {
+        $packages += @{
+          key = 'winml'
+          id = 'Microsoft.Windows.AI.MachineLearning'
+          version = '${{ parameters.winmlVersion }}'
+        }
+      }
 
-        case "$key" in
-          genai) defines+=("\"GENAI_FETCH_URL=$out\"") ;;
-          ort)   defines+=("\"ORT_FETCH_URL=$out\"") ;;
-        esac
-      done
+      $references = $packages | ForEach-Object {
+        "    <PackageReference Include=`"$($_.id)`" Version=`"$($_.version)`" />"
+      }
+      $feedUrl = 'https://pkgs.dev.azure.com/aiinfra/AIFoundryLocal/_packaging/' +
+        'AIFoundryLocal_PublicPackages/nuget/v3/index.json'
+      @"
+      <Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
+        <ItemGroup>
+      $($references -join "`n")
+        </ItemGroup>
+      </Project>
+      "@ | Set-Content (Join-Path $restoreDir "restore.csproj")
 
-      joined="${defines[*]}"
-      echo "##vso[task.setvariable variable=cmakeFetchDefines]$joined"
-      echo "cmakeFetchDefines = $joined"
-    displayName: 'Pre-download NuGet packages'
+      @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <clear />
+          <add key="AIFoundryLocal_PublicPackages" value="$feedUrl" />
+        </packageSources>
+      </configuration>
+      "@ | Set-Content (Join-Path $restoreDir "NuGet.config")
+
+      dotnet restore (Join-Path $restoreDir "restore.csproj") `
+        --configfile (Join-Path $restoreDir "NuGet.config") `
+        --packages $packagesDir `
+        --no-cache
+      if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      $defines = @()
+      foreach ($pkg in $packages) {
+        $packageDir = Join-Path $packagesDir "$($pkg.id.ToLowerInvariant())/$($pkg.version)"
+        if (-not (Test-Path $packageDir)) {
+          throw "Restored package directory not found: $packageDir"
+        }
+        $archive = Join-Path $cacheDir "$($pkg.key).zip"
+        Compress-Archive -Path "$packageDir/*" -DestinationPath $archive -Force
+        Write-Host "Restored $($pkg.id) $($pkg.version) -> $archive"
+
+        switch ($pkg.key) {
+          'genai' {
+            $defines += "GENAI_FETCH_URL=$archive"
+            $defines += "ORT_GENAI_VERSION=$($pkg.version)"
+          }
+          'ort' { $defines += "ORT_FETCH_URL=$archive" }
+          'winml' { $defines += "WINML_EP_CATALOG_FETCH_URL=$archive" }
+        }
+      }
+
+      $joined = ($defines | ForEach-Object { "`"$_`"" }) -join ' '
+      Write-Host "##vso[task.setvariable variable=cmakeFetchDefines]$joined"
+      Write-Host "cmakeFetchDefines = $joined"


### PR DESCRIPTION
New API in ort-genai needs to be propagated to foundry-local ci pipeline so that dev work with the new api can begin.