### PR TITLE
Fix streaming audio language selection

### DIFF
--- a/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/audio/audio_session.cc
@@ -332,6 +332,12 @@ void AudioSession::ProcessStreamingAudio(const AudioItem& format_item, ItemQueue
   }
 
   auto generator = OgaGenerator::Create(oga_model, *gen_params);
+  if (IsNemotronSpeechModel()) {
+    auto language = effective_kvp.find("language");
+    if (language != effective_kvp.end()) {
+      TryNemotronLanguageId(*generator, language->second);
+    }
+  }
   auto tokenizer_stream = Model().GetPreprocessor().CreateTokenizerStream();
 
   auto streaming_callback = CreateCallbackHandler(request);


### PR DESCRIPTION
The AudioSession API never binds the language to the underlying model preventing recognition of things other than English. This enables properly binding for multi-lingual model