### PR TITLE
Clarify Foundry Local CLI installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,29 @@ Explore complete working examples in the [`samples/`](samples/) folder:
 
 ## 🖥️ CLI
 
-The Foundry Local CLI lets you explore models and experiment interactively.
+The optional Foundry Local CLI lets you explore models and experiment interactively. It is available in Public Preview.
 
-**Install (public preview):**
+**Install the CLI:**
 
-Download the asset for your platform from the [`cli-preview-0.10.0`](https://github.com/microsoft/Foundry-Local/releases/tag/cli-preview-0.10.0) GitHub release.
+Windows:
+
+```powershell
+winget install Microsoft.FoundryLocal
+```
+
+macOS (Apple silicon):
+
+```bash
+brew tap microsoft/foundrylocal
+brew install foundrylocal
+```
+
+For manual installation, download the current asset for your platform from the
+[Foundry Local CLI release assets](https://aka.ms/foundry-local-installer).
+
+> [!NOTE]
+> The releases page includes both SDK and CLI releases. `vX.Y.Z` tags are SDK releases, not CLI installers; use a
+> `cli-preview-X.Y.Z` release for a manual CLI download.
 
 **Run a model:**
 


### PR DESCRIPTION
## Summary
- replace the version-pinned CLI preview release link with the maintained `https://aka.ms/foundry-local-installer` entry point
- document the current Winget and Homebrew installation commands
- distinguish SDK `vX.Y.Z` releases from optional CLI `cli-preview-X.Y.Z` Public Preview releases

## Validation
- rendered `README.md` through GitHub's GFM API
- checked the README-only diff for whitespace errors and version-pinned CLI release URLs
- confirmed the installer alias and CLI documentation links return HTTP 200
- verified the `Microsoft.FoundryLocal` Winget package and `microsoft/foundrylocal` Homebrew formula