### PR TITLE
fixes bug in auditing python linux x64 whl

### DIFF
--- a/.pipelines/v2/templates/stages-python.yml
+++ b/.pipelines/v2/templates/stages-python.yml
@@ -255,6 +255,7 @@ stages:
       parameters:
         wheelDir: '$(Pipeline.Workspace)/python-sdk-linux-x64'
         testDataSharedDir: '$(Build.SourcesDirectory)/test-data-shared'
+        useSystemPython: true
 
 - stage: python_test_linux_arm64
   displayName: 'Python SDK: Test Linux ARM64'

--- a/.pipelines/v2/templates/steps-build-python.yml
+++ b/.pipelines/v2/templates/steps-build-python.yml
@@ -314,9 +314,19 @@ steps:
             throw "Expected exactly one .whl under ${{ parameters.outputDir }}, found $($wheels.Count)"
         }
 
-        $json = (& auditwheel show --json $wheels[0].FullName) -join "`n"
+        $hostVenv = "$(Agent.TempDirectory)/auditwheel-venv"
+        python3 -m venv $hostVenv
         if ($LASTEXITCODE -ne 0) {
-            throw "auditwheel failed with exit code $LASTEXITCODE"
+            throw "Failed to create auditwheel virtual environment with exit code $LASTEXITCODE"
+        }
+        $hostPython = "$hostVenv/bin/python"
+        & $hostPython -m pip install --upgrade pip "auditwheel==6.8.1"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to install auditwheel with exit code $LASTEXITCODE"
+        }
+        $json = (& $hostPython -m auditwheel show --json $wheels[0].FullName) -join "`n"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Auditwheel inspection failed with exit code $LASTEXITCODE"
         }
         $report = $json | ConvertFrom-Json
         Write-Host "auditwheel overall platform: $($report.overall_tag)"


### PR DESCRIPTION
```
Condition evaluation
Starting: Audit Linux ABI compatibility
==============================================================================
Task         : PowerShell
Description  : Run a PowerShell script on Linux, macOS, or Windows
Version      : 2.279.0
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/powershell
==============================================================================
[Host] Selected Node version: Node24 (Strategy: Node24Strategy)
Generating script.
========================== Starting Command Output ===========================
/usr/bin/pwsh -NoLogo -NoProfile -NonInteractive -Command . '/mnt/azure_nvme_temp/_work/_temp/37145821-df28-4f7f-996b-40e66b1199d7.ps1'
&: /mnt/azure_nvme_temp/_work/_temp/37145821-df28-4f7f-996b-40e66b1199d7.ps1:9
Line |
   9 |  $json = (& auditwheel show --json $wheels[0].FullName) -join "`n"
     |             ~~~~~~~~~~
     | The term 'auditwheel' is not recognized as a name of a cmdlet, function,
     | script file, or executable program. Check the spelling of the name, or
     | if a path was included, verify that the path is correct and try again.

##[error]PowerShell exited with code '1'.
Finishing: Audit Linux ABI compatibility
```