### PR TITLE
Enforce OpenAI generation penalty semantics

### DIFF
--- a/sdk_v2/cpp/include/foundry_local/foundry_local_c.h
+++ b/sdk_v2/cpp/include/foundry_local/foundry_local_c.h
@@ -294,8 +294,9 @@ typedef enum flTensorDataType {
 #define FOUNDRY_LOCAL_PARAM_TOP_P "top_p"                          ///< float [0.0, 1.0]. nucleus sampling
 #define FOUNDRY_LOCAL_PARAM_TOP_K "top_k"                          ///< int. top-k sampling
 #define FOUNDRY_LOCAL_PARAM_MAX_OUTPUT_TOKENS "max_output_tokens"  ///< int. max tokens to generate
-/// Penalty parameters currently support only the neutral float value 0.
+/// Float frequency penalty. Currently only the neutral value 0 is supported.
 #define FOUNDRY_LOCAL_PARAM_FREQUENCY_PENALTY "frequency_penalty"
+/// Float presence penalty. Currently only the neutral value 0 is supported.
 #define FOUNDRY_LOCAL_PARAM_PRESENCE_PENALTY "presence_penalty"
 #define FOUNDRY_LOCAL_PARAM_SEED "seed"                            ///< int. for reproducible outputs
 #define FOUNDRY_LOCAL_PARAM_EARLY_STOPPING "early_stopping"        ///< bool. whether to stop on stop sequence or only at max tokens

--- a/sdk_v2/cpp/include/foundry_local/foundry_local_c.h
+++ b/sdk_v2/cpp/include/foundry_local/foundry_local_c.h
@@ -294,8 +294,9 @@ typedef enum flTensorDataType {
 #define FOUNDRY_LOCAL_PARAM_TOP_P "top_p"                          ///< float [0.0, 1.0]. nucleus sampling
 #define FOUNDRY_LOCAL_PARAM_TOP_K "top_k"                          ///< int. top-k sampling
 #define FOUNDRY_LOCAL_PARAM_MAX_OUTPUT_TOKENS "max_output_tokens"  ///< int. max tokens to generate
-#define FOUNDRY_LOCAL_PARAM_FREQUENCY_PENALTY "frequency_penalty"  ///< float [-2.0, 2.0]
-#define FOUNDRY_LOCAL_PARAM_PRESENCE_PENALTY "presence_penalty"    ///< float [-2.0, 2.0]
+/// Penalty parameters currently support only the neutral float value 0.
+#define FOUNDRY_LOCAL_PARAM_FREQUENCY_PENALTY "frequency_penalty"
+#define FOUNDRY_LOCAL_PARAM_PRESENCE_PENALTY "presence_penalty"
 #define FOUNDRY_LOCAL_PARAM_SEED "seed"                            ///< int. for reproducible outputs
 #define FOUNDRY_LOCAL_PARAM_EARLY_STOPPING "early_stopping"        ///< bool. whether to stop on stop sequence or only at max tokens
 #define FOUNDRY_LOCAL_PARAM_DO_SAMPLE "do_sample"                  ///< bool. whether to sample (false = greedy decoding)

--- a/sdk_v2/cpp/include/foundry_local/foundry_local_cpp.h
+++ b/sdk_v2/cpp/include/foundry_local/foundry_local_cpp.h
@@ -943,8 +943,8 @@ struct SearchOptions {
   std::optional<float> top_p;              ///< Nucleus sampling [0.0, 1.0].
   std::optional<int> top_k;                ///< Top-k sampling.
   std::optional<int> max_output_tokens;    ///< Maximum tokens to generate.
-  std::optional<float> frequency_penalty;  ///< Frequency penalty [-2.0, 2.0].
-  std::optional<float> presence_penalty;   ///< Presence penalty [-2.0, 2.0].
+  std::optional<float> frequency_penalty;  ///< Currently only the neutral value 0 is supported.
+  std::optional<float> presence_penalty;   ///< Currently only the neutral value 0 is supported.
   std::optional<int> seed;                 ///< Random seed for reproducibility.
   std::optional<bool> early_stopping;      ///< Stop on stop-sequence match.
   std::optional<bool> do_sample;           ///< Whether to sample (false = greedy).

--- a/sdk_v2/cpp/src/contracts/chat_completions.h
+++ b/sdk_v2/cpp/src/contracts/chat_completions.h
@@ -65,8 +65,8 @@ struct ChatCompletionRequest {
   std::optional<nlohmann::json> stop;                          // "stop" — string or array
   std::optional<int> max_tokens;                               // "max_tokens" (deprecated)
   std::optional<int> max_completion_tokens;                    // "max_completion_tokens"
-  std::optional<float> presence_penalty;                       // "presence_penalty"
-  std::optional<float> frequency_penalty;                      // "frequency_penalty"
+  std::optional<float> presence_penalty;                       // "presence_penalty"; only 0 is supported
+  std::optional<float> frequency_penalty;                      // "frequency_penalty"; only 0 is supported
   std::optional<std::vector<ChatCompletionTool>> tools;        // "tools"
   std::optional<nlohmann::json> tool_choice;                   // "tool_choice" — string or object
   std::optional<nlohmann::json> response_format;               // "response_format"

--- a/sdk_v2/cpp/src/contracts/chat_completions_converter.cc
+++ b/sdk_v2/cpp/src/contracts/chat_completions_converter.cc
@@ -48,8 +48,6 @@ void ApplyCatalogDefaults(ChatCompletionRequest& req, const KeyValuePairs& model
 
   apply_default_float("temperature", req.temperature);
   apply_default_float("top_p", req.top_p);
-  apply_default_float("presence_penalty", req.presence_penalty);
-  apply_default_float("frequency_penalty", req.frequency_penalty);
   apply_default_int("max_tokens", req.max_tokens);
 
   // top_k and random_seed go through metadata (matches C# behavior)
@@ -153,8 +151,14 @@ void MapRequestParameters(const ChatCompletionRequest& req, Request& session_req
 
   set_float_param(req.temperature, "temperature");
   set_float_param(req.top_p, "top_p");
-  set_float_param(req.frequency_penalty, "frequency_penalty");
-  set_float_param(req.presence_penalty, "presence_penalty");
+  if (req.frequency_penalty.value_or(0.0f) != 0.0f) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+             "nonzero frequency_penalty is not supported; ORT repetition_penalty has different semantics");
+  }
+  if (req.presence_penalty.value_or(0.0f) != 0.0f) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+             "nonzero presence_penalty is not supported; ORT diversity_penalty has different semantics");
+  }
 
   if (req.seed.has_value()) {
     session_request.options["seed"] = std::to_string(*req.seed);

--- a/sdk_v2/cpp/src/contracts/responses.h
+++ b/sdk_v2/cpp/src/contracts/responses.h
@@ -137,8 +137,8 @@ struct ResponseCreateParams {
   std::optional<float> temperature;
   std::optional<int> max_output_tokens;
   std::optional<float> top_p;
-  std::optional<float> presence_penalty;
-  std::optional<float> frequency_penalty;
+  std::optional<float> presence_penalty;   // OpenAI semantics; only the neutral value 0 is currently supported.
+  std::optional<float> frequency_penalty;  // OpenAI semantics; only the neutral value 0 is currently supported.
   std::optional<int> seed;
   bool stream = false;
   bool store = false;
@@ -257,8 +257,8 @@ struct ResponseObject {
   std::optional<ToolChoice> tool_choice;
   std::optional<float> temperature;
   std::optional<float> top_p;
-  std::optional<float> presence_penalty;
-  std::optional<float> frequency_penalty;
+  std::optional<float> presence_penalty;   // OpenAI semantics; only the neutral value 0 is currently supported.
+  std::optional<float> frequency_penalty;  // OpenAI semantics; only the neutral value 0 is currently supported.
   std::optional<int> max_output_tokens;
   bool parallel_tool_calls = true;
   bool store = false;

--- a/sdk_v2/cpp/src/inferencing/generative/chat/search_options.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/search_options.cc
@@ -74,14 +74,14 @@ int ApplySearchOptions(const SearchOptions& options,
     gen_params.SetSearchOption("top_k", static_cast<double>(*options.top_k));
   }
 
-  // Frequency penalty → repetition_penalty in ORT GenAI
-  if (options.frequency_penalty.has_value()) {
-    gen_params.SetSearchOption("repetition_penalty", static_cast<double>(*options.frequency_penalty));
+  if (options.frequency_penalty.value_or(0.0f) != 0.0f) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+             "nonzero frequency_penalty is not supported; ORT repetition_penalty has different semantics");
   }
 
-  // Presence penalty → diversity_penalty in ORT GenAI
-  if (options.presence_penalty.has_value()) {
-    gen_params.SetSearchOption("diversity_penalty", static_cast<double>(*options.presence_penalty));
+  if (options.presence_penalty.value_or(0.0f) != 0.0f) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+             "nonzero presence_penalty is not supported; ORT diversity_penalty has different semantics");
   }
 
   // Random seed

--- a/sdk_v2/cpp/src/inferencing/generative/chat/search_options.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/search_options.h
@@ -24,8 +24,8 @@ struct SearchOptions {
   std::optional<float> top_p;
   std::optional<int> top_k;
   std::optional<int> max_output_tokens;
-  std::optional<float> frequency_penalty;
-  std::optional<float> presence_penalty;
+  std::optional<float> frequency_penalty;  // Currently only the neutral value 0 is supported.
+  std::optional<float> presence_penalty;   // Currently only the neutral value 0 is supported.
   std::optional<int> seed;
   std::optional<bool> do_sample;
   std::optional<bool> early_stopping;

--- a/sdk_v2/cpp/src/inferencing/generative/openresponses/response_converter.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/openresponses/response_converter.cc
@@ -418,14 +418,14 @@ Request ToSessionRequest(const ResponseCreateParams& params,
         std::to_string(*params.max_output_tokens);
   }
 
-  if (params.presence_penalty.has_value()) {
-    request.options["presence_penalty"] =
-        std::to_string(*params.presence_penalty);
+  if (params.presence_penalty.value_or(0.0f) != 0.0f) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+             "nonzero presence_penalty is not supported; ORT diversity_penalty has different semantics");
   }
 
-  if (params.frequency_penalty.has_value()) {
-    request.options["frequency_penalty"] =
-        std::to_string(*params.frequency_penalty);
+  if (params.frequency_penalty.value_or(0.0f) != 0.0f) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+             "nonzero frequency_penalty is not supported; ORT repetition_penalty has different semantics");
   }
 
   if (params.seed.has_value()) {

--- a/sdk_v2/cpp/src/service/chat_completions_handler.cc
+++ b/sdk_v2/cpp/src/service/chat_completions_handler.cc
@@ -56,6 +56,12 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> ChatCompletionsHandler::Pa
     return ErrorResponse(Status::CODE_400, "Missing required field: messages");
   }
 
+  if (req.frequency_penalty.value_or(0.0f) != 0.0f ||
+      req.presence_penalty.value_or(0.0f) != 0.0f) {
+    return ErrorResponse(Status::CODE_400, "Unsupported parameter",
+                         "nonzero frequency_penalty and presence_penalty are not supported");
+  }
+
   return nullptr;
 }
 

--- a/sdk_v2/cpp/src/service/responses_handler.cc
+++ b/sdk_v2/cpp/src/service/responses_handler.cc
@@ -76,6 +76,12 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> ResponsesHandler::ParseAnd
     return ErrorResponse(Status::CODE_400, "Invalid request parameters", ex.what());
   }
 
+  if (params.frequency_penalty.value_or(0.0f) != 0.0f ||
+      params.presence_penalty.value_or(0.0f) != 0.0f) {
+    return ErrorResponse(Status::CODE_400, "Unsupported parameter",
+                         "nonzero frequency_penalty and presence_penalty are not supported");
+  }
+
   return nullptr;
 }
 

--- a/sdk_v2/cpp/test/internal_api/chat/search_options_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat/search_options_test.cc
@@ -153,14 +153,38 @@ TEST_F(SearchOptionsTest, AllOptionsSetSimultaneously) {
   opts.top_p = 0.9f;
   opts.top_k = 50;
   opts.max_output_tokens = 256;
-  opts.frequency_penalty = 1.1f;
-  opts.presence_penalty = 0.5f;
   opts.seed = 42;
   opts.do_sample = true;
   auto params = MakeParams();
 
   int max_length = ApplySearchOptions(opts, 20, GetConfig(), *params, ExecutionProvider::kDefault);
   EXPECT_EQ(max_length, 276);  // 20 + 256
+}
+
+TEST_F(SearchOptionsTest, ZeroPenaltiesDoNotOverrideModelDefaults) {
+  SearchOptions opts;
+  opts.frequency_penalty = 0.0f;
+  opts.presence_penalty = 0.0f;
+  auto params = MakeParams();
+  const auto repetition_penalty = params->GetSearchNumber("repetition_penalty");
+  const auto diversity_penalty = params->GetSearchNumber("diversity_penalty");
+
+  ApplySearchOptions(opts, 10, GetConfig(), *params, ExecutionProvider::kDefault);
+
+  EXPECT_EQ(params->GetSearchNumber("repetition_penalty"), repetition_penalty);
+  EXPECT_EQ(params->GetSearchNumber("diversity_penalty"), diversity_penalty);
+}
+
+TEST_F(SearchOptionsTest, NonzeroPenaltiesAreRejected) {
+  for (const auto& [frequency, presence] :
+       {std::pair{0.5f, 0.0f}, std::pair{0.0f, 0.3f}, std::pair{-0.5f, 0.0f}, std::pair{0.0f, -0.3f}}) {
+    SearchOptions opts;
+    opts.frequency_penalty = frequency;
+    opts.presence_penalty = presence;
+    auto params = MakeParams();
+
+    EXPECT_THROW(ApplySearchOptions(opts, 10, GetConfig(), *params, ExecutionProvider::kDefault), fl::Exception);
+  }
 }
 
 TEST_F(SearchOptionsTest, ZeroMaxOutputTokensThrows) {

--- a/sdk_v2/cpp/test/internal_api/chat_completions_converter_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat_completions_converter_test.cc
@@ -69,11 +69,8 @@ TEST(ChatCompletionsConverterTest, ApplyCatalogDefaults_AppliesFloatsWhenNotSet)
   ASSERT_TRUE(req.top_p.has_value());
   EXPECT_FLOAT_EQ(*req.top_p, 0.9f);
 
-  ASSERT_TRUE(req.presence_penalty.has_value());
-  EXPECT_FLOAT_EQ(*req.presence_penalty, 0.1f);
-
-  ASSERT_TRUE(req.frequency_penalty.has_value());
-  EXPECT_FLOAT_EQ(*req.frequency_penalty, 0.2f);
+  EXPECT_FALSE(req.presence_penalty.has_value());
+  EXPECT_FALSE(req.frequency_penalty.has_value());
 }
 
 TEST(ChatCompletionsConverterTest, ApplyCatalogDefaults_DoesNotOverrideExisting) {
@@ -343,20 +340,40 @@ TEST(ChatCompletionsConverterTest, ExtractToolDefinitions_ToolChoiceObject_NoMat
 // MapRequestParameters
 // ========================================================================
 
-TEST(ChatCompletionsConverterTest, MapRequestParameters_AllFloatParams) {
+TEST(ChatCompletionsConverterTest, MapRequestParameters_TemperatureAndTopP) {
   ChatCompletionRequest req;
   req.temperature = 0.7f;
   req.top_p = 0.9f;
-  req.frequency_penalty = 0.5f;
-  req.presence_penalty = 0.3f;
 
   Request session_request;
   MapRequestParameters(req, session_request);
 
   EXPECT_NE(session_request.options.Find("temperature"), nullptr);
   EXPECT_NE(session_request.options.Find("top_p"), nullptr);
-  EXPECT_NE(session_request.options.Find("frequency_penalty"), nullptr);
-  EXPECT_NE(session_request.options.Find("presence_penalty"), nullptr);
+}
+
+TEST(ChatCompletionsConverterTest, MapRequestParameters_RejectsNonzeroPenalties) {
+  for (const auto& [frequency, presence] :
+       {std::pair{0.5f, 0.0f}, std::pair{0.0f, 0.3f}, std::pair{-0.5f, 0.0f}, std::pair{0.0f, -0.3f}}) {
+    ChatCompletionRequest req;
+    req.frequency_penalty = frequency;
+    req.presence_penalty = presence;
+
+    Request session_request;
+    EXPECT_THROW(MapRequestParameters(req, session_request), fl::Exception);
+  }
+}
+
+TEST(ChatCompletionsConverterTest, MapRequestParameters_ZeroPenaltiesAreNoOps) {
+  ChatCompletionRequest req;
+  req.frequency_penalty = 0.0f;
+  req.presence_penalty = 0.0f;
+
+  Request session_request;
+  MapRequestParameters(req, session_request);
+
+  EXPECT_EQ(session_request.options.Find("frequency_penalty"), nullptr);
+  EXPECT_EQ(session_request.options.Find("presence_penalty"), nullptr);
 }
 
 TEST(ChatCompletionsConverterTest, MapRequestParameters_Seed) {

--- a/sdk_v2/cpp/test/internal_api/response_converter_test.cc
+++ b/sdk_v2/cpp/test/internal_api/response_converter_test.cc
@@ -833,8 +833,6 @@ TEST(ResponseConverterTest, ToSessionRequest_AllRequestOptions_PropagatedToSessi
   params.temperature = 0.5f;
   params.top_p = 0.95f;
   params.max_output_tokens = 256;
-  params.presence_penalty = 0.25f;
-  params.frequency_penalty = 0.75f;
   params.seed = 42;
 
   ResponseTextConfig text_cfg;
@@ -857,12 +855,36 @@ TEST(ResponseConverterTest, ToSessionRequest_AllRequestOptions_PropagatedToSessi
   expect_opt("temperature", std::to_string(0.5f));
   expect_opt("top_p", std::to_string(0.95f));
   expect_opt("max_output_tokens", "256");
-  expect_opt("presence_penalty", std::to_string(0.25f));
-  expect_opt("frequency_penalty", std::to_string(0.75f));
   expect_opt("seed", "42");
   expect_opt("guidance_type", "json_schema");
   expect_opt("guidance_data", R"({"type":"object"})");
   expect_opt("tool_choice", "required");
 
   EXPECT_FALSE(tools_json.empty());
+}
+
+TEST(ResponseConverterTest, ToSessionRequest_RejectsNonzeroPenalties) {
+  for (const auto& [frequency, presence] :
+       {std::pair{0.75f, 0.0f}, std::pair{0.0f, 0.25f}, std::pair{-0.75f, 0.0f}, std::pair{0.0f, -0.25f}}) {
+    ResponseCreateParams params;
+    params.model = "test-model";
+    params.input = std::string("hello");
+    params.frequency_penalty = frequency;
+    params.presence_penalty = presence;
+
+    EXPECT_THROW(ToSessionRequest(params), fl::Exception);
+  }
+}
+
+TEST(ResponseConverterTest, ToSessionRequest_ZeroPenaltiesAreNoOps) {
+  ResponseCreateParams params;
+  params.model = "test-model";
+  params.input = std::string("hello");
+  params.presence_penalty = 0.0f;
+  params.frequency_penalty = 0.0f;
+
+  Request req = ToSessionRequest(params);
+
+  EXPECT_EQ(req.options.Find("presence_penalty"), nullptr);
+  EXPECT_EQ(req.options.Find("frequency_penalty"), nullptr);
 }

--- a/sdk_v2/cpp/test/sdk_api/chat_completions_test.cc
+++ b/sdk_v2/cpp/test/sdk_api/chat_completions_test.cc
@@ -235,6 +235,21 @@ TEST_F(WebServiceIntegrationTest, ChatCompletionsMissingMessages) {
   EXPECT_EQ(result->status, 400);
 }
 
+TEST_F(WebServiceIntegrationTest, ChatCompletionsRejectsNonzeroPenaltyBeforeInference) {
+  auto client = MakeClient();
+  json request_body = {
+      {"model", model_id()},
+      {"messages", json::array({{{"role", "user"}, {"content", "Hello"}}})},
+      {"frequency_penalty", 0.5},
+  };
+
+  auto result = client.Post("/v1/chat/completions", request_body.dump(), "application/json");
+
+  ASSERT_TRUE(result) << "HTTP request failed";
+  EXPECT_EQ(result->status, 400);
+  EXPECT_EQ(json::parse(result->body)["error"]["type"], "invalid_request_error");
+}
+
 TEST_F(WebServiceIntegrationTest, ChatCompletionsModelNotFound) {
   auto client = MakeClient();
   json request_body = {

--- a/sdk_v2/cpp/test/sdk_api/reasoning_model_test.cc
+++ b/sdk_v2/cpp/test/sdk_api/reasoning_model_test.cc
@@ -66,7 +66,6 @@ TEST_F(ReasoningFixture, SingleTurnStripsThinkBlock) {
   RequestOptions opts;
   opts.search.temperature = 0.0f;
   opts.search.max_output_tokens = 1024;
-  opts.search.frequency_penalty = 1.2f;
   request.SetOptions(opts);
 
   Response response = session.ProcessRequest(request);
@@ -188,7 +187,6 @@ TEST_F(ReasoningFixture, MultiTurnContinuousDecoding) {
   RequestOptions session_opts;
   session_opts.search.temperature = 0.0f;
   session_opts.search.max_output_tokens = 1024;
-  session_opts.search.frequency_penalty = 1.2f;
   session.SetOptions(session_opts);
 
   // Turn 1

--- a/sdk_v2/cpp/test/sdk_api/responses_test.cc
+++ b/sdk_v2/cpp/test/sdk_api/responses_test.cc
@@ -242,6 +242,21 @@ TEST_F(WebServiceIntegrationTest, ResponsesMissingInput) {
   EXPECT_EQ(result->status, 400);
 }
 
+TEST_F(WebServiceIntegrationTest, ResponsesRejectsNonzeroPenaltyBeforeInference) {
+  auto client = MakeClient();
+  json request_body = {
+      {"model", model_id()},
+      {"input", "Hello"},
+      {"presence_penalty", -0.3},
+  };
+
+  auto result = client.Post("/v1/responses", request_body.dump(), "application/json");
+
+  ASSERT_TRUE(result) << "HTTP request failed";
+  EXPECT_EQ(result->status, 400);
+  EXPECT_EQ(json::parse(result->body)["error"]["type"], "invalid_request_error");
+}
+
 TEST_F(WebServiceIntegrationTest, ResponsesModelNotFound) {
   auto client = MakeClient();
   json request_body = {

--- a/sdk_v2/cs/README.md
+++ b/sdk_v2/cs/README.md
@@ -233,7 +233,7 @@ Tune generation parameters per client:
 chatClient.Settings.Temperature = 0.7f;
 chatClient.Settings.MaxTokens = 256;
 chatClient.Settings.TopP = 0.9f;
-chatClient.Settings.FrequencyPenalty = 0.5f;
+chatClient.Settings.FrequencyPenalty = 0.0f; // Nonzero OpenAI penalties are not currently supported.
 ```
 
 ### Audio Transcription

--- a/sdk_v2/cs/src/RequestOptions.cs
+++ b/sdk_v2/cs/src/RequestOptions.cs
@@ -43,10 +43,10 @@ public sealed record SearchOptions
     /// <summary>Maximum tokens to generate.</summary>
     public int? MaxOutputTokens { get; init; }
 
-    /// <summary>Frequency penalty. Float [-2.0, 2.0].</summary>
+    /// <summary>Frequency penalty. Currently only the neutral value 0 is supported.</summary>
     public float? FrequencyPenalty { get; init; }
 
-    /// <summary>Presence penalty. Float [-2.0, 2.0].</summary>
+    /// <summary>Presence penalty. Currently only the neutral value 0 is supported.</summary>
     public float? PresencePenalty { get; init; }
 
     /// <summary>Random seed for reproducibility.</summary>

--- a/sdk_v2/cs/src/SessionParam.cs
+++ b/sdk_v2/cs/src/SessionParam.cs
@@ -26,10 +26,10 @@ internal static class SessionParam
     /// <summary>Maximum tokens to generate. Int.</summary>
     public const string MaxOutputTokens = "max_output_tokens";
 
-    /// <summary>Frequency penalty. Float [-2.0, 2.0].</summary>
+    /// <summary>Frequency penalty. Currently only the neutral value 0 is supported.</summary>
     public const string FrequencyPenalty = "frequency_penalty";
 
-    /// <summary>Presence penalty. Float [-2.0, 2.0].</summary>
+    /// <summary>Presence penalty. Currently only the neutral value 0 is supported.</summary>
     public const string PresencePenalty = "presence_penalty";
 
     /// <summary>Random seed for reproducible outputs. Int.</summary>

--- a/sdk_v2/python/README.md
+++ b/sdk_v2/python/README.md
@@ -380,7 +380,7 @@ Common session methods:
 | `Response` | Owns an `flResponse*`. Iterable over output items. Exposes `item_count`, `get_item(i)`, `finish_reason` (`FinishReason` enum), and `get_usage()` (`TokenUsage`). Read item data **inside** the response's `with` block — items returned by `get_item` borrow the response's handle. |
 | `FinishReason` | `NONE`, `ERROR`, `STOP`, `LENGTH`, `TOOL_CALLS`. |
 | `TokenUsage` | `prompt_tokens`, `completion_tokens`, `total_tokens`. |
-| `RequestOptions` | Typed inference options passed to `set_options`. Wraps `search: SearchOptions` (sampling params: `temperature`, `top_p`, `top_k`, `max_output_tokens`, `frequency_penalty`, `presence_penalty`, `seed`, `early_stopping`, `do_sample`), `tool_choice: ToolChoice | None` (`AUTO`/`NONE`/`REQUIRED`), and `additional_options: dict[str, str]` as the passthrough escape hatch. |
+| `RequestOptions` | Typed inference options passed to `set_options`. Wraps `search: SearchOptions` (sampling params: `temperature`, `top_p`, `top_k`, `max_output_tokens`, `frequency_penalty` and `presence_penalty`—currently zero only—`seed`, `early_stopping`, `do_sample`), `tool_choice: ToolChoice | None` (`AUTO`/`NONE`/`REQUIRED`), and `additional_options: dict[str, str]` as the passthrough escape hatch. |
 
 ### Items
 

--- a/sdk_v2/python/test/unit/test_chat_settings.py
+++ b/sdk_v2/python/test/unit/test_chat_settings.py
@@ -21,19 +21,19 @@ class TestSerialization:
 
     def test_top_level_fields_round_trip(self):
         s = ChatClientSettings(
-            frequency_penalty=0.1,
+            frequency_penalty=0.0,
             max_tokens=128,
             n=2,
             temperature=0.7,
-            presence_penalty=0.2,
+            presence_penalty=0.0,
             top_p=0.9,
         )
         d = s._serialize()
-        assert d["frequency_penalty"] == 0.1
+        assert d["frequency_penalty"] == 0.0
         assert d["max_tokens"] == 128
         assert d["n"] == 2
         assert d["temperature"] == 0.7
-        assert d["presence_penalty"] == 0.2
+        assert d["presence_penalty"] == 0.0
         assert d["top_p"] == 0.9
         assert "metadata" not in d
 

--- a/sdk_v2/python/test/unit/test_session_types.py
+++ b/sdk_v2/python/test/unit/test_session_types.py
@@ -76,8 +76,8 @@ class TestRequestOptions:
                 top_p=0.9,
                 top_k=40,
                 max_output_tokens=128,
-                frequency_penalty=-0.5,
-                presence_penalty=1.25,
+                frequency_penalty=0.0,
+                presence_penalty=0.0,
                 seed=42,
                 early_stopping=True,
                 do_sample=False,
@@ -88,8 +88,8 @@ class TestRequestOptions:
         assert native["top_p"] == "0.9"
         assert native["top_k"] == "40"
         assert native["max_output_tokens"] == "128"
-        assert native["frequency_penalty"] == "-0.5"
-        assert native["presence_penalty"] == "1.25"
+        assert native["frequency_penalty"] == "0.0"
+        assert native["presence_penalty"] == "0.0"
         assert native["seed"] == "42"
         # Bools must be lowercase to match the C++ "true"/"false" literal.
         assert native["early_stopping"] == "true"

--- a/sdk_v2/rust/README.md
+++ b/sdk_v2/rust/README.md
@@ -264,7 +264,7 @@ let client = model.create_chat_client()
     .temperature(0.7)
     .max_tokens(256)
     .top_p(0.9)
-    .frequency_penalty(0.5);
+    .frequency_penalty(0.0);
 
 // Non-streaming completion
 let response = client.complete_chat(
@@ -473,8 +473,8 @@ All settings are configured via chainable builder methods on `ChatClient`:
 | `max_tokens(v)` | `u32` | Maximum number of tokens to generate |
 | `top_p(v)` | `f64` | Nucleus sampling probability (0.0–1.0) |
 | `top_k(v)` | `u32` | Top-k sampling parameter (Foundry extension) |
-| `frequency_penalty(v)` | `f64` | Frequency penalty |
-| `presence_penalty(v)` | `f64` | Presence penalty |
+| `frequency_penalty(v)` | `f64` | OpenAI frequency penalty; currently only `0` is supported |
+| `presence_penalty(v)` | `f64` | OpenAI presence penalty; currently only `0` is supported |
 | `n(v)` | `u32` | Number of completions to generate |
 | `random_seed(v)` | `u64` | Random seed for reproducible results (Foundry extension) |
 | `response_format(v)` | `ChatResponseFormat` | Output format (Text, JsonObject, JsonSchema, LarkGrammar) |

--- a/sdk_v2/rust/docs/api.md
+++ b/sdk_v2/rust/docs/api.md
@@ -205,11 +205,11 @@ pub struct ChatClient { /* private fields */ }
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `frequency_penalty` | `fn frequency_penalty(mut self, v: f64) -> Self` | Set the frequency penalty. |
+| `frequency_penalty` | `fn frequency_penalty(mut self, v: f64) -> Self` | Set the OpenAI frequency penalty; currently only `0` is supported. |
 | `max_tokens` | `fn max_tokens(mut self, v: u32) -> Self` | Maximum tokens to generate. |
 | `n` | `fn n(mut self, v: u32) -> Self` | Number of completions. |
 | `temperature` | `fn temperature(mut self, v: f64) -> Self` | Sampling temperature. |
-| `presence_penalty` | `fn presence_penalty(mut self, v: f64) -> Self` | Presence penalty. |
+| `presence_penalty` | `fn presence_penalty(mut self, v: f64) -> Self` | Set the OpenAI presence penalty; currently only `0` is supported. |
 | `top_p` | `fn top_p(mut self, v: f64) -> Self` | Nucleus sampling probability. |
 | `top_k` | `fn top_k(mut self, v: u32) -> Self` | Top-k sampling *(Foundry extension)*. |
 | `random_seed` | `fn random_seed(mut self, v: u64) -> Self` | Random seed for reproducibility *(Foundry extension)*. |

--- a/sdk_v2/rust/src/openai/chat_client.rs
+++ b/sdk_v2/rust/src/openai/chat_client.rs
@@ -144,7 +144,7 @@ impl ChatClient {
         }
     }
 
-    /// Set the frequency penalty.
+    /// Set the frequency penalty. Currently only the neutral value `0` is supported.
     pub fn frequency_penalty(mut self, v: f64) -> Self {
         self.settings.frequency_penalty = Some(v);
         self
@@ -168,7 +168,7 @@ impl ChatClient {
         self
     }
 
-    /// Set the presence penalty.
+    /// Set the presence penalty. Currently only the neutral value `0` is supported.
     pub fn presence_penalty(mut self, v: f64) -> Self {
         self.settings.presence_penalty = Some(v);
         self

--- a/sdk_v2/rust/src/request.rs
+++ b/sdk_v2/rust/src/request.rs
@@ -50,9 +50,9 @@ pub struct SearchOptions {
     pub top_k: Option<i32>,
     /// Maximum number of tokens to generate.
     pub max_output_tokens: Option<i32>,
-    /// Frequency penalty in `[-2.0, 2.0]`.
+    /// Frequency penalty. Currently only the neutral value `0` is supported.
     pub frequency_penalty: Option<f32>,
-    /// Presence penalty in `[-2.0, 2.0]`.
+    /// Presence penalty. Currently only the neutral value `0` is supported.
     pub presence_penalty: Option<f32>,
     /// Random seed for reproducible sampling.
     pub seed: Option<i64>,


### PR DESCRIPTION
## Summary

Foundry Local currently maps OpenAI `frequency_penalty` and `presence_penalty` values to ONNX Runtime GenAI options with different meanings.

This can produce incorrect output. GitHub Copilot CLI also sends both fields with the neutral value `0`.

This change treats zero penalties as no-ops and rejects nonzero penalties before inference.

## Behavior

- `frequency_penalty: 0` is accepted and does not change model settings.
- `presence_penalty: 0` is accepted and does not change model settings.
- Nonzero penalty values return a client error.
- Foundry Local does not map frequency penalty to repetition penalty.
- Foundry Local does not map presence penalty to diversity penalty.
- Chat Completions and Responses use the same behavior.
- Direct SDK requests use the same behavior.

## Why

OpenAI frequency and presence penalties are additive token-frequency controls.

ONNX Runtime GenAI repetition and diversity penalties have different semantics.

Silently mapping between them is not correct. Rejecting unsupported values is safer and makes the limitation clear.

## Testing

- Added tests that zero penalties do not override model defaults.
- Added tests that positive and negative nonzero penalties are rejected.
- Added Chat Completions and Responses converter coverage.
- Added endpoint coverage that verifies rejection happens before inference.
- Updated Python serialization tests.
- Updated C, C++, Python, C#, and Rust documentation.
