### PR TITLE
Use model token IDs for guidance markers

### DIFF
--- a/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.cc
@@ -77,6 +77,16 @@ std::string GetOptionOrEmpty(const KeyValuePairs& options, const char* key) {
   return it != options.end() ? it->second : std::string{};
 }
 
+/// Use a model-published boundary ID only when its published text matches the configured marker.
+std::optional<int32_t> ResolveMarkerTokenId(const std::string& marker_text,
+                                            const PublishedMarker& published) {
+  if (!UsesPublishedToken(marker_text, published) || *published.id < 0) {
+    return std::nullopt;
+  }
+
+  return published.id;
+}
+
 /// Build the assistant transcript message for a completed generation. The generation events are already in the order
 /// the model produced them, so the transcript keeps visible text, reasoning, and calls interleaved exactly as emitted.
 ///
@@ -323,6 +333,15 @@ ToolCallContext ChatSession::BuildToolCallContext(const Request& request) const 
     tool_ctx.tool_call_end = tag_info.eot_str;
   }
 
+  // Resolve each boundary independently. A matching model-published ID uses llguidance's exact numeric token syntax;
+  // an override or a boundary without an authoritative ID is rendered as a quoted literal.
+  if (tool_ctx.HasToolCallTokens()) {
+    tool_ctx.tool_call_start_token_id =
+        ResolveMarkerTokenId(tool_ctx.tool_call_start, {tag_info.bot_id, tag_info.bot_str});
+    tool_ctx.tool_call_end_token_id =
+        ResolveMarkerTokenId(tool_ctx.tool_call_end, {tag_info.eot_id, tag_info.eot_str});
+  }
+
   // Check if the model supports chain-of-thought reasoning
   const auto* reasoning_val = info.GetPropertyInt(FOUNDRY_LOCAL_MODEL_PROP_SUPPORTS_REASONING_INT);
   if (reasoning_val && *reasoning_val == 1) {
@@ -351,6 +370,14 @@ ToolCallContext ChatSession::BuildToolCallContext(const Request& request) const 
   }
   if (tool_ctx.reasoning_end.empty()) {
     tool_ctx.reasoning_end = tag_info.eor_str;
+  }
+
+  // Resolve reasoning boundaries independently from tool-call boundaries.
+  if (tool_ctx.HasReasoningTokens()) {
+    tool_ctx.reasoning_start_token_id =
+        ResolveMarkerTokenId(tool_ctx.reasoning_start, {tag_info.bor_id, tag_info.bor_str});
+    tool_ctx.reasoning_end_token_id =
+        ResolveMarkerTokenId(tool_ctx.reasoning_end, {tag_info.eor_id, tag_info.eor_str});
   }
 
   // Accumulate tool definitions from the session.
@@ -796,7 +823,8 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
   //
   // A turn stopped at a tool call because the model kept talking afterwards is truncated mid-sequence with no turn
   // terminator, so its KV cache is no basis for the next turn either.
-  const bool grammar_was_active = ResolveTurnGuidanceOptions(cached_tool_ctx_).has_value();
+  const bool grammar_was_active =
+      ResolveTurnGuidanceOptions(cached_tool_ctx_, cached_generator_->PromptOpensReasoning()).has_value();
   const bool reasoning_was_active = cached_tool_ctx_.supports_reasoning;
   const bool discard_after_success =
       chat_session_internal::ShouldInvalidateRetainedGenerationStateAfterSuccessfulTurn(

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_engine.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_engine.cc
@@ -57,7 +57,17 @@ void ApplyEngineTurnOptions(const EngineTurnOptionsPlan& plan, OgaTurnOptions& o
   }
 
   if (plan.guidance.has_value()) {
-    options.SetGuidance(plan.guidance->type.c_str(), plan.guidance->data.c_str());
+    try {
+      options.SetGuidance(plan.guidance->type.c_str(), plan.guidance->data.c_str());
+    } catch (const std::runtime_error& e) {
+      if (plan.guidance->user_specified) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+                 "failed to apply requested response guidance: " + std::string(e.what()));
+      }
+
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL,
+               "failed to apply required tool-call guidance: " + std::string(e.what()));
+    }
   }
 }
 
@@ -125,7 +135,8 @@ std::shared_ptr<OnnxChatEngine::Conversation> OnnxChatEngine::CreateConversation
 uint64_t OnnxChatEngine::BeginTurn(const std::shared_ptr<Conversation>& conversation,
                                    std::span<const int32_t> input_ids,
                                    const SearchOptions& options,
-                                   const ToolCallContext& tool_ctx) {
+                                   const ToolCallContext& tool_ctx,
+                                   bool prompt_opens_reasoning) {
   if (input_ids.empty()) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "Engine turn input must not be empty");
   }
@@ -135,7 +146,7 @@ uint64_t OnnxChatEngine::BeginTurn(const std::shared_ptr<Conversation>& conversa
   auto ready = completion->get_future();
 
   Enqueue(
-      [this, conversation, tokens = std::move(tokens), options, tool_ctx, completion]() {
+      [this, conversation, tokens = std::move(tokens), options, tool_ctx, prompt_opens_reasoning, completion]() {
         auto& native = FindNative(conversation);
         auto turn_options = native.request->CreateTurnOptions();
         size_t existing_tokens = 0;
@@ -156,7 +167,8 @@ uint64_t OnnxChatEngine::BeginTurn(const std::shared_ptr<Conversation>& conversa
           conversation->turn_has_progress = false;
         }
 
-        auto plan = BuildEngineTurnOptionsPlan(options, tool_ctx, model_.GetGenAIConfig().GetChatBackendKind());
+        auto plan = BuildEngineTurnOptionsPlan(options, tool_ctx, model_.GetGenAIConfig().GetChatBackendKind(),
+                                               prompt_opens_reasoning);
         if (plan.max_generated_tokens.has_value()) {
           // Validate only the limit the caller requested. When it is absent, leave the turn uncapped and let OGA
           // enforce the Request's model-context session limit.

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_engine.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_engine.h
@@ -85,7 +85,8 @@ class OnnxChatEngine {
   uint64_t BeginTurn(const std::shared_ptr<Conversation>& conversation,
                      std::span<const int32_t> input_ids,
                      const SearchOptions& options,
-                     const ToolCallContext& tool_ctx);
+                     const ToolCallContext& tool_ctx,
+                     bool prompt_opens_reasoning);
   std::optional<int32_t> WaitForToken(const std::shared_ptr<Conversation>& conversation);
   bool IsTurnFinished(const std::shared_ptr<Conversation>& conversation) const;
   TurnResult GetTurnResult(const std::shared_ptr<Conversation>& conversation) const;

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
@@ -30,30 +30,6 @@ bool DetectPromptOpensReasoning(const std::string& prompt,
   return PromptOpensReasoning(prompt_token_ids, markers, prompt);
 }
 
-/// Token IDs `text` encodes to with the model's own tokenizer, or an empty sequence when it cannot be encoded.
-///
-/// Encoding is best-effort by design: a marker the tokenizer cannot represent leaves the splitter matching decoded
-/// text, which is what a model that publishes no marker IDs already does. Failing the turn instead would break
-/// reasoning models over a detail that has a working fallback.
-std::vector<int32_t> EncodeMarker(const std::string& text, GenAIModelInstance& model) {
-  try {
-    auto sequences = model.GetPreprocessor().Encode(text.c_str());
-    if (!sequences || sequences->Count() == 0) {
-      return {};
-    }
-
-    const auto* data = sequences->SequenceData(0);
-    const auto count = sequences->SequenceCount(0);
-    if (data == nullptr || count == 0) {
-      return {};
-    }
-
-    return {data, data + count};
-  } catch (...) {
-    return {};
-  }
-}
-
 }  // namespace
 
 ReasoningMarkers ResolveReasoningMarkers(const ToolCallContext& tool_ctx, GenAIModelInstance& model) {
@@ -66,7 +42,7 @@ ReasoningMarkers ResolveReasoningMarkers(const ToolCallContext& tool_ctx, GenAIM
   // A request may override the marker strings. The published IDs describe the model's own markers, so they are
   // reused only when they decode to exactly the marker in effect; anything else is encoded with the model's
   // tokenizer, which also covers overrides that are several tokens long.
-  auto encode = [&model](const std::string& text) { return EncodeMarker(text, model); };
+  auto encode = [&model](const std::string& text) { return model.EncodeText(text); };
   const PublishedMarker published_start{tag_info.bor_id, tag_info.bor_str};
   markers.start_token_is_published = UsesPublishedToken(markers.start, published_start);
   markers.start_token_ids = ResolveMarkerTokenIds(markers.start, published_start, encode);
@@ -439,8 +415,10 @@ std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateImpl(const std::stri
   ApplySearchOptions(options, input_token_count, model.GetGenAIConfig(), *gen_params, model.EP(),
                      use_full_context, GetDefaultMaxOutputTokens(media_branch));
 
-  // 4. Apply constrained decoding for tool-only output or an explicit response format.
-  ApplyGuidanceOptions(tool_ctx, *gen_params);
+  // 4. Build guidance from the actual rendered prompt state, then reuse that state to seed stream reasoning.
+  auto reasoning_markers = ResolveReasoningMarkers(tool_ctx, model);
+  const bool prompt_opens_reasoning = DetectPromptOpensReasoning(prompt, sequences.get(), reasoning_markers);
+  ApplyGuidanceOptions(tool_ctx, prompt_opens_reasoning, *gen_params);
 
   // 5. Create the Generator and feed it the prompt.
   //    Text path: append the encoded token sequences.
@@ -462,10 +440,6 @@ std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateImpl(const std::stri
 
   // 6. Create tokenizer stream (single-decode path).
   auto stream = model.GetPreprocessor().CreateTokenizerStream();
-
-  // 7. Probe the prompt for a template-opened reasoning block so the caller's splitter starts in the right state.
-  auto reasoning_markers = ResolveReasoningMarkers(tool_ctx, model);
-  const bool prompt_opens_reasoning = DetectPromptOpensReasoning(prompt, sequences.get(), reasoning_markers);
 
   // `std::make_unique` constructs inside the library helper, which does not have
   // access to this class's private constructor.

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_engine_chat_stream.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_engine_chat_stream.cc
@@ -144,6 +144,7 @@ int OnnxEngineChatStream::AppendMessages(const std::vector<TranscriptMessage>& n
   const std::span<const int32_t> full_prompt(data, static_cast<size_t>(count));
   const auto resident_tokens = engine_.ResidentTokens(conversation_);
   const auto suffix_start = chat_internal::FindUnmatchedPromptSuffix(resident_tokens, full_prompt);
+  const bool prompt_opens_reasoning = DetectPromptOpensReasoning(prompt, *sequences, tool_ctx, model);
 
   // Keep the previous decoder intact if admission fails. Once admitted, start a fresh stream so partial UTF-8/BPE
   // state from the prior turn cannot affect generated tokens; prompt tokens are never decoded.
@@ -155,12 +156,12 @@ int OnnxEngineChatStream::AppendMessages(const std::vector<TranscriptMessage>& n
                "chat template produced no new tokens for a non-empty Engine continuation");
     }
 
-    engine_.BeginTurn(conversation_, suffix, options, tool_ctx);
+    engine_.BeginTurn(conversation_, suffix, options, tool_ctx, prompt_opens_reasoning);
     submitted_tokens = static_cast<int>(suffix.size());
   } else {
     auto replacement = engine_.CreateConversation(options, tool_ctx, count);
     try {
-      engine_.BeginTurn(replacement, full_prompt, options, tool_ctx);
+      engine_.BeginTurn(replacement, full_prompt, options, tool_ctx, prompt_opens_reasoning);
     } catch (...) {
       engine_.Close(replacement);
       throw;
@@ -175,7 +176,7 @@ int OnnxEngineChatStream::AppendMessages(const std::vector<TranscriptMessage>& n
   // Public chat usage describes the complete logical prompt, not only the suffix admitted to a resident Engine
   // request. The suffix remains an internal KV-reuse optimization.
   prompt_token_count_ = count;
-  prompt_opens_reasoning_ = DetectPromptOpensReasoning(prompt, *sequences, tool_ctx, model);
+  prompt_opens_reasoning_ = prompt_opens_reasoning;
   cancelled_ = false;
   return submitted_tokens;
 }
@@ -213,17 +214,18 @@ std::unique_ptr<OnnxEngineChatStream> OnnxEngineChatStream::Create(
   auto prompt = BuildChatPrompt(messages, model, tool_ctx.tools_json);
   auto sequences = EncodePrompt(prompt, model);
   const int prompt_token_count = static_cast<int>(sequences->SequenceCount(0));
+  const bool prompt_opens_reasoning = DetectPromptOpensReasoning(prompt, *sequences, tool_ctx, model);
   auto stream = model.GetPreprocessor().CreateTokenizerStream();
   auto conversation = engine->CreateConversation(options, tool_ctx, prompt_token_count);
   try {
     const auto* data = sequences->SequenceData(0);
     engine->BeginTurn(conversation, std::span<const int32_t>(data, static_cast<size_t>(prompt_token_count)), options,
-                      tool_ctx);
+                      tool_ctx, prompt_opens_reasoning);
 
     auto result = std::unique_ptr<OnnxEngineChatStream>(
         new OnnxEngineChatStream(*engine, std::move(conversation), std::move(stream), model,
                                  prompt_token_count));
-    result->prompt_opens_reasoning_ = DetectPromptOpensReasoning(prompt, *sequences, tool_ctx, model);
+    result->prompt_opens_reasoning_ = prompt_opens_reasoning;
     return result;
   } catch (...) {
     try {

--- a/sdk_v2/cpp/src/inferencing/generative/chat/search_options.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/search_options.cc
@@ -70,7 +70,8 @@ int GetModelMaxContextLength(const GenAIConfig& config) {
   return model_max_length;
 }
 
-std::optional<TurnGuidanceOptions> ResolveTurnGuidanceOptions(const ToolCallContext& tool_ctx) {
+std::optional<TurnGuidanceOptions> ResolveTurnGuidanceOptions(const ToolCallContext& tool_ctx,
+                                                              bool prompt_opens_reasoning) {
   std::string guidance_type;
   std::string guidance_data;
   const bool user_specified_guidance =
@@ -85,7 +86,7 @@ std::optional<TurnGuidanceOptions> ResolveTurnGuidanceOptions(const ToolCallCont
       json_schema = BuildToolJsonSchema(tool_ctx);
     }
 
-    guidance_data = BuildLarkGrammar(tool_ctx, json_schema);
+    guidance_data = BuildLarkGrammar(tool_ctx, json_schema, prompt_opens_reasoning);
     if (!guidance_data.empty()) {
       guidance_type = "lark_grammar";
     }
@@ -94,7 +95,11 @@ std::optional<TurnGuidanceOptions> ResolveTurnGuidanceOptions(const ToolCallCont
   const bool tool_call_only = tool_ctx.tool_output && !tool_ctx.text_output;
   if (!guidance_type.empty() && !guidance_data.empty() &&
       (user_specified_guidance || tool_call_only)) {
-    return TurnGuidanceOptions{std::move(guidance_type), std::move(guidance_data)};
+    return TurnGuidanceOptions{
+        std::move(guidance_type),
+        std::move(guidance_data),
+        user_specified_guidance,
+    };
   }
 
   return std::nullopt;
@@ -157,7 +162,8 @@ bool SupportsPerTurnSeed(ChatBackendKind backend_kind) {
 
 EngineTurnOptionsPlan BuildEngineTurnOptionsPlan(const SearchOptions& options,
                                                  const ToolCallContext& tool_ctx,
-                                                 ChatBackendKind backend_kind) {
+                                                 ChatBackendKind backend_kind,
+                                                 bool prompt_opens_reasoning) {
   ValidatePenalties(options);
   if (options.early_stopping.value_or(false)) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
@@ -182,23 +188,24 @@ EngineTurnOptionsPlan BuildEngineTurnOptionsPlan(const SearchOptions& options,
     plan.stop_sequences = options.stop_sequences;
   }
 
-  plan.guidance = ResolveTurnGuidanceOptions(tool_ctx);
+  plan.guidance = ResolveTurnGuidanceOptions(tool_ctx, prompt_opens_reasoning);
   return plan;
 }
 
-void ApplyGuidanceOptions(const ToolCallContext& tool_ctx, OgaGeneratorParams& gen_params) {
-  if (const auto guidance = ResolveTurnGuidanceOptions(tool_ctx)) {
-    const bool user_specified_guidance =
-        !tool_ctx.guidance_type.empty() && !tool_ctx.guidance_data.empty();
+void ApplyGuidanceOptions(const ToolCallContext& tool_ctx,
+                          bool prompt_opens_reasoning,
+                          OgaGeneratorParams& gen_params) {
+  if (const auto guidance = ResolveTurnGuidanceOptions(tool_ctx, prompt_opens_reasoning)) {
     try {
       gen_params.SetGuidance(guidance->type.c_str(), guidance->data.c_str());
     } catch (const std::runtime_error& e) {
-      if (user_specified_guidance) {
+      if (guidance->user_specified) {
         FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
                  "failed to apply requested response guidance: " + std::string(e.what()));
       }
 
-      // Auto-generated tool grammar remains best-effort for models that do not implement guidance.
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL,
+               "failed to apply required tool-call guidance: " + std::string(e.what()));
     }
   }
 }

--- a/sdk_v2/cpp/src/inferencing/generative/chat/search_options.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/search_options.h
@@ -23,6 +23,7 @@ struct ToolCallContext;
 struct TurnGuidanceOptions {
   std::string type;
   std::string data;
+  bool user_specified = false;
 };
 
 /// Caller-expressed sampling settings, normalized to a combination ORT GenAI accepts.
@@ -106,7 +107,8 @@ int ResolveMaxOutputTokens(const SearchOptions& options,
 int GetModelMaxContextLength(const GenAIConfig& config);
 
 /// Resolve the guidance configuration that should apply to a single tool-only turn.
-std::optional<TurnGuidanceOptions> ResolveTurnGuidanceOptions(const ToolCallContext& tool_ctx);
+std::optional<TurnGuidanceOptions> ResolveTurnGuidanceOptions(const ToolCallContext& tool_ctx,
+                                                              bool prompt_opens_reasoning);
 
 /// Normalize caller-expressed sampling settings for one turn. See SamplingPlan.
 /// Throws fl::Exception when a value is outside the range ORT GenAI accepts for any turn.
@@ -122,7 +124,8 @@ bool SupportsPerTurnSeed(ChatBackendKind backend_kind);
 /// Throws fl::Exception when the request asks for something this backend cannot honor per turn.
 EngineTurnOptionsPlan BuildEngineTurnOptionsPlan(const SearchOptions& options,
                                                  const ToolCallContext& tool_ctx,
-                                                 ChatBackendKind backend_kind);
+                                                 ChatBackendKind backend_kind,
+                                                 bool prompt_opens_reasoning);
 
 /// Apply search options to OgaGeneratorParams.
 /// Validates token budget (input + output vs model max_length from config).
@@ -151,6 +154,8 @@ int ApplySearchOptions(const SearchOptions& options,
                        int default_max_output_tokens = kDefaultChatTextMaxOutputTokens);
 
 /// Applies request-level grammar guidance to generator parameters when the tool context requires tool-only output.
-void ApplyGuidanceOptions(const ToolCallContext& tool_ctx, OgaGeneratorParams& gen_params);
+void ApplyGuidanceOptions(const ToolCallContext& tool_ctx,
+                          bool prompt_opens_reasoning,
+                          OgaGeneratorParams& gen_params);
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/genai_model_instance.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/genai_model_instance.cc
@@ -169,4 +169,23 @@ const GenAIModelInstance::TagInfo& GenAIModelInstance::GetTagInfo() {
   return tag_info_;
 }
 
+std::vector<int32_t> GenAIModelInstance::EncodeText(const std::string& text) {
+  try {
+    auto sequences = GetPreprocessor().Encode(text.c_str());
+    if (!sequences || sequences->Count() == 0) {
+      return {};
+    }
+
+    const auto* data = sequences->SequenceData(0);
+    const auto count = sequences->SequenceCount(0);
+    if (data == nullptr || count == 0) {
+      return {};
+    }
+
+    return {data, data + count};
+  } catch (...) {
+    return {};
+  }
+}
+
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/genai_model_instance.h
+++ b/sdk_v2/cpp/src/inferencing/generative/genai_model_instance.h
@@ -9,10 +9,12 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <vector>
 
 // Forward declarations for ORT GenAI types (defined in ort_genai.h)
 struct OgaModel;
@@ -51,6 +53,11 @@ class GenAIModelInstance {
     std::string eor_str;
   };
   const TagInfo& GetTagInfo();
+
+  /// Token IDs `text` encodes to with this model's tokenizer, or an empty sequence when it cannot be encoded.
+  /// Encoding is best-effort by design: a marker the tokenizer cannot represent leaves callers matching decoded
+  /// text instead of token IDs, which is the same fallback a model that publishes no marker IDs already uses.
+  std::vector<int32_t> EncodeText(const std::string& text);
 
   /// Access the underlying OGA objects.
   OgaModel& GetOgaModel();

--- a/sdk_v2/cpp/src/inferencing/generative/toolcalling/grammar.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/toolcalling/grammar.cc
@@ -55,7 +55,7 @@ std::string EscapeLarkLiteral(const std::string& text) {
 }
 
 std::string RenderLarkMarker(const std::string& marker_text, std::optional<int32_t> token_id) {
-  if (token_id.has_value()) {
+  if (token_id.has_value() && *token_id >= 0) {
     return "<[" + std::to_string(*token_id) + "]>";
   }
 

--- a/sdk_v2/cpp/src/inferencing/generative/toolcalling/grammar.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/toolcalling/grammar.cc
@@ -9,6 +9,59 @@
 
 namespace fl {
 
+std::string EscapeLarkLiteral(const std::string& text) {
+  std::string out;
+  out.reserve(text.size() + 2);
+  out.push_back('"');
+
+  for (const char c : text) {
+    switch (c) {
+      case '\\':
+        out += "\\\\";
+        break;
+      case '"':
+        out += "\\\"";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      case '\b':
+        out += "\\b";
+        break;
+      case '\f':
+        out += "\\f";
+        break;
+      default:
+        if (const auto byte = static_cast<unsigned char>(c); byte < 0x20) {
+          static constexpr char kHex[] = "0123456789abcdef";
+          out += "\\u00";
+          out.push_back(kHex[byte >> 4]);
+          out.push_back(kHex[byte & 0x0f]);
+        } else {
+          out.push_back(c);
+        }
+        break;
+    }
+  }
+
+  out.push_back('"');
+  return out;
+}
+
+std::string RenderLarkMarker(const std::string& marker_text, std::optional<int32_t> token_id) {
+  if (token_id.has_value()) {
+    return "<[" + std::to_string(*token_id) + "]>";
+  }
+
+  return EscapeLarkLiteral(marker_text);
+}
+
 std::string BuildToolJsonSchema(const ToolCallContext& ctx) {
   // Create a JSON schema from tools for use with ORT GenAI's SetGuidance.
   //
@@ -184,14 +237,15 @@ std::string BuildToolJsonSchema(const ToolCallContext& ctx) {
 }
 
 std::string BuildLarkGrammar(const ToolCallContext& ctx,
-                             const std::string& json_schema) {
+                             const std::string& json_schema,
+                             bool prompt_opens_reasoning) {
   // Legend:
   //
   // 1. cot = chain-of-thought output with newline at the end
   // 2. THINK_TEXT = chain-of-thought text output
   // 3. output = output row (text and/or tool call)
   // 4. TEXT = text output
-  // 5. toolcall = tool call output (with known ids)
+  // 5. toolcall = tool call output (with configured boundary markers)
   // 6. functioncall = JSON schemas for each registered tool
   //
   // Cases:
@@ -199,20 +253,20 @@ std::string BuildLarkGrammar(const ToolCallContext& ctx,
   // | Case | Description                                                                                        |
   // |------|----------------------------------------------------------------------------------------------------|
   // |  1   | Return text only                                                                                   |
-  // |  2   | Return tool call only (known tool call token ids)                                                  |
-  // |  3   | Return tool call only (unknown tool call token ids)                                                |
-  // |  4   | Return text or tool call (known tool call token ids)                                               |
-  // |  5   | Return text or tool call (unknown tool call token ids)                                             |
-  // |  6   | Return chain-of-thought + text only (known think token ids)                                        |
-  // |  7   | Return chain-of-thought + text only (unknown think token ids)                                      |
-  // |  8   | Return chain-of-thought + tool call only (known think token ids, known tool call token ids)        |
-  // |  9   | Return chain-of-thought + tool call only (unknown think token ids, known tool call token ids)      |
-  // |  10  | Return chain-of-thought + tool call only (known think token ids, unknown tool call token ids)      |
-  // |  11  | Return chain-of-thought + tool call only (unknown think token ids, unknown tool call token ids)    |
-  // |  12  | Return chain-of-thought + text or tool call (known think token ids, known tool call token ids)     |
-  // |  13  | Return chain-of-thought + text or tool call (unknown think token ids, known tool call token ids)   |
-  // |  14  | Return chain-of-thought + text or tool call (known think token ids, unknown tool call token ids)   |
-  // |  15  | Return chain-of-thought + text or tool call (unknown think token ids, unknown tool call token ids) |
+  // |  2   | Return tool call only (configured tool-call markers)                                               |
+  // |  3   | Return tool call only (no configured tool-call markers)                                            |
+  // |  4   | Return text or tool call (configured tool-call markers)                                            |
+  // |  5   | Return text or tool call (no configured tool-call markers)                                         |
+  // |  6   | Return chain-of-thought + text only (configured reasoning markers)                                 |
+  // |  7   | Return chain-of-thought + text only (no configured reasoning markers)                              |
+  // |  8   | Return chain-of-thought + tool call only (both marker pairs configured)                            |
+  // |  9   | Return chain-of-thought + tool call only (only tool-call markers configured)                       |
+  // |  10  | Return chain-of-thought + tool call only (only reasoning markers configured)                       |
+  // |  11  | Return chain-of-thought + tool call only (no marker pairs configured)                              |
+  // |  12  | Return chain-of-thought + text or tool call (both marker pairs configured)                         |
+  // |  13  | Return chain-of-thought + text or tool call (only tool-call markers configured)                    |
+  // |  14  | Return chain-of-thought + text or tool call (only reasoning markers configured)                    |
+  // |  15  | Return chain-of-thought + text or tool call (no marker pairs configured)                           |
   //
   // Grammar patterns for each case:
   //
@@ -221,104 +275,104 @@ std::string BuildLarkGrammar(const ToolCallContext& ctx,
   // start: TEXT
   // TEXT: /[^{<](.|\\n)*/
   //
-  // 2. Return tool call only (known tool call token ids)
+  // 2. Return tool call only (configured tool-call markers)
   //
   // start: toolcall
-  // toolcall: <starting tool call token id> functioncall <ending tool call token id>
+  // toolcall: <[123]> functioncall <[124]>
   // functioncall: %json { <schemas for each tool> }
   //
-  // 3. Return tool call only (unknown tool call token ids)
+  // 3. Return tool call only (no configured tool-call markers)
   //
   // start: functioncall
   // functioncall: %json { <schemas for each tool> }
   //
-  // 4. Return text or tool call (known tool call token ids)
+  // 4. Return text or tool call (configured tool-call markers)
   //
   // start: TEXT | toolcall
   // TEXT: /[^{<](.|\\n)*/
-  // toolcall: <starting tool call token id> functioncall <ending tool call token id>
+  // toolcall: "<tool_call>" functioncall "</tool_call>"
   // functioncall: %json { <schemas for each tool> }
   //
-  // 5. Return text or tool call (unknown tool call token ids)
+  // 5. Return text or tool call (no configured tool-call markers)
   //
   // start: TEXT | functioncall
   // TEXT: /[^{<](.|\\n)*/
   // functioncall: %json { <schemas for each tool> }
   //
-  // 6. Return chain-of-thought + text only (known think token ids)
+  // 6. Return chain-of-thought + text only (configured reasoning markers)
   //
   // start: cot TEXT
-  // cot: <starting think token id> THINK_TEXT <ending think token id> "\\n"
+  // cot: <[125]> THINK_TEXT <[126]> "\\n"
   // THINK_TEXT: /[^<]+/
   // TEXT: /[^{<](.|\\n)*/
   //
-  // 7. Return chain-of-thought + text only (unknown think token ids)
+  // 7. Return chain-of-thought + text only (no configured reasoning markers)
   //
   // start: cot TEXT
   // cot: "<think>" THINK_TEXT "</think>" "\\n"
   // THINK_TEXT: /[^<]+/
   // TEXT: /[^{<](.|\\n)*/
   //
-  // 8. Return chain-of-thought + tool call only (known think token ids, known tool call token ids)
+  // 8. Return chain-of-thought + tool call only (both marker pairs configured)
   //
   // start: cot toolcall
-  // cot: <starting think token id> THINK_TEXT <ending think token id> "\\n"
+  // cot: <[125]> THINK_TEXT <[126]> "\\n"
   // THINK_TEXT: /[^<]+/
-  // toolcall: <starting tool call token id> functioncall <ending tool call token id>
+  // toolcall: <[123]> functioncall <[124]>
   // functioncall: %json { <schemas for each tool> }
   //
-  // 9. Return chain-of-thought + tool call only (unknown think token ids, known tool call token ids)
+  // 9. Return chain-of-thought + tool call only (only tool-call markers configured)
   //
   // start: cot toolcall
   // cot: "<think>" THINK_TEXT "</think>" "\\n"
   // THINK_TEXT: /[^<]+/
-  // toolcall: <starting tool call token id> functioncall <ending tool call token id>
+  // toolcall: "<tool_call>" functioncall "</tool_call>"
   // functioncall: %json { <schemas for each tool> }
   //
-  // 10. Return chain-of-thought + tool call only (known think token ids, unknown tool call token ids)
+  // 10. Return chain-of-thought + tool call only (only reasoning markers configured)
   //
   // start: cot functioncall
-  // cot: <starting think token id> THINK_TEXT <ending think token id> "\\n"
+  // cot: <[125]> THINK_TEXT <[126]> "\\n"
   // THINK_TEXT: /[^<]+/
   // functioncall: %json { <schemas for each tool> }
   //
-  // 11. Return chain-of-thought + tool call only (unknown think token ids, unknown tool call token ids)
+  // 11. Return chain-of-thought + tool call only (no marker pairs configured)
   //
   // start: cot functioncall
   // cot: "<think>" THINK_TEXT "</think>" "\\n"
   // THINK_TEXT: /[^<]+/
   // functioncall: %json { <schemas for each tool> }
   //
-  // 12. Return chain-of-thought + text or tool call (known think token ids, known tool call token ids)
+  // 12. Return chain-of-thought + text or tool call (both marker pairs configured)
   //
   // start: cot output
-  // cot: <starting think token id> THINK_TEXT <ending think token id> "\\n"
+  // cot: <[125]> THINK_TEXT <[126]> "\\n"
   // THINK_TEXT: /[^<]+/
   // output: TEXT | toolcall
   // TEXT: /[^{<](.|\\n)*/
-  // toolcall: <starting tool call token id> functioncall <ending tool call token id>
+  // toolcall: <[123]> functioncall <[124]>
   // functioncall: %json { <schemas for each tool> }
   //
-  // 13. Return chain-of-thought + text or tool call (unknown think token ids, known tool call token ids)
+  // 13. Return chain-of-thought + text or tool call (only tool-call markers configured)
   //
   // start: cot output
   // cot: "<think>" THINK_TEXT "</think>" "\\n"
   // THINK_TEXT: /[^<]+/
   // output: TEXT | toolcall
   // TEXT: /[^{<](.|\\n)*/
-  // toolcall: <starting tool call token id> functioncall <ending tool call token id>
+  // toolcall: "<tool_call>" functioncall "</tool_call>"
   // functioncall: %json { <schemas for each tool> }
   //
-  // 14. Return chain-of-thought + text or tool call (known think token ids, unknown tool call token ids)
+  // 14. Return chain-of-thought + text or tool call (only reasoning markers configured)
   //
   // start: cot output
-  // cot: <starting think token id> THINK_TEXT <ending think token id> "\\n"
+  // cot: <[125]> THINK_TEXT <[126]> "\\n"
   // THINK_TEXT: /[^<]+/
   // output: TEXT | functioncall
   // TEXT: /[^{<](.|\\n)*/
   // functioncall: %json { <schemas for each tool> }
   //
-  // 15. Return chain-of-thought + text or tool call (unknown think token ids, unknown tool call token ids)
+  // 15. Return chain-of-thought + text or tool call (no marker pairs configured)
   //
   // start: cot output
   // cot: "<think>" THINK_TEXT "</think>" "\\n"
@@ -332,6 +386,10 @@ std::string BuildLarkGrammar(const ToolCallContext& ctx,
   // (e.g. is less than). While the rule does not permit empty thinking, that is a rare occurrence.
   // There is usually some reasoning done even if it is little. Without such a restrictive grammar, models
   // such as Phi-4 mini reasoning fall out of distribution.
+  //
+  // Marker IDs use llguidance's exact numeric-token syntax (`<[ID]>`). A marker without one authoritative token
+  // ID uses quoted literal bytes, which may tokenize to multiple IDs. Named `<token_name>` syntax is only for
+  // tokenizer special tokens and is not inferred from marker text.
   if (!ctx.text_output && !ctx.tool_output) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE,
              "neither text output nor tool calling output are enabled — "
@@ -342,9 +400,11 @@ std::string BuildLarkGrammar(const ToolCallContext& ctx,
   bool known_think_tokens = ctx.HasReasoningTokens();
   bool reasoning_enabled = ctx.supports_reasoning;
 
-  // For unknown think tokens, use literal Lark grammar string tokens
-  std::string reasoning_start = known_think_tokens ? ctx.reasoning_start : "\"<think>\"";
-  std::string reasoning_end = known_think_tokens ? ctx.reasoning_end : "\"</think>\"";
+  // Known boundaries use an exact numeric token ID when available; all others use literal bytes.
+  std::string reasoning_start =
+      known_think_tokens ? RenderLarkMarker(ctx.reasoning_start, ctx.reasoning_start_token_id) : "\"<think>\"";
+  std::string reasoning_end =
+      known_think_tokens ? RenderLarkMarker(ctx.reasoning_end, ctx.reasoning_end_token_id) : "\"</think>\"";
 
   // Set rows for grammar
   std::ostringstream grammar;
@@ -371,7 +431,15 @@ std::string BuildLarkGrammar(const ToolCallContext& ctx,
 
   // Add grammar for chain-of-thought output
   if (reasoning_enabled) {
-    grammar << "cot: " << reasoning_start << " THINK_TEXT " << reasoning_end << " \"\\n\"\n";
+    if (prompt_opens_reasoning) {
+      // The rendered prompt already ends with the reasoning opener (see PromptOpensReasoning in
+      // reasoning_stream_splitter.h), so generation starts inside reasoning. The model neither emits nor can be
+      // asked to emit the opener again — omitting it here is required, not just an optimization: a grammar that
+      // still demanded the opener as the first production would be unsatisfiable against this prompt.
+      grammar << "cot: THINK_TEXT " << reasoning_end << " \"\\n\"\n";
+    } else {
+      grammar << "cot: " << reasoning_start << " THINK_TEXT " << reasoning_end << " \"\\n\"\n";
+    }
     grammar << "THINK_TEXT: /[^<]+/\n";
   }
 
@@ -388,8 +456,8 @@ std::string BuildLarkGrammar(const ToolCallContext& ctx,
   // Add grammar for tool output
   if (ctx.tool_output) {
     if (known_tool_tokens) {
-      grammar << "toolcall: " << ctx.tool_call_start
-              << " functioncall " << ctx.tool_call_end << "\n";
+      grammar << "toolcall: " << RenderLarkMarker(ctx.tool_call_start, ctx.tool_call_start_token_id)
+              << " functioncall " << RenderLarkMarker(ctx.tool_call_end, ctx.tool_call_end_token_id) << "\n";
     }
 
     grammar << "functioncall: %json " << json_schema << "\n";

--- a/sdk_v2/cpp/src/inferencing/generative/toolcalling/grammar.h
+++ b/sdk_v2/cpp/src/inferencing/generative/toolcalling/grammar.h
@@ -4,6 +4,8 @@
 
 #include "inferencing/generative/toolcalling/tool_call_context.h"
 
+#include <cstdint>
+#include <optional>
 #include <string>
 
 namespace fl {
@@ -11,41 +13,43 @@ namespace fl {
 /// Build a Lark grammar string for ORT GenAI's SetGuidance.
 ///
 /// Grammar controls whether the model produces text, tool calls, chain-of-thought
-/// reasoning, or combinations thereof, using special tokens when available.
+/// reasoning, or combinations thereof, using exact token IDs or quoted marker literals when available.
 ///
 /// Legend:
 ///   cot          = chain-of-thought output with newline at the end
 ///   THINK_TEXT   = chain-of-thought text output
 ///   output       = output row (text and/or tool call)
 ///   TEXT         = text output
-///   toolcall     = tool call output (with known ids)
+///   toolcall     = tool call output (with configured boundary markers)
 ///   functioncall = JSON schemas for each registered tool
 ///
 /// | Case | Description                                                                                        |
 /// |------|----------------------------------------------------------------------------------------------------|
 /// |  1   | Return text only                                                                                   |
-/// |  2   | Return tool call only (known tool call token ids)                                                  |
-/// |  3   | Return tool call only (unknown tool call token ids)                                                |
-/// |  4   | Return text or tool call (known tool call token ids)                                               |
-/// |  5   | Return text or tool call (unknown tool call token ids)                                             |
-/// |  6   | Return chain-of-thought + text only (known think token ids)                                        |
-/// |  7   | Return chain-of-thought + text only (unknown think token ids)                                      |
-/// |  8   | Return chain-of-thought + tool call only (known think token ids, known tool call token ids)        |
-/// |  9   | Return chain-of-thought + tool call only (unknown think token ids, known tool call token ids)      |
-/// |  10  | Return chain-of-thought + tool call only (known think token ids, unknown tool call token ids)      |
-/// |  11  | Return chain-of-thought + tool call only (unknown think token ids, unknown tool call token ids)    |
-/// |  12  | Return chain-of-thought + text or tool call (known think token ids, known tool call token ids)     |
-/// |  13  | Return chain-of-thought + text or tool call (unknown think token ids, known tool call token ids)   |
-/// |  14  | Return chain-of-thought + text or tool call (known think token ids, unknown tool call token ids)   |
-/// |  15  | Return chain-of-thought + text or tool call (unknown think token ids, unknown tool call token ids) |
+/// |  2   | Return tool call only (configured tool-call markers)                                               |
+/// |  3   | Return tool call only (no configured tool-call markers)                                            |
+/// |  4   | Return text or tool call (configured tool-call markers)                                            |
+/// |  5   | Return text or tool call (no configured tool-call markers)                                         |
+/// |  6   | Return chain-of-thought + text only (configured reasoning markers)                                 |
+/// |  7   | Return chain-of-thought + text only (no configured reasoning markers)                              |
+/// |  8   | Return chain-of-thought + tool call only (both marker pairs configured)                            |
+/// |  9   | Return chain-of-thought + tool call only (only tool-call markers configured)                       |
+/// |  10  | Return chain-of-thought + tool call only (only reasoning markers configured)                       |
+/// |  11  | Return chain-of-thought + tool call only (no marker pairs configured)                              |
+/// |  12  | Return chain-of-thought + text or tool call (both marker pairs configured)                         |
+/// |  13  | Return chain-of-thought + text or tool call (only tool-call markers configured)                    |
+/// |  14  | Return chain-of-thought + text or tool call (only reasoning markers configured)                    |
+/// |  15  | Return chain-of-thought + text or tool call (no marker pairs configured)                           |
 ///
 /// See grammar.cc for the full grammar pattern for each case.
 ///
-/// @param ctx           Tool calling context with flags and tokens (includes reasoning state)
-/// @param json_schema   JSON schema string for the tool definitions (may be empty)
-/// @return              Lark grammar string suitable for SetGuidance("lark_grammar", ...)
+/// @param ctx                    Tool calling context with flags and marker metadata
+/// @param json_schema            JSON schema string for the tool definitions (may be empty)
+/// @param prompt_opens_reasoning Whether the rendered prompt ends inside an open reasoning block
+/// @return                       Lark grammar string suitable for SetGuidance("lark_grammar", ...)
 std::string BuildLarkGrammar(const ToolCallContext& ctx,
-                             const std::string& json_schema);
+                             const std::string& json_schema,
+                             bool prompt_opens_reasoning = false);
 
 /// Build a JSON schema string for tool call guidance.
 ///
@@ -58,5 +62,24 @@ std::string BuildLarkGrammar(const ToolCallContext& ctx,
 /// @return     JSON schema string suitable for SetGuidance("json_schema", ...)
 ///             or for embedding in Lark grammar as %json directive
 std::string BuildToolJsonSchema(const ToolCallContext& ctx);
+
+/// Escape `text` as a Lark string literal: wraps it in double quotes and escapes the characters that would
+/// otherwise break out of the literal or corrupt the rendered grammar — backslash, double quote, and the
+/// whitespace control characters (newline, carriage return, tab) that a marker string can plausibly contain.
+///
+/// @param text  Raw marker text (e.g. "<tool_call>")
+/// @return      A double-quoted, escaped Lark string literal (e.g. "\"<tool_call>\"")
+std::string EscapeLarkLiteral(const std::string& text);
+
+/// Render one boundary marker for splicing into a Lark grammar production.
+///
+/// An authoritative single token ID is emitted with llguidance's exact numeric-token syntax (`<[ID]>`).
+/// Otherwise the marker text is emitted as an escaped quoted literal, which represents normal bytes and may
+/// tokenize to multiple IDs. Named `<token_name>` syntax is reserved for tokenizer special-token names.
+///
+/// @param marker_text  Raw marker text (e.g. "<tool_call>")
+/// @param token_id     Authoritative exact token ID, or nullopt for literal rendering
+/// @return             Grammar-ready numeric token terminal or escaped literal
+std::string RenderLarkMarker(const std::string& marker_text, std::optional<int32_t> token_id);
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/toolcalling/tool_call_context.h
+++ b/sdk_v2/cpp/src/inferencing/generative/toolcalling/tool_call_context.h
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include <cstdint>
+#include <optional>
 #include <string>
 
 namespace fl {
@@ -42,6 +44,11 @@ struct ToolCallContext {
     return !reasoning_start.empty() && !reasoning_end.empty();
   }
 
+  /// Exact token IDs for reasoning boundaries when each marker resolves authoritatively to one nonnegative ID.
+  /// llguidance renders these as numeric `<[ID]>` terminals. Unresolved or multi-token markers remain literals.
+  std::optional<int32_t> reasoning_start_token_id;
+  std::optional<int32_t> reasoning_end_token_id;
+
   /// The raw tools JSON string for the chat template (passed to ApplyChatTemplate).
   std::string tools_json;
 
@@ -62,6 +69,11 @@ struct ToolCallContext {
   bool HasToolCallTokens() const {
     return !tool_call_start.empty() && !tool_call_end.empty();
   }
+
+  /// Exact token IDs for tool-call boundaries when each marker resolves authoritatively to one nonnegative ID.
+  /// Start and end are resolved independently; unresolved or multi-token markers remain quoted literals.
+  std::optional<int32_t> tool_call_start_token_id;
+  std::optional<int32_t> tool_call_end_token_id;
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/test/internal_api/chat/dynamic_engine_chat_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat/dynamic_engine_chat_test.cc
@@ -330,9 +330,9 @@ TEST_F(DynamicEngineChatTest, CapacityTimeoutFailsOnlyNewestWaitingConversation)
   auto first = engine.CreateConversation(options, tool_context, static_cast<int>(tokens.size()));
   auto second = engine.CreateConversation(options, tool_context, static_cast<int>(tokens.size()));
   auto waiting = engine.CreateConversation(options, tool_context, static_cast<int>(tokens.size()));
-  engine.BeginTurn(first, tokens, options, tool_context);
-  engine.BeginTurn(second, tokens, options, tool_context);
-  engine.BeginTurn(waiting, tokens, options, tool_context);
+  engine.BeginTurn(first, tokens, options, tool_context, false);
+  engine.BeginTurn(second, tokens, options, tool_context, false);
+  engine.BeginTurn(waiting, tokens, options, tool_context, false);
 
   auto wait_result = std::async(std::launch::async, [&]() {
     try {
@@ -363,7 +363,7 @@ TEST_F(DynamicEngineChatTest, LateCancelAfterCompletedConversationRemovalIsNoOp)
   const auto tokens = EncodeUserPrompt("Reply OK.", ModelInstance());
 
   auto completed = engine.CreateConversation(options, tool_context, static_cast<int>(tokens.size()));
-  engine.BeginTurn(completed, tokens, options, tool_context);
+  engine.BeginTurn(completed, tokens, options, tool_context, false);
   while (!engine.IsTurnFinished(completed)) {
     (void)engine.WaitForToken(completed);
   }

--- a/sdk_v2/cpp/test/internal_api/chat/search_options_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat/search_options_test.cc
@@ -213,7 +213,8 @@ TEST(SamplingPlanTest, OutOfRangeScalarsAreRejected) {
 }
 
 TEST(EngineTurnOptionsPlanTest, LeavesMaxOutputAndSamplingUnsetWhenCallerOmitsThem) {
-  const auto plan = BuildEngineTurnOptionsPlan(SearchOptions{}, ToolCallContext{}, ChatBackendKind::kEngine);
+  const auto plan =
+      BuildEngineTurnOptionsPlan(SearchOptions{}, ToolCallContext{}, ChatBackendKind::kEngine, false);
   EXPECT_FALSE(plan.max_generated_tokens.has_value());
   EXPECT_FALSE(plan.sampling.do_sample.has_value());
   EXPECT_FALSE(plan.sampling.temperature.has_value());
@@ -226,7 +227,8 @@ TEST(EngineTurnOptionsPlanTest, RejectsNonpositiveExplicitMaxOutputTokens) {
   for (int max_output_tokens : {0, -1}) {
     SearchOptions options;
     options.max_output_tokens = max_output_tokens;
-    EXPECT_THROW(BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine), fl::Exception);
+    EXPECT_THROW(BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine, false),
+                 fl::Exception);
   }
 }
 
@@ -242,7 +244,7 @@ TEST(EngineTurnOptionsPlanTest, CarriesStopStringsSeedAndGuidanceOnDynamicBacken
   tool_ctx.guidance_type = "json_schema";
   tool_ctx.guidance_data = R"({"type":"object"})";
 
-  const auto plan = BuildEngineTurnOptionsPlan(options, tool_ctx, ChatBackendKind::kEngine);
+  const auto plan = BuildEngineTurnOptionsPlan(options, tool_ctx, ChatBackendKind::kEngine, false);
   ASSERT_TRUE(plan.max_generated_tokens.has_value());
   EXPECT_EQ(*plan.max_generated_tokens, 64);
   ASSERT_TRUE(plan.seed.has_value());
@@ -251,6 +253,7 @@ TEST(EngineTurnOptionsPlanTest, CarriesStopStringsSeedAndGuidanceOnDynamicBacken
   ASSERT_TRUE(plan.guidance.has_value());
   EXPECT_EQ(plan.guidance->type, "json_schema");
   EXPECT_EQ(plan.guidance->data, R"({"type":"object"})");
+  EXPECT_TRUE(plan.guidance->user_specified);
 }
 
 TEST(EngineTurnOptionsPlanTest, NegativeSeedIsOmitted) {
@@ -258,7 +261,8 @@ TEST(EngineTurnOptionsPlanTest, NegativeSeedIsOmitted) {
     SearchOptions options;
     options.seed = seed;
 
-    const auto plan = BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine);
+    const auto plan =
+        BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine, false);
     EXPECT_FALSE(plan.seed.has_value());
   }
 }
@@ -267,7 +271,8 @@ TEST(EngineTurnOptionsPlanTest, ZeroSeedIsForwarded) {
   SearchOptions options;
   options.seed = 0;
 
-  const auto plan = BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine);
+  const auto plan =
+      BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine, false);
   ASSERT_TRUE(plan.seed.has_value());
   EXPECT_EQ(*plan.seed, 0);
 }
@@ -278,11 +283,36 @@ TEST(EngineTurnOptionsPlanTest, UserGuidanceAppliesWithoutToolOnlyMode) {
   tool_ctx.guidance_data = R"({"type":"object","required":["answer"]})";
 
   const auto plan =
-      BuildEngineTurnOptionsPlan(SearchOptions{}, tool_ctx, ChatBackendKind::kEngine);
+      BuildEngineTurnOptionsPlan(SearchOptions{}, tool_ctx, ChatBackendKind::kEngine, false);
 
   ASSERT_TRUE(plan.guidance.has_value());
   EXPECT_EQ(plan.guidance->type, "json_schema");
   EXPECT_EQ(plan.guidance->data, R"({"type":"object","required":["answer"]})");
+  EXPECT_TRUE(plan.guidance->user_specified);
+}
+
+TEST(EngineTurnOptionsPlanTest, PromptOpenedReasoningOmitsTheGrammarOpener) {
+  ToolCallContext tool_ctx;
+  tool_ctx.text_output = false;
+  tool_ctx.tool_output = true;
+  tool_ctx.supports_reasoning = true;
+  tool_ctx.reasoning_start = "<think>";
+  tool_ctx.reasoning_end = "</think>";
+  tool_ctx.reasoning_start_token_id = 248058;
+  tool_ctx.reasoning_end_token_id = 248059;
+
+  const auto closed_plan =
+      BuildEngineTurnOptionsPlan(SearchOptions{}, tool_ctx, ChatBackendKind::kEngine, false);
+  const auto open_plan =
+      BuildEngineTurnOptionsPlan(SearchOptions{}, tool_ctx, ChatBackendKind::kEngine, true);
+
+  ASSERT_TRUE(closed_plan.guidance.has_value());
+  ASSERT_TRUE(open_plan.guidance.has_value());
+  EXPECT_FALSE(closed_plan.guidance->user_specified);
+  EXPECT_FALSE(open_plan.guidance->user_specified);
+  EXPECT_NE(closed_plan.guidance->data.find("cot: <[248058]> THINK_TEXT"), std::string::npos);
+  EXPECT_NE(open_plan.guidance->data.find("cot: THINK_TEXT <[248059]>"), std::string::npos);
+  EXPECT_EQ(open_plan.guidance->data.find("cot: <[248058]>"), std::string::npos);
 }
 
 TEST(EngineTurnOptionsPlanTest, NeutralPenaltiesDoNotOverrideModelDefaults) {
@@ -290,7 +320,8 @@ TEST(EngineTurnOptionsPlanTest, NeutralPenaltiesDoNotOverrideModelDefaults) {
   options.frequency_penalty = 0.0f;
   options.presence_penalty = 0.0f;
 
-  EXPECT_NO_THROW(BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine));
+  EXPECT_NO_THROW(
+      BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine, false));
 }
 
 TEST(EngineTurnOptionsPlanTest, RejectsNonzeroPenalties) {
@@ -301,7 +332,7 @@ TEST(EngineTurnOptionsPlanTest, RejectsNonzeroPenalties) {
     options.frequency_penalty = frequency;
     options.presence_penalty = presence;
 
-    EXPECT_THROW(BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine),
+    EXPECT_THROW(BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine, false),
                  fl::Exception);
   }
 }
@@ -309,11 +340,13 @@ TEST(EngineTurnOptionsPlanTest, RejectsNonzeroPenalties) {
 TEST(EngineTurnOptionsPlanTest, RejectsTrueEarlyStoppingAndAcceptsNeutralFalse) {
   SearchOptions enabled;
   enabled.early_stopping = true;
-  EXPECT_THROW(BuildEngineTurnOptionsPlan(enabled, ToolCallContext{}, ChatBackendKind::kEngine), fl::Exception);
+  EXPECT_THROW(BuildEngineTurnOptionsPlan(enabled, ToolCallContext{}, ChatBackendKind::kEngine, false),
+               fl::Exception);
 
   SearchOptions disabled;
   disabled.early_stopping = false;
-  EXPECT_NO_THROW(BuildEngineTurnOptionsPlan(disabled, ToolCallContext{}, ChatBackendKind::kEngine));
+  EXPECT_NO_THROW(
+      BuildEngineTurnOptionsPlan(disabled, ToolCallContext{}, ChatBackendKind::kEngine, false));
 }
 
 TEST(SearchOptionsParsingTest, EngineSupportsPerTurnStopStringsAndSeed) {

--- a/sdk_v2/cpp/test/internal_api/toolcalling/grammar_test.cc
+++ b/sdk_v2/cpp/test/internal_api/toolcalling/grammar_test.cc
@@ -189,11 +189,11 @@ TEST(EscapeLarkLiteralTest, WrapsPlainTextInQuotes) {
 }
 
 TEST(EscapeLarkLiteralTest, EscapesBackslashAndQuote) {
-  EXPECT_EQ(EscapeLarkLiteral(R"(a\b"c)"), R"("a\\b\"c")");
+  EXPECT_EQ(EscapeLarkLiteral("a\\b\"c"), "\"a\\\\b\\\"c\"");
 }
 
 TEST(EscapeLarkLiteralTest, EscapesNewlineCarriageReturnAndTab) {
-  EXPECT_EQ(EscapeLarkLiteral("a\nb\rc\td"), R"("a\nb\rc\td")");
+  EXPECT_EQ(EscapeLarkLiteral("a\nb\rc\td"), "\"a\\nb\\rc\\td\"");
 }
 
 TEST(EscapeLarkLiteralTest, EscapesRemainingControlCharacters) {

--- a/sdk_v2/cpp/test/internal_api/toolcalling/grammar_test.cc
+++ b/sdk_v2/cpp/test/internal_api/toolcalling/grammar_test.cc
@@ -118,12 +118,14 @@ TEST(BuildLarkGrammarTest, ToolOnlyWithMarkersGrammar) {
   ctx.tool_output = true;
   ctx.tool_call_start = "<tool>";
   ctx.tool_call_end = "</tool>";
+  ctx.tool_call_start_token_id = 200;
+  ctx.tool_call_end_token_id = 201;
 
   std::string grammar = BuildLarkGrammar(ctx, R"({"type":"array"})");
   EXPECT_NE(grammar.find("start: toolcall"), std::string::npos);
   EXPECT_NE(grammar.find("functioncall"), std::string::npos);
-  EXPECT_NE(grammar.find("<tool>"), std::string::npos);
-  EXPECT_NE(grammar.find("</tool>"), std::string::npos);
+  EXPECT_NE(grammar.find("<[200]>"), std::string::npos);
+  EXPECT_NE(grammar.find("<[201]>"), std::string::npos);
 }
 
 TEST(BuildLarkGrammarTest, ToolOnlyWithoutMarkersGrammar) {
@@ -179,8 +181,175 @@ TEST(BuildLarkGrammarTest, GrammarContainsJsonDirective) {
 }
 
 // ========================================================================
+// RenderLarkMarker / EscapeLarkLiteral — exact-token-vs-literal rendering
+// ========================================================================
+
+TEST(EscapeLarkLiteralTest, WrapsPlainTextInQuotes) {
+  EXPECT_EQ(EscapeLarkLiteral("<tool_call>"), "\"<tool_call>\"");
+}
+
+TEST(EscapeLarkLiteralTest, EscapesBackslashAndQuote) {
+  EXPECT_EQ(EscapeLarkLiteral(R"(a\b"c)"), R"("a\\b\"c")");
+}
+
+TEST(EscapeLarkLiteralTest, EscapesNewlineCarriageReturnAndTab) {
+  EXPECT_EQ(EscapeLarkLiteral("a\nb\rc\td"), R"("a\nb\rc\td")");
+}
+
+TEST(EscapeLarkLiteralTest, EscapesRemainingControlCharacters) {
+  EXPECT_EQ(EscapeLarkLiteral(std::string("a\b\f") + static_cast<char>(0x01) + "b"), R"("a\b\f\u0001b")");
+}
+
+TEST(EscapeLarkLiteralTest, EmptyTextProducesEmptyLiteral) {
+  EXPECT_EQ(EscapeLarkLiteral(""), "\"\"");
+}
+
+TEST(RenderLarkMarkerTest, AuthoritativeIdRendersExactNumericToken) {
+  EXPECT_EQ(RenderLarkMarker("<tool_call>", 248068), "<[248068]>");
+}
+
+TEST(RenderLarkMarkerTest, UnresolvedMarkerRendersEscapedLiteral) {
+  EXPECT_EQ(RenderLarkMarker("<tool_call>", std::nullopt), "\"<tool_call>\"");
+}
+
+TEST(BuildLarkGrammarTest, UnresolvedToolMarkersRenderAsEscapedLiterals) {
+  ToolCallContext ctx;
+  ctx.text_output = false;
+  ctx.tool_output = true;
+  ctx.tool_call_start = "<tool_call>";
+  ctx.tool_call_end = "</tool_call>";
+
+  std::string grammar = BuildLarkGrammar(ctx, R"({"type":"array"})");
+  EXPECT_NE(grammar.find("toolcall: \"<tool_call>\" functioncall \"</tool_call>\""), std::string::npos);
+  EXPECT_EQ(grammar.find("toolcall: <tool_call>"), std::string::npos);
+}
+
+TEST(BuildLarkGrammarTest, ToolMarkersMixNumericAndLiteralBoundaries) {
+  ToolCallContext ctx;
+  ctx.text_output = false;
+  ctx.tool_output = true;
+  ctx.tool_call_start = "<tool_call>";
+  ctx.tool_call_end = "</tool_call>";
+  ctx.tool_call_start_token_id = 248068;
+
+  std::string grammar = BuildLarkGrammar(ctx, R"({"type":"array"})");
+  EXPECT_NE(grammar.find("toolcall: <[248068]> functioncall \"</tool_call>\""), std::string::npos);
+}
+
+TEST(BuildLarkGrammarTest, MultiTokenReasoningMarkersFallBackToLiterals) {
+  ToolCallContext ctx;
+  ctx.text_output = true;
+  ctx.tool_output = false;
+  ctx.supports_reasoning = true;
+  ctx.reasoning_start = "<think>";
+  ctx.reasoning_end = "</think>";
+
+  std::string grammar = BuildLarkGrammar(ctx, "{}");
+  EXPECT_NE(grammar.find(R"(cot: "<think>" THINK_TEXT "</think>" "\n")"), std::string::npos);
+  EXPECT_EQ(grammar.find("cot: <think>"), std::string::npos);
+}
+
+TEST(BuildLarkGrammarTest, ToolAndReasoningMarkerIdsAreIndependent) {
+  ToolCallContext ctx;
+  ctx.text_output = false;
+  ctx.tool_output = true;
+  ctx.supports_reasoning = true;
+  ctx.reasoning_start = "<think>";
+  ctx.reasoning_end = "</think>";
+  ctx.tool_call_start = "<tool_call>";
+  ctx.tool_call_end = "</tool_call>";
+  ctx.tool_call_start_token_id = 248068;
+  ctx.tool_call_end_token_id = 248069;
+
+  std::string grammar = BuildLarkGrammar(ctx, R"({"type":"array"})");
+  EXPECT_NE(grammar.find(R"(cot: "<think>" THINK_TEXT "</think>" "\n")"), std::string::npos);
+  EXPECT_NE(grammar.find("toolcall: <[248068]> functioncall <[248069]>"), std::string::npos);
+}
+
+TEST(BuildLarkGrammarTest, NoMarkersUseModelIndependentLiteralFallbacks) {
+  ToolCallContext ctx;
+  ctx.text_output = true;
+  ctx.tool_output = true;
+  ctx.supports_reasoning = true;
+
+  std::string grammar = BuildLarkGrammar(ctx, R"({"type":"array"})");
+  EXPECT_NE(grammar.find(R"(cot: "<think>" THINK_TEXT "</think>" "\n")"), std::string::npos);
+  EXPECT_NE(grammar.find("output: TEXT | functioncall"), std::string::npos);
+  EXPECT_EQ(grammar.find("toolcall:"), std::string::npos);
+}
+
+TEST(BuildLarkGrammarTest, PromptOpensReasoningOmitsCotOpener) {
+  // The rendered prompt already opened reasoning (see PromptOpensReasoning), so the cot rule must not require the
+  // model to re-emit the opener — only the closer remains.
+  ToolCallContext ctx;
+  ctx.text_output = true;
+  ctx.tool_output = false;
+  ctx.supports_reasoning = true;
+  ctx.reasoning_start = "<think>";
+  ctx.reasoning_end = "</think>";
+  ctx.reasoning_start_token_id = 248058;
+  ctx.reasoning_end_token_id = 248059;
+  std::string grammar = BuildLarkGrammar(ctx, "{}", /*prompt_opens_reasoning=*/true);
+
+  std::string expected = R"(start: cot TEXT
+cot: THINK_TEXT <[248059]> "\n"
+THINK_TEXT: /[^<]+/
+TEXT: /[^{<](.|\n)*/
+)";
+
+  EXPECT_EQ(grammar, expected);
+}
+
+TEST(BuildLarkGrammarTest, PromptOpensReasoningOmitsCotOpenerWithToolCall) {
+  // Same shortening applies when the turn's output is tool-call-only — only the cot body changes; the surrounding
+  // start/toolcall productions are unaffected by prompt_opens_reasoning.
+  ToolCallContext ctx;
+  ctx.text_output = false;
+  ctx.tool_output = true;
+  ctx.supports_reasoning = true;
+  ctx.reasoning_start = "<think>";
+  ctx.reasoning_end = "</think>";
+  ctx.reasoning_start_token_id = 248058;
+  ctx.reasoning_end_token_id = 248059;
+  ctx.tool_call_start = "<tool_call>";
+  ctx.tool_call_end = "</tool_call>";
+  ctx.tool_call_start_token_id = 248068;
+  ctx.tool_call_end_token_id = 248069;
+  ctx.tools_json = R"([{"type":"function","function":{"name":"get_weather","parameters":{"type":"object"}}}])";
+
+  std::string json_schema = BuildToolJsonSchema(ctx);
+  std::string grammar = BuildLarkGrammar(ctx, json_schema, /*prompt_opens_reasoning=*/true);
+
+  std::string expected =
+      R"(start: cot toolcall
+cot: THINK_TEXT <[248059]> "\n"
+THINK_TEXT: /[^<]+/
+toolcall: <[248068]> functioncall <[248069]>
+functioncall: %json )" +
+      json_schema + "\n";
+
+  EXPECT_EQ(grammar, expected);
+}
+
+TEST(BuildLarkGrammarTest, PromptDoesNotOpenReasoningKeepsCotOpener) {
+  // Sanity check for the default (false) case: the opener is present when the prompt did not already open
+  // reasoning.
+  ToolCallContext ctx;
+  ctx.text_output = true;
+  ctx.tool_output = false;
+  ctx.supports_reasoning = true;
+  ctx.reasoning_start = "<think>";
+  ctx.reasoning_end = "</think>";
+  ctx.reasoning_start_token_id = 248058;
+  ctx.reasoning_end_token_id = 248059;
+  std::string grammar = BuildLarkGrammar(ctx, "{}");
+  EXPECT_NE(grammar.find("cot: <[248058]> THINK_TEXT <[248059]> \"\\n\""), std::string::npos);
+}
+
+// ========================================================================
 // ToolCallContext tests
 // ========================================================================
+
 
 TEST(ToolCallContextTest, DefaultsAreCorrect) {
   ToolCallContext ctx;
@@ -189,6 +358,10 @@ TEST(ToolCallContextTest, DefaultsAreCorrect) {
   EXPECT_TRUE(ctx.tool_call_start.empty());
   EXPECT_TRUE(ctx.tool_call_end.empty());
   EXPECT_TRUE(ctx.tools_json.empty());
+  EXPECT_FALSE(ctx.tool_call_start_token_id.has_value());
+  EXPECT_FALSE(ctx.tool_call_end_token_id.has_value());
+  EXPECT_FALSE(ctx.reasoning_start_token_id.has_value());
+  EXPECT_FALSE(ctx.reasoning_end_token_id.has_value());
 }
 
 TEST(ToolCallContextTest, HasToolsWhenJsonPresent) {
@@ -233,11 +406,13 @@ TEST(BuildLarkGrammarTest, CoT_TextOnly_KnownThinkIds) {
   ctx.supports_reasoning = true;
   ctx.reasoning_start = "<think>";
   ctx.reasoning_end = "</think>";
+  ctx.reasoning_start_token_id = 248058;
+  ctx.reasoning_end_token_id = 248059;
 
   std::string grammar = BuildLarkGrammar(ctx, "{}");
 
   std::string expected = R"(start: cot TEXT
-cot: <think> THINK_TEXT </think> "\n"
+cot: <[248058]> THINK_TEXT <[248059]> "\n"
 THINK_TEXT: /[^<]+/
 TEXT: /[^{<](.|\n)*/
 )";
@@ -270,8 +445,12 @@ TEST(BuildLarkGrammarTest, CoT_ToolOnly_KnownThinkIds_KnownToolIds) {
   ctx.supports_reasoning = true;
   ctx.reasoning_start = "<think>";
   ctx.reasoning_end = "</think>";
+  ctx.reasoning_start_token_id = 248058;
+  ctx.reasoning_end_token_id = 248059;
   ctx.tool_call_start = "<tool_call>";
   ctx.tool_call_end = "</tool_call>";
+  ctx.tool_call_start_token_id = 248068;
+  ctx.tool_call_end_token_id = 248069;
   ctx.tools_json = R"([{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}])";
 
   std::string json_schema = BuildToolJsonSchema(ctx);
@@ -279,9 +458,9 @@ TEST(BuildLarkGrammarTest, CoT_ToolOnly_KnownThinkIds_KnownToolIds) {
 
   std::string expected =
       R"(start: cot toolcall
-cot: <think> THINK_TEXT </think> "\n"
+cot: <[248058]> THINK_TEXT <[248059]> "\n"
 THINK_TEXT: /[^<]+/
-toolcall: <tool_call> functioncall </tool_call>
+toolcall: <[248068]> functioncall <[248069]>
 functioncall: %json )" +
       json_schema + "\n";
 
@@ -295,6 +474,8 @@ TEST(BuildLarkGrammarTest, CoT_ToolOnly_UnknownThinkIds_KnownToolIds) {
   ctx.supports_reasoning = true;
   ctx.tool_call_start = "<tool_call>";
   ctx.tool_call_end = "</tool_call>";
+  ctx.tool_call_start_token_id = 248068;
+  ctx.tool_call_end_token_id = 248069;
   ctx.tools_json = R"([{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}])";
 
   std::string json_schema = BuildToolJsonSchema(ctx);
@@ -304,7 +485,7 @@ TEST(BuildLarkGrammarTest, CoT_ToolOnly_UnknownThinkIds_KnownToolIds) {
       R"(start: cot toolcall
 cot: "<think>" THINK_TEXT "</think>" "\n"
 THINK_TEXT: /[^<]+/
-toolcall: <tool_call> functioncall </tool_call>
+toolcall: <[248068]> functioncall <[248069]>
 functioncall: %json )" +
       json_schema + "\n";
 
@@ -318,6 +499,8 @@ TEST(BuildLarkGrammarTest, CoT_ToolOnly_KnownThinkIds_UnknownToolIds) {
   ctx.supports_reasoning = true;
   ctx.reasoning_start = "<think>";
   ctx.reasoning_end = "</think>";
+  ctx.reasoning_start_token_id = 248058;
+  ctx.reasoning_end_token_id = 248059;
   ctx.tools_json = R"([{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}])";
 
   std::string json_schema = BuildToolJsonSchema(ctx);
@@ -325,7 +508,7 @@ TEST(BuildLarkGrammarTest, CoT_ToolOnly_KnownThinkIds_UnknownToolIds) {
 
   std::string expected =
       R"(start: cot functioncall
-cot: <think> THINK_TEXT </think> "\n"
+cot: <[248058]> THINK_TEXT <[248059]> "\n"
 THINK_TEXT: /[^<]+/
 functioncall: %json )" +
       json_schema + "\n";
@@ -360,8 +543,12 @@ TEST(BuildLarkGrammarTest, CoT_TextOrTool_KnownThinkIds_KnownToolIds) {
   ctx.supports_reasoning = true;
   ctx.reasoning_start = "<think>";
   ctx.reasoning_end = "</think>";
+  ctx.reasoning_start_token_id = 248058;
+  ctx.reasoning_end_token_id = 248059;
   ctx.tool_call_start = "<tool_call>";
   ctx.tool_call_end = "</tool_call>";
+  ctx.tool_call_start_token_id = 248068;
+  ctx.tool_call_end_token_id = 248069;
   ctx.tools_json = R"([{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}])";
 
   std::string json_schema = BuildToolJsonSchema(ctx);
@@ -369,11 +556,11 @@ TEST(BuildLarkGrammarTest, CoT_TextOrTool_KnownThinkIds_KnownToolIds) {
 
   std::string expected =
       R"(start: cot output
-cot: <think> THINK_TEXT </think> "\n"
+cot: <[248058]> THINK_TEXT <[248059]> "\n"
 THINK_TEXT: /[^<]+/
 output: TEXT | toolcall
 TEXT: /[^{<](.|\n)*/
-toolcall: <tool_call> functioncall </tool_call>
+toolcall: <[248068]> functioncall <[248069]>
 functioncall: %json )" +
       json_schema + "\n";
 
@@ -387,6 +574,8 @@ TEST(BuildLarkGrammarTest, CoT_TextOrTool_UnknownThinkIds_KnownToolIds) {
   ctx.supports_reasoning = true;
   ctx.tool_call_start = "<tool_call>";
   ctx.tool_call_end = "</tool_call>";
+  ctx.tool_call_start_token_id = 248068;
+  ctx.tool_call_end_token_id = 248069;
   ctx.tools_json = R"([{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}])";
 
   std::string json_schema = BuildToolJsonSchema(ctx);
@@ -398,7 +587,7 @@ cot: "<think>" THINK_TEXT "</think>" "\n"
 THINK_TEXT: /[^<]+/
 output: TEXT | toolcall
 TEXT: /[^{<](.|\n)*/
-toolcall: <tool_call> functioncall </tool_call>
+toolcall: <[248068]> functioncall <[248069]>
 functioncall: %json )" +
       json_schema + "\n";
 
@@ -412,6 +601,8 @@ TEST(BuildLarkGrammarTest, CoT_TextOrTool_KnownThinkIds_UnknownToolIds) {
   ctx.supports_reasoning = true;
   ctx.reasoning_start = "<think>";
   ctx.reasoning_end = "</think>";
+  ctx.reasoning_start_token_id = 248058;
+  ctx.reasoning_end_token_id = 248059;
   ctx.tools_json = R"([{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}])";
 
   std::string json_schema = BuildToolJsonSchema(ctx);
@@ -419,7 +610,7 @@ TEST(BuildLarkGrammarTest, CoT_TextOrTool_KnownThinkIds_UnknownToolIds) {
 
   std::string expected =
       R"(start: cot output
-cot: <think> THINK_TEXT </think> "\n"
+cot: <[248058]> THINK_TEXT <[248059]> "\n"
 THINK_TEXT: /[^<]+/
 output: TEXT | functioncall
 TEXT: /[^{<](.|\n)*/

--- a/sdk_v2/cpp/test/internal_api/toolcalling/grammar_test.cc
+++ b/sdk_v2/cpp/test/internal_api/toolcalling/grammar_test.cc
@@ -212,6 +212,10 @@ TEST(RenderLarkMarkerTest, UnresolvedMarkerRendersEscapedLiteral) {
   EXPECT_EQ(RenderLarkMarker("<tool_call>", std::nullopt), "\"<tool_call>\"");
 }
 
+TEST(RenderLarkMarkerTest, NegativeTokenIdRendersEscapedLiteral) {
+  EXPECT_EQ(RenderLarkMarker("<tool_call>", -1), "\"<tool_call>\"");
+}
+
 TEST(BuildLarkGrammarTest, UnresolvedToolMarkersRenderAsEscapedLiterals) {
   ToolCallContext ctx;
   ctx.text_output = false;
@@ -247,6 +251,21 @@ TEST(BuildLarkGrammarTest, MultiTokenReasoningMarkersFallBackToLiterals) {
   std::string grammar = BuildLarkGrammar(ctx, "{}");
   EXPECT_NE(grammar.find(R"(cot: "<think>" THINK_TEXT "</think>" "\n")"), std::string::npos);
   EXPECT_EQ(grammar.find("cot: <think>"), std::string::npos);
+}
+
+TEST(BuildLarkGrammarTest, Phi4MiniReasoningWithoutPublishedIdsUsesLiteralMarkers) {
+  ToolCallContext ctx;
+  ctx.text_output = true;
+  ctx.tool_output = false;
+  ctx.supports_reasoning = true;
+  ctx.reasoning_start = "<think>";
+  ctx.reasoning_end = "</think>";
+
+  const std::string grammar = BuildLarkGrammar(ctx, "{}");
+
+  EXPECT_NE(grammar.find(R"(cot: "<think>" THINK_TEXT "</think>" "\n")"), std::string::npos);
+  EXPECT_NE(grammar.find("THINK_TEXT: /[^<]+/"), std::string::npos);
+  EXPECT_EQ(grammar.find("<["), std::string::npos);
 }
 
 TEST(BuildLarkGrammarTest, ToolAndReasoningMarkerIdsAreIndependent) {

--- a/sdk_v2/cpp/test/internal_api/toolcalling/grammar_test.cc
+++ b/sdk_v2/cpp/test/internal_api/toolcalling/grammar_test.cc
@@ -197,7 +197,8 @@ TEST(EscapeLarkLiteralTest, EscapesNewlineCarriageReturnAndTab) {
 }
 
 TEST(EscapeLarkLiteralTest, EscapesRemainingControlCharacters) {
-  EXPECT_EQ(EscapeLarkLiteral(std::string("a\b\f") + static_cast<char>(0x01) + "b"), R"("a\b\f\u0001b")");
+  EXPECT_EQ(EscapeLarkLiteral(std::string("a\b\f") + static_cast<char>(0x01) + "b"),
+            "\"a\\b\\f\\u0001b\"");
 }
 
 TEST(EscapeLarkLiteralTest, EmptyTextProducesEmptyLiteral) {


### PR DESCRIPTION
## What this fixes

Foundry Local builds an llguidance grammar when a request requires a tool call.

Previously, Foundry inserted marker text directly into the grammar:

```lark
toolcall: <tool_call> functioncall </tool_call>
```

In llguidance, `<tool_call>` means a named tokenizer special token. This fails for models that use the same marker as
an ordinary token or ordinary text.

## What changed

Foundry now uses the boundary token IDs published by ORT GenAI:

- BOT — beginning of tool call
- EOT — end of tool call
- BOR — beginning of reasoning
- EOR — end of reasoning

When a published ID matches the configured marker, Foundry uses llguidance's exact numeric token syntax:

```lark
toolcall: <[248058]> functioncall <[248059]>
```

This works whether the tokenizer marks the token as special or ordinary.

If an ID is unavailable, invalid, or does not match an overridden marker, Foundry uses an escaped quoted string:

```lark
toolcall: "<tool_call>" functioncall "</tool_call>"
```

The quoted form allows llguidance to tokenize the marker as ordinary text, including markers represented by multiple
tokens.

Tool-call and reasoning start/end boundaries are resolved independently. The implementation contains no model names
or hardcoded token IDs.

## Why not mark every marker as special?

Changing tokenizer metadata affects more than grammar construction. ORT GenAI normally decodes with
`skip_special_tokens=true`, so changing an ordinary marker to `special: true` can remove it from decoded output.

Using numeric IDs preserves the model package's tokenizer behavior while still constraining the exact published
token.

## Required tool-call failures

If Foundry generates guidance for a required tool call and the runtime cannot apply it, the request now fails clearly
instead of continuing with unconstrained generation.

Invalid caller-provided guidance remains an invalid-argument error on both Generator and Engine backends.

## Example

Request:

```text
Use the multiply tool to calculate 17 times 23. Do not answer directly.
```

Result:

```json
{
  "finish_reason": "tool_calls",
  "tool_calls": [
    {
      "type": "function",
      "function": {
        "name": "multiply",
        "arguments": "{\"a\":17,\"b\":23}"
      }
    }
  ]
}
```

After the tool returns `391`, the next turn answers `17 × 23 = 391`.