### PR TITLE
Add exact request budget preflight

### DIFF
--- a/sdk_v2/cpp/CMakeLists.txt
+++ b/sdk_v2/cpp/CMakeLists.txt
@@ -291,6 +291,8 @@ set(FOUNDRY_LOCAL_SOURCES
     src/model_info.cc
     src/inferencing/model_load_manager.cc
     src/inferencing/generative/chat/onnx_chat_generator.cc
+    src/inferencing/generative/chat/prepared_chat_prompt.cc
+    src/inferencing/generative/chat/request_budget.cc
     src/model.cc
     src/inferencing/generative/openresponses/response_converter.cc
     src/inferencing/generative/openresponses/response_store.cc
@@ -466,14 +468,14 @@ configure_file(
 add_library(foundry_local_objects OBJECT ${FOUNDRY_LOCAL_SOURCES})
 set_target_properties(foundry_local_objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
 foundry_local_configure_target(foundry_local_objects PUBLIC)
-# FL_STATIC_LIBRARY makes FL_EXPORT empty on Windows so the two exported entry
-# points compile without __declspec(dllimport/dllexport). The DLL gets its
+# FL_STATIC_LIBRARY makes FL_EXPORT empty on Windows so exported entry points
+# compile without __declspec(dllimport/dllexport). The DLL gets its
 # exports from the .def file instead.
 target_compile_definitions(foundry_local_objects PRIVATE FL_STATIC_LIBRARY=1)
 
 # --------------------------------------------------------------------------
 # Shared library — for releases and public API consumers.
-# On Windows a .def file exports the two public entry points, replacing
+# On Windows a .def file exports the two public entry points and the private Node getter, replacing
 # __declspec(dllexport) so the objects can be compiled once.
 # --------------------------------------------------------------------------
 add_library(foundry_local SHARED)

--- a/sdk_v2/cpp/docs/CodingConventionsAndStandards.md
+++ b/sdk_v2/cpp/docs/CodingConventionsAndStandards.md
@@ -136,7 +136,11 @@ The C API boundary (`foundry_local_c.h`) follows these conventions for ABI stabi
 
 ### Exports and Versioning
 
-* The library exports exactly **two symbols**: `FoundryLocalGetApi(uint32_t version)` and `FoundryLocalGetVersionString()`.
+* The library has exactly **two supported public exports**: `FoundryLocalGetApi(uint32_t version)` and
+  `FoundryLocalGetVersionString()`.
+* `FoundryLocalGetNodePrivateApi(version, size)` is an additional unsupported, versioned lockstep getter used only
+  by the in-repo Node addon. External bindings must not use it. Its contract may change independently when the
+  packaged addon and native runtime are updated together.
 * All other functionality is accessed through **versioned structs of function pointers** (vtables) returned by `FoundryLocalGetApi`.
 * `FOUNDRY_LOCAL_API_VERSION` is incremented with each release. New entries are appended at the end of each vtable struct — never removed or reordered.
 

--- a/sdk_v2/cpp/docs/CppPortGuide.md
+++ b/sdk_v2/cpp/docs/CppPortGuide.md
@@ -59,7 +59,10 @@ Manager (singleton, explicit Create/Destroy lifecycle)
 The C++ SDK exposes three layers:
 
 1. **C ABI** (`foundry_local_c.h`) — Versioned vtable-based API with opaque handles.
-   Only two exported symbols: `FoundryLocalGetApi(version)` and `FoundryLocalGetVersionString()`.
+   It has two supported public exports: `FoundryLocalGetApi(version)` and `FoundryLocalGetVersionString()`.
+   The additional versioned `FoundryLocalGetNodePrivateApi(version, size)` getter is an unsupported lockstep bridge
+   for the in-repo Node addon. External bindings must not use it; it may change independently when the packaged
+   addon and native runtime are updated together.
 2. **C++ Wrapper** (`foundry_local_cpp.h`) — Header-only RAII wrappers over the C API.
 3. **Internal Implementation** (`src/`) — The actual business logic.
 

--- a/sdk_v2/cpp/include/foundry_local/foundry_local_c.h
+++ b/sdk_v2/cpp/include/foundry_local/foundry_local_c.h
@@ -62,6 +62,9 @@
  * ----------------------------------------------------------------------- */
 #define FOUNDRY_LOCAL_API_VERSION 2
 
+/// Minimum supported `flRequestPreflight::version`.
+#define FOUNDRY_LOCAL_REQUEST_PREFLIGHT_MIN_VERSION 2
+
 /* -----------------------------------------------------------------------
  * Platform export macros (C version)
  * ----------------------------------------------------------------------- */
@@ -167,7 +170,7 @@ typedef flStatus* flStatusPtr;
 #endif
 
 /* -----------------------------------------------------------------------
- * Exported symbols — these are the ONLY symbols the library exports
+ * Supported public exports — these are the only symbols consumers may use
  * ----------------------------------------------------------------------- */
 
 /** Get the API function table for the requested version. Returns NULL if unsupported.
@@ -376,6 +379,31 @@ typedef struct flUsage {
   int64_t total_tokens;
   /* V3 fields go here. Read only when version >= 3. */
 } flUsage;
+
+/// Exact token-budget preflight for a request in the current session state.
+/// `output_reserve_tokens` is the explicit cap reserved for generated output. The current package
+/// schema has no distinct generation-default field. When no explicit cap is supplied, the server
+/// falls back to 2048 tokens for text requests and 3072 tokens for media requests. A future
+/// supported positive package default would take precedence over that server fallback. Callers,
+/// including Toolkit, may explicitly choose their own cap.
+///
+/// Preflight is not submit-time enforcement. After compaction or any other request mutation,
+/// callers must rerun preflight on the final rebuilt/private request immediately before submitting
+/// that request.
+///
+/// The caller initializes `version` to a supported value in the inclusive range
+/// [FOUNDRY_LOCAL_REQUEST_PREFLIGHT_MIN_VERSION, FOUNDRY_LOCAL_API_VERSION].
+/// The V2 implementation writes only fields known to V2.
+typedef struct flRequestPreflight {
+  uint32_t version;               ///< Set to a supported version in the documented range.
+  int64_t prompt_tokens;          ///< Exact number of prompt tokens after request preparation.
+  int64_t output_reserve_tokens;  ///< Tokens reserved for generated output.
+  int64_t required_tokens;        ///< Total tokens required: prompt plus output reserve.
+  int64_t context_limit_tokens;   ///< Model context-window limit.
+  int64_t fits;                   ///< 1 if required_tokens fits within the context limit; otherwise 0.
+  int64_t deficit_tokens;         ///< Tokens over budget, or 0 when fits is 1.
+  /* V3 fields go here. Read only when version >= 3. */
+} flRequestPreflight;
 
 /// Information about a discoverable execution provider.
 /// Returned by Manager_GetDiscoverableEps. Storage is owned by the Manager; the
@@ -647,8 +675,8 @@ typedef int (*flEpProgressCallback)(_In_z_ const char* ep_name, float value, _In
  * API function tables
  *
  * The library exposes its functionality through versioned structs of
- * function pointers. Only three symbols are exported from the shared
- * library; everything else is accessed through these tables.
+ * function pointers. Only two supported public symbols are exported from
+ * the shared library; everything else is accessed through these tables.
  *
  * To maintain ABI compatibility, append new entries at the end of each
  * struct. Never remove or reorder existing entries.
@@ -953,7 +981,27 @@ struct flInferenceApi {
   FL_API_STATUS(Session_UndoTurns, _In_ flSession* session, size_t count);
 
   // End V1
+
+  /// Compute the exact token budget for a chat request without mutating the request or session.
+  /// The session handle is generic at the ABI boundary; non-chat sessions are rejected.
+  /// After compaction or any other request mutation, rerun this on the final rebuilt/private
+  /// request immediately before submitting that request.
+  /// The caller initializes `out_preflight->version` to a supported value in the inclusive range
+  /// [FOUNDRY_LOCAL_REQUEST_PREFLIGHT_MIN_VERSION, FOUNDRY_LOCAL_API_VERSION].
+  /// The V2 implementation writes only fields known to V2.
+  FL_API_STATUS(Session_PreflightRequest, _In_ const flSession* session, _In_ const flRequest* request,
+                _Inout_ flRequestPreflight* out_preflight);
+
+  // End V2
 };
+
+#ifdef __cplusplus
+static_assert(offsetof(flInferenceApi, Session_UndoTurns) == 21 * sizeof(void*),
+              "flInferenceApi V1 layout changed");
+static_assert(offsetof(flInferenceApi, Session_PreflightRequest) == 22 * sizeof(void*),
+              "Session_PreflightRequest must remain at vtable offset 22");
+static_assert(sizeof(flInferenceApi) == 23 * sizeof(void*), "flInferenceApi V2 layout changed");
+#endif
 
 /* --- Configuration API ------------------------------------------------- */
 struct flConfigurationApi {

--- a/sdk_v2/cpp/include/foundry_local/foundry_local_cpp.h
+++ b/sdk_v2/cpp/include/foundry_local/foundry_local_cpp.h
@@ -994,6 +994,21 @@ struct RequestOptions {
                                             ///< Typed fields take precedence on key collision.
 };
 
+/// Exact token-budget preflight for a request in the current session state.
+/// `output_reserve_tokens` is the explicit cap reserved for generated output. The current package
+/// schema has no distinct generation-default field. When no explicit cap is supplied, the server
+/// falls back to 2048 tokens for text requests and 3072 tokens for media requests. A future
+/// supported positive package default would take precedence over that server fallback. Callers,
+/// including Toolkit, may explicitly choose their own cap.
+struct RequestPreflight {
+  int64_t prompt_tokens;
+  int64_t output_reserve_tokens;
+  int64_t required_tokens;
+  int64_t context_limit_tokens;
+  bool fits;
+  int64_t deficit_tokens;
+};
+
 // ===========================================================================
 // Inference — Request, Response, Session
 // ===========================================================================
@@ -1056,6 +1071,7 @@ class Response {
 
 namespace detail {
 struct StreamingCallbackHelper;
+class NodeAddonAccess;
 }  // namespace detail
 
 /// Wrapper for an opaque flSession. Created from a loaded IModel.
@@ -1104,6 +1120,14 @@ class ChatSession : public Session {
   /// Undo the last `count` turns and remove their input messages and assistant replies from history.
   /// Retained inference state is reused when it can be restored safely; otherwise it is rebuilt on the next request.
   void UndoTurns(size_t count);
+
+  /// Compute the exact token budget for a request without mutating the request or session.
+  /// After compaction or any other request mutation, rerun this on the final rebuilt/private
+  /// Request immediately before submitting that Request.
+  RequestPreflight PreflightRequest(const Request& request) const;
+
+ private:
+  friend class detail::NodeAddonAccess;
 };
 
 /// Session for automatic-speech-recognition (transcription) models.

--- a/sdk_v2/cpp/include/foundry_local/foundry_local_cpp.inline.h
+++ b/sdk_v2/cpp/include/foundry_local/foundry_local_cpp.inline.h
@@ -1270,6 +1270,21 @@ inline void ChatSession::UndoTurns(size_t count) {
   Check(detail::inference_api()->Session_UndoTurns(handle_.get_mutable(), count));
 }
 
+inline RequestPreflight ChatSession::PreflightRequest(const Request& request) const {
+  flRequestPreflight preflight{};
+  preflight.version = FOUNDRY_LOCAL_REQUEST_PREFLIGHT_MIN_VERSION;
+  Check(detail::inference_api()->Session_PreflightRequest(handle_.get(), request.native_handle(), &preflight));
+
+  return {
+      preflight.prompt_tokens,
+      preflight.output_reserve_tokens,
+      preflight.required_tokens,
+      preflight.context_limit_tokens,
+      preflight.fits != 0,
+      preflight.deficit_tokens,
+  };
+}
+
 // ===========================================================================
 // AudioSession
 // ===========================================================================

--- a/sdk_v2/cpp/src/c_api.cc
+++ b/sdk_v2/cpp/src/c_api.cc
@@ -7,7 +7,10 @@
 
 #include "c_api_types.h"
 #include "catalog.h"
+#include "ep_detection/ep_bootstrapper.h"
 #include "exception.h"
+#include "inferencing/generative/chat/chat_session.h"
+#include "node_private_api.h"
 #include "version.h"
 #include "util/string_utils.h"
 #include "items/audio_item.h"
@@ -21,7 +24,7 @@
 #include "items/tool_call_item.h"
 #include "items/tool_result_item.h"
 #include "manager.h"
-#include "ep_detection/ep_bootstrapper.h"
+#include "version.h"
 
 #include <cstddef>
 #include <functional>
@@ -1903,6 +1906,79 @@ FL_API_STATUS_IMPL(Session_UndoTurnsImpl, flSession* session, size_t count) {
   API_IMPL_END
 }
 
+static void WriteRequestPreflight(const fl::RequestBudget& result, flRequestPreflight& out_preflight) {
+  out_preflight.prompt_tokens = result.prompt_tokens;
+  out_preflight.output_reserve_tokens = result.output_reserve_tokens;
+  out_preflight.required_tokens = result.required_tokens;
+  out_preflight.context_limit_tokens = result.context_limit_tokens;
+  out_preflight.fits = result.fits ? 1 : 0;
+  out_preflight.deficit_tokens = result.deficit_tokens;
+}
+
+FL_API_STATUS_IMPL(Session_PreflightRequestImpl, const flSession* session, const flRequest* request,
+                   flRequestPreflight* out_preflight) {
+  API_IMPL_BEGIN
+  if (!session || !request || !out_preflight) {
+    return MakeStatus(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "null argument");
+  }
+
+  if (AsImpl(session)->Type() != fl::SessionType::kChat) {
+    return MakeStatus(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "request preflight is only supported for chat sessions");
+  }
+  if (!fl::detail::IsRequestPreflightVersionSupported(out_preflight->version)) {
+    return MakeStatus(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "out_preflight->version is not supported");
+  }
+
+  const auto result = AsImpl<fl::ChatSession>(session)->PreflightRequest(*AsImpl(request));
+  WriteRequestPreflight(result, *out_preflight);
+  return nullptr;
+  API_IMPL_END
+}
+
+static FL_API_STATUS_IMPL(Node_Session_CaptureRequestPreflightImpl, const flSession* session,
+                          const flRequest* request, flRequestPreflightOperation** out_operation) {
+  API_IMPL_BEGIN
+  if (!out_operation) {
+    return MakeStatus(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "null out_operation");
+  }
+
+  *out_operation = nullptr;
+  if (!session || !request) {
+    return MakeStatus(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "null session or request");
+  }
+  if (AsImpl(session)->Type() != fl::SessionType::kChat) {
+    return MakeStatus(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "request preflight is only supported for chat sessions");
+  }
+
+  auto operation = AsImpl<fl::ChatSession>(session)->CaptureRequestPreflight(*AsImpl(request));
+  *out_operation = reinterpret_cast<flRequestPreflightOperation*>(operation.release());
+  return nullptr;
+  API_IMPL_END
+}
+
+static FL_API_STATUS_IMPL(Node_RequestPreflightOperation_ExecuteImpl,
+                          flRequestPreflightOperation* operation,
+                          flRequestPreflight* out_preflight) {
+  API_IMPL_BEGIN
+  if (!operation || !out_preflight) {
+    return MakeStatus(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "null argument");
+  }
+  if (!fl::detail::IsRequestPreflightVersionSupported(out_preflight->version)) {
+    return MakeStatus(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "out_preflight->version is not supported");
+  }
+
+  auto* impl = reinterpret_cast<fl::Session::RequestPreflightOperation*>(operation);
+  const auto result = impl->Execute();
+  WriteRequestPreflight(result, *out_preflight);
+  return nullptr;
+  API_IMPL_END
+}
+
+static void FL_API_CALL Node_RequestPreflightOperation_ReleaseImpl(
+    flRequestPreflightOperation* operation) FL_NO_EXCEPTION {
+  delete reinterpret_cast<fl::Session::RequestPreflightOperation*>(operation);
+}
+
 static const flInferenceApi g_inference_api = {
     Request_CreateImpl,
     Request_ReleaseImpl,
@@ -1926,10 +2002,20 @@ static const flInferenceApi g_inference_api = {
     Session_RemoveToolDefinitionImpl,
     Session_GetTurnCountImpl,
     Session_UndoTurnsImpl,
+    Session_PreflightRequestImpl,
 };
 
-static_assert(offsetof(flInferenceApi, Session_UndoTurns) / sizeof(void*) == 21,
-              "Size of version 1 Inference API cannot change");
+static_assert(offsetof(flInferenceApi, Session_UndoTurns) == 21 * sizeof(void*),
+              "flInferenceApi version 1 layout changed");
+static_assert(offsetof(flInferenceApi, Session_PreflightRequest) == 22 * sizeof(void*),
+              "Session_PreflightRequest must remain at vtable offset 22");
+static_assert(sizeof(flInferenceApi) == 23 * sizeof(void*), "flInferenceApi version 2 layout changed");
+
+static const flNodePrivateApi g_node_private_api = {
+    Node_Session_CaptureRequestPreflightImpl,
+    Node_RequestPreflightOperation_ExecuteImpl,
+    Node_RequestPreflightOperation_ReleaseImpl,
+};
 
 // ========================================================================
 // Sub-API accessors
@@ -1994,7 +2080,7 @@ static_assert(offsetof(flApi, Manager_GetCatalogByType) / sizeof(void*) == 29,
               "Size of version 2 API cannot change");
 
 // ========================================================================
-// Exported symbols — the ONLY symbols the library exports
+// Supported public exports. The private Node getter below is lockstep-only and not part of the SDK contract.
 // ========================================================================
 
 extern "C" {
@@ -2009,6 +2095,15 @@ FL_EXPORT const flApi* FL_API_CALL FoundryLocalGetApi(uint32_t version) FL_NO_EX
 
 FL_EXPORT const char* FL_API_CALL FoundryLocalGetVersionString(void) FL_NO_EXCEPTION {
   return FOUNDRY_LOCAL_VERSION;
+}
+
+FL_EXPORT const flNodePrivateApi* FL_API_CALL FoundryLocalGetNodePrivateApi(
+    uint32_t version, uint32_t size) FL_NO_EXCEPTION {
+  if (version != FOUNDRY_LOCAL_NODE_PRIVATE_API_VERSION || size != sizeof(flNodePrivateApi)) {
+    return nullptr;
+  }
+
+  return &g_node_private_api;
 }
 
 }  // extern "C"

--- a/sdk_v2/cpp/src/c_api_types.h
+++ b/sdk_v2/cpp/src/c_api_types.h
@@ -87,6 +87,17 @@ struct HandleImpl<flSession> {
 
 }  // namespace fl::detail
 
+namespace fl::detail {
+
+inline constexpr bool IsRequestPreflightVersionSupported(
+    uint32_t version,
+    uint32_t current_api_version = FOUNDRY_LOCAL_API_VERSION) noexcept {
+  return version >= FOUNDRY_LOCAL_REQUEST_PREFLIGHT_MIN_VERSION &&
+         version <= current_api_version;
+}
+
+}  // namespace fl::detail
+
 // Convert an internal fl::Xxx* to its opaque handle. Always pick the matching
 // handle type explicitly, e.g. AsHandle<flItem>(item_ptr).
 template <typename Handle, typename Impl>

--- a/sdk_v2/cpp/src/contracts/chat_completions_converter.cc
+++ b/sdk_v2/cpp/src/contracts/chat_completions_converter.cc
@@ -38,18 +38,8 @@ void ApplyCatalogDefaults(ChatCompletionRequest& req, const KeyValuePairs& model
     }
   };
 
-  auto apply_default_int = [&](const char* key, std::optional<int>& field) {
-    if (!field.has_value()) {
-      const char* val = model_settings.Find(key);
-      if (val) {
-        field = std::stoi(val);
-      }
-    }
-  };
-
   apply_default_float("temperature", req.temperature);
   apply_default_float("top_p", req.top_p);
-  apply_default_int("max_tokens", req.max_tokens);
 
   // top_k and random_seed go through metadata (matches C# behavior)
   if (!req.metadata.has_value()) {

--- a/sdk_v2/cpp/src/contracts/chat_completions_converter.h
+++ b/sdk_v2/cpp/src/contracts/chat_completions_converter.h
@@ -18,8 +18,8 @@ namespace chat_completions {
 /// Generate a random completion ID (e.g. "chatcmpl-abc123def").
 std::string GenerateCompletionId();
 
-/// Apply catalog model defaults to request fields the user didn't set.
-/// Reads directly from the model's model_settings map.
+/// Apply supported catalog sampling defaults to request fields the user didn't set.
+/// Output limits are request inputs and are not inferred from catalog model_settings.
 void ApplyCatalogDefaults(ChatCompletionRequest& req, const KeyValuePairs& model_settings);
 
 /// Map flFinishReason to OpenAI finish_reason string ("stop", "length", "tool_calls").

--- a/sdk_v2/cpp/src/exports.def
+++ b/sdk_v2/cpp/src/exports.def
@@ -3,6 +3,8 @@
 ; Using a .def file instead of __declspec(dllexport) allows the OBJECT library
 ; to compile sources once and share the object files between the shared (DLL)
 ; and static library targets.
+; FoundryLocalGetNodePrivateApi is a lockstep private bridge for the in-repo Node addon.
 EXPORTS
     FoundryLocalGetApi
     FoundryLocalGetVersionString
+    FoundryLocalGetNodePrivateApi

--- a/sdk_v2/cpp/src/inferencing/generative/chat/chat_generator.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/chat_generator.h
@@ -13,6 +13,7 @@
 namespace fl {
 
 class GenAIModelInstance;
+struct PreparedChatPrompt;
 struct TranscriptMessage;
 struct SearchOptions;
 struct ToolCallContext;
@@ -75,6 +76,13 @@ class ChatGenerator {
                              GenAIModelInstance& model,
                              const ToolCallContext& tool_ctx,
                              const SearchOptions& options) = 0;
+
+  /// Append the exact full-prompt artifact produced during request preparation.
+  virtual int AppendPreparedPrompt(const std::vector<TranscriptMessage>& new_messages,
+                                   const PreparedChatPrompt& prepared,
+                                   GenAIModelInstance& model,
+                                   const ToolCallContext& tool_ctx,
+                                   const SearchOptions& options) = 0;
 
   /// Whether the prompt for the active turn ends inside a reasoning block opened by the chat template.
   virtual bool PromptOpensReasoning() const { return false; }

--- a/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.cc
@@ -8,6 +8,8 @@
 #include "inferencing/generative/chat/media_input.h"
 #include "inferencing/generative/chat/onnx_chat_engine.h"
 #include "inferencing/generative/chat/onnx_chat_generator.h"
+#include "inferencing/generative/chat/prepared_chat_prompt.h"
+#include "inferencing/generative/chat/request_budget.h"
 #if FOUNDRY_LOCAL_OGA_HAS_DYNAMIC_ENGINE
 #include "inferencing/generative/chat/onnx_engine_chat_stream.h"
 #endif
@@ -26,12 +28,38 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <fmt/format.h>
+#include <mutex>
 #include <optional>
 #include <unordered_map>
 #include <utility>
 
 namespace fl {
+
+struct PreparedChatRequest {
+  Request request;
+  TranscriptIngest ingest;
+  MediaInput media;
+  ToolCallContext tool_context;
+  SearchOptions options;
+  ChatBackendKind backend_kind = ChatBackendKind::kGenerator;
+  std::string system_prompt;
+  std::vector<TranscriptMessage> all_messages;
+  PreparedChatPrompt prompt;
+  RequestBudget budget;
+  std::string json_model_name;
+  bool json_passthrough = false;
+};
+
+struct ChatSessionStateSnapshot {
+  Request request;
+  ChatTranscript transcript;
+  KeyValuePairs base_session_options;
+  SearchOptions chat_session_options;
+  std::vector<ToolDefinition> tool_definitions;
+  ModelInfo model_info;
+};
 
 namespace {
 
@@ -55,21 +83,31 @@ void ApplyToolChoiceToContext(std::optional<flToolChoice> tool_choice, ToolCallC
   }
 }
 
-std::unique_ptr<ChatGenerator> CreateTextChatGenerator(const std::vector<TranscriptMessage>& messages,
+std::unique_ptr<ChatGenerator> CreateTextChatGenerator(PreparedChatPrompt prepared,
                                                        const SearchOptions& options,
                                                        GenAIModelInstance& model,
                                                        const ToolCallContext& tool_ctx,
                                                        bool use_full_context) {
   if (model.GetGenAIConfig().GetChatBackendKind() != ChatBackendKind::kGenerator) {
 #if FOUNDRY_LOCAL_OGA_HAS_DYNAMIC_ENGINE
-    return OnnxEngineChatStream::Create(messages, options, model, tool_ctx);
+    return OnnxEngineChatStream::CreatePrepared(std::move(prepared), options, model, tool_ctx);
 #else
     FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL,
              "model requires the ORT GenAI dynamic Engine API, but this build does not provide it");
 #endif
   }
 
-  return OnnxChatGenerator::Create(messages, options, model, tool_ctx, use_full_context);
+  return OnnxChatGenerator::CreatePrepared(std::move(prepared), options, model, tool_ctx, use_full_context);
+}
+
+void FinalizePreparedRequest(PreparedChatRequest& prepared,
+                             GenAIModelInstance& model,
+                             bool media_turn) {
+  const auto& config = model.GetGenAIConfig();
+  const auto output_limit = ResolveOutputLimit(prepared.options, media_turn);
+  prepared.options.max_output_tokens = output_limit;
+  const int64_t context_limit = GetModelMaxContextLength(config);
+  prepared.budget = ComputeRequestBudget(prepared.prompt.prompt_token_count, output_limit, context_limit);
 }
 
 using TextSegment = ReasoningStreamSplitter::Segment;
@@ -78,6 +116,16 @@ using TextSegment = ReasoningStreamSplitter::Segment;
 std::string GetOptionOrEmpty(const KeyValuePairs& options, const char* key) {
   auto it = options.find(key);
   return it != options.end() ? it->second : std::string{};
+}
+
+KeyValuePairs MergeOptions(const KeyValuePairs& session_options,
+                           const KeyValuePairs& request_options) {
+  auto merged = session_options;
+  for (const auto& [key, value] : request_options) {
+    merged.Add(key, value);
+  }
+
+  return merged;
 }
 
 /// Use a model-published boundary ID only when its published text matches the configured marker.
@@ -355,15 +403,18 @@ void ChatSession::SetSessionOptionsImpl(const KeyValuePairs& options) {
   session_options_ = SearchOptions::FromParameters(options);
 }
 
-ToolCallContext ChatSession::BuildToolCallContext(const Request& request,
-                                                  const std::vector<ToolDefinition>& definitions) const {
+ToolCallContext BuildToolCallContext(const Request& request,
+                                     const std::vector<ToolDefinition>& tool_definitions,
+                                     const SearchOptions& session_options,
+                                     const ModelInfo& model_info,
+                                     GenAIModelInstance& model) {
   ToolCallContext tool_ctx;
 
   tool_ctx.tool_call_start = GetOptionOrEmpty(request.options, FOUNDRY_LOCAL_MODEL_PROP_TOOL_CALL_START_STR);
   tool_ctx.tool_call_end = GetOptionOrEmpty(request.options, FOUNDRY_LOCAL_MODEL_PROP_TOOL_CALL_END_STR);
 
   // Fall back to model info properties if not specified in the request
-  const auto& info = CatalogModel().Info();
+  const auto& info = model_info;
 
   // Check if the model supports tool calling
   const auto* tool_calling_val = info.GetPropertyInt(FOUNDRY_LOCAL_MODEL_PROP_SUPPORTS_TOOL_CALLING_INT);
@@ -388,7 +439,7 @@ ToolCallContext ChatSession::BuildToolCallContext(const Request& request,
   // Catalog metadata is immutable and may not contain markers for models whose
   // tokenizer defines them dynamically. Read those markers from the loaded GenAI
   // model without mutating the published ModelInfo.
-  const auto& tag_info = model_.GetTagInfo();
+  const auto& tag_info = model.GetTagInfo();
   if (tool_ctx.tool_call_start.empty()) {
     tool_ctx.tool_call_start = tag_info.bot_str;
   }
@@ -443,23 +494,15 @@ ToolCallContext ChatSession::BuildToolCallContext(const Request& request,
         ResolveMarkerTokenId(tool_ctx.reasoning_end, {tag_info.eor_id, tag_info.eor_str});
   }
 
-  // Accumulate tool definitions from the session.
-  // Tool definitions may come from two sources:
-  // 1. Individual AddToolDefinition calls (name + description + parameters schema)
-  // 2. ChatCompletions converter (pre-serialized full OpenAI tools JSON array, no name)
-  // We need to produce a JSON array in OpenAI tools format for the chat template.
-  // Custom tools are already normalized by the registry into a function-shaped schema, so the
-  // template and the guidance grammar only ever see function tools. Their kinds are carried on the
-  // context, so this turn's output is read back with exactly the tool set that shaped its prompt
-  // even if the session's registry changes underneath.
+  // Custom tools are normalized into function-shaped schemas by ToolRegistry. Keep their kinds on the immutable
+  // request context so prompt construction, replay normalization, and generated output use the same snapshot.
   nlohmann::json tools_array = nlohmann::json::array();
   bool has_preserialized = false;
 
-  tool_ctx.tool_kinds = KindsByName(definitions);
+  tool_ctx.tool_kinds = KindsByName(tool_definitions);
 
-  for (const auto& td : definitions) {
+  for (const auto& td : tool_definitions) {
     if (!td.name.empty()) {
-      // Individual tool: wrap in OpenAI format
       nlohmann::json tool;
       tool["type"] = "function";
       tool["function"]["name"] = td.name;
@@ -471,7 +514,6 @@ ToolCallContext ChatSession::BuildToolCallContext(const Request& request,
 
       tools_array.push_back(std::move(tool));
     } else if (!td.json_schema.empty()) {
-      // Pre-serialized from ChatCompletions path — already a complete tools array
       has_preserialized = true;
       tool_ctx.tools_json += td.json_schema;
     }
@@ -487,7 +529,7 @@ ToolCallContext ChatSession::BuildToolCallContext(const Request& request,
   // ParseToolChoice rejects unknown values with FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT.
   auto tool_choice = SearchOptions::ParseToolChoice(request.options);
   if (!tool_choice.has_value()) {
-    tool_choice = session_options_.tool_choice;
+    tool_choice = session_options.tool_choice;
   }
 
   if (tool_ctx.HasTools()) {
@@ -571,72 +613,214 @@ void ChatSession::ProcessGeneratedOutput(std::vector<GeneratedOutputEvent> event
                   total_tokens, prompt_tokens, completion_tokens, reasoning_tokens));
 }
 
-void ChatSession::ProcessRequestImpl(const Request& request, Response& response) {
-  // OpenAI chat completions JSON pass-through: a TEXT item tagged OPENAI_JSON. Routes to a separate handler that
-  // never uses the cached generator or the transcript (the JSON payload is self-contained).
+std::unique_ptr<PreparedChatRequest> PrepareChatRequest(
+    Request request_snapshot,
+    const ChatTranscript& transcript,
+    const KeyValuePairs& base_session_options,
+    const SearchOptions& chat_session_options,
+    const std::vector<ToolDefinition>& tool_definitions,
+    const ModelInfo& model_info,
+    GenAIModelInstance& model) {
+  auto prepared = std::make_unique<PreparedChatRequest>();
+  prepared->request = std::move(request_snapshot);
+  const auto& request = prepared->request;
+
   for (const auto* item : request.items) {
     if (item->type == FOUNDRY_LOCAL_ITEM_TEXT) {
       const auto& text_item = static_cast<const fl::TextItem&>(*item);
 
       if (text_item.text_type == FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON) {
-        ProcessChatCompletionsJson(text_item.text, request, response);
-        return;
+        auto request_json = nlohmann::json::parse(text_item.text);
+        auto chat_request = request_json.get<ChatCompletionRequest>();
+        chat_completions::ApplyCatalogDefaults(chat_request, model_info.model_settings);
+
+        Request internal_request;
+        chat_completions::BuildRequestItems(chat_request, internal_request);
+        if (internal_request.items.empty()) {
+          FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+                   "the request has nothing to generate from: `messages` carried no content");
+        }
+
+        std::string tools_json =
+            chat_completions::ExtractToolDefinitions(chat_request, internal_request);
+        chat_completions::MapRequestParameters(chat_request, internal_request);
+        chat_completions::MapGuidance(chat_request, internal_request);
+        chat_completions::MapStopSequences(chat_request, internal_request);
+
+        for (const auto& [key, value] : request.options) {
+          if (internal_request.options.find(key) == internal_request.options.end()) {
+            internal_request.options[key] = value;
+          }
+        }
+
+        const auto request_tool_definitions =
+            chat_session_internal::BuildJsonRequestToolDefinitions(std::move(tools_json), tool_definitions);
+
+        prepared->json_passthrough = true;
+        prepared->json_model_name = chat_request.model;
+        prepared->tool_context = BuildToolCallContext(internal_request, request_tool_definitions,
+                                                      chat_session_options, model_info, model);
+        auto effective_kvp = MergeOptions(base_session_options, internal_request.options);
+        prepared->options = SearchOptions::FromParameters(effective_kvp);
+        prepared->backend_kind = model.GetGenAIConfig().GetChatBackendKind();
+        prepared->all_messages =
+            BuildTranscriptMessages(internal_request.items, prepared->tool_context.tool_kinds);
+
+        const ChatTranscript payload_transcript;
+        payload_transcript.ValidateInputs(prepared->all_messages);
+        prepared->prompt =
+            PrepareTextChatPrompt(prepared->all_messages, model, prepared->tool_context);
+        FinalizePreparedRequest(*prepared, model, /*media_turn=*/false);
+        return prepared;
       }
     }
   }
 
-  // One snapshot of the session's tools for this whole turn, taken before anything reads them. The registry is safe
-  // to mutate from another thread while a request generates, so taking it once is what makes a turn
-  // self-consistent: the calls it replays, the prompt it builds, and the calls it produces are all resolved against
-  // the same tool set.
-  //
-  // A turn appended to a cached generator does not rebuild the prompt and so keeps the kinds from the turn that
-  // did. That stays consistent because a turn carrying tool activity always invalidates the cached generator
-  // below, so any turn that actually replays a call is also the turn that rebuilds the prompt from this snapshot.
-  auto turn_tool_ctx = BuildToolCallContext(request, ToolDefinitions());
+  prepared->tool_context =
+      BuildToolCallContext(request, tool_definitions, chat_session_options, model_info, model);
+  prepared->ingest =
+      IngestRequestItems(request.items, request.item_segment_starts, prepared->tool_context.tool_kinds);
+  transcript.ValidateInputs(prepared->ingest.messages);
+  prepared->media = CollectMediaInput(request);
+  ValidateMediaTurn(prepared->media, prepared->ingest.messages,
+                    {.session_has_history = !transcript.Empty(),
+                     .tools_declared = prepared->tool_context.HasTools()});
 
-  // Collect this turn's input messages locally — nothing reaches the transcript until the turn commits. Replay
-  // segment boundaries travel with the items so a reconstructed conversation regroups exactly as it was committed.
-  //
-  // Replayed tool calls are normalized with this turn's kinds: a custom tool's call comes back as the text payload
-  // this session handed out, so it must be rewrapped rather than rejected as malformed JSON.
-  auto ingest = IngestRequestItems(request.items, request.item_segment_starts, turn_tool_ctx.tool_kinds);
-  auto inputs = std::move(ingest.messages);
+  auto effective_kvp = MergeOptions(base_session_options, request.options);
+  prepared->options = SearchOptions::FromParameters(effective_kvp);
+  prepared->backend_kind = model.GetGenAIConfig().GetChatBackendKind();
+  prepared->system_prompt = GetOptionOrEmpty(effective_kvp, kSystemPromptOption);
+  const bool media_turn = !prepared->media.Empty();
 
-  // Reject bad tool-call correlation before any generator work: a rejected turn must cost nothing and leave no
-  // state. This runs before the has-anything-to-say check below so a tool result that answers nothing is reported
-  // as the correlation error it is — an empty result for an unknown call ID is a broken conversation, not an
-  // empty request.
-  transcript_.ValidateInputs(inputs);
-
-  // Media is single-shot. One conversation-scoped rule covers a live session and a conversation replayed into this
-  // request after the session cache dropped it, so a continuation is rejected identically either way.
-  auto media = CollectMediaInput(request);
-  const bool media_turn = !media.Empty();
-  ValidateMediaTurn(media, inputs,
-                    {.session_has_history = !transcript_.Empty(), .tools_declared = turn_tool_ctx.HasTools()});
-
-  // Merge session-level and per-request options once for this turn.
-  auto effective_kvp = MergedOptions(request.options);
-  SearchOptions effective_options = SearchOptions::FromParameters(effective_kvp);
-  const ChatBackendKind backend_kind = Model().GetGenAIConfig().GetChatBackendKind();
-
-  // Request-scoped system prefix. It is not conversation history: it never enters the transcript, so it cannot
-  // accumulate a copy per turn, and the value this request carries is the only one used. It is baked into a
-  // generator's prompt, so a changed prefix has to rebuild while an unchanged one keeps the KV cache.
-  const std::string turn_system_prompt = GetOptionOrEmpty(effective_kvp, kSystemPromptOption);
-
-  // One gate for every way a turn can carry meaning: its own messages, media bytes, the conversation behind it, or
-  // the instructions in front of it. A turn with none of them is the caller's mistake, so it is a client error —
-  // and a turn with any of them generates, whether the conversation is held in this session or was replayed into
-  // the request after the cache dropped it.
-  if (!TurnCanGenerate(inputs, {.media = media_turn,
-                                .history = !transcript_.Empty(),
-                                .system_prefix = !turn_system_prompt.empty()})) {
+  if (!TurnCanGenerate(prepared->ingest.messages,
+                       {.media = media_turn,
+                        .history = !transcript.Empty(),
+                        .system_prefix = !prepared->system_prompt.empty()})) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
              "the request has nothing to generate from: no message content, no image or audio, no instructions, "
              "and no conversation to continue");
   }
+
+  const auto& committed = transcript.Messages();
+  prepared->all_messages.reserve(
+      committed.size() + prepared->ingest.messages.size() + (prepared->system_prompt.empty() ? 0u : 1u));
+  prepared->all_messages.insert(prepared->all_messages.end(), committed.begin(), committed.end());
+  prepared->all_messages.insert(
+      prepared->all_messages.end(), prepared->ingest.messages.begin(), prepared->ingest.messages.end());
+  prepared->all_messages = WithSystemPrompt(prepared->system_prompt, std::move(prepared->all_messages));
+
+  if (media_turn) {
+    auto media_messages = prepared->media.messages;
+    if (!prepared->system_prompt.empty()) {
+      media_messages.insert(
+          media_messages.begin(), MessageItem(FOUNDRY_LOCAL_ROLE_SYSTEM, prepared->system_prompt));
+    }
+
+    prepared->prompt =
+        PrepareMediaChatPrompt(media_messages, model, prepared->media.images, prepared->media.audios,
+                               prepared->tool_context);
+  } else {
+    prepared->prompt = PrepareTextChatPrompt(prepared->all_messages, model, prepared->tool_context);
+  }
+
+  FinalizePreparedRequest(*prepared, model, media_turn);
+  return prepared;
+}
+
+namespace {
+
+class ChatRequestPreflightOperation final : public Session::RequestPreflightOperation {
+ public:
+  ChatRequestPreflightOperation(ChatSessionStateSnapshot state, GenAIModelInstance& model)
+      : state_(std::move(state)), model_(model) {
+    // Match ChatSession's loaded-model lease so the immutable tokenizer/config
+    // services remain valid even if the originating session is released.
+    model_.AcquireSession();
+  }
+
+  ~ChatRequestPreflightOperation() override {
+    model_.ReleaseSession();
+  }
+
+  RequestBudget Execute() override {
+    ChatSessionStateSnapshot state;
+    {
+      std::lock_guard lock(mutex_);
+      if (!state_.has_value()) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_USAGE, "request preflight operation has already been executed");
+      }
+
+      state = std::move(*state_);
+      state_.reset();
+    }
+
+    const auto prepared =
+        PrepareChatRequest(std::move(state.request), state.transcript, state.base_session_options,
+                           state.chat_session_options, state.tool_definitions, state.model_info, model_);
+    return prepared->budget;
+  }
+
+ private:
+  std::mutex mutex_;
+  std::optional<ChatSessionStateSnapshot> state_;
+  GenAIModelInstance& model_;
+};
+
+}  // namespace
+
+ChatSessionStateSnapshot ChatSession::CaptureState(Request request) const {
+  auto state_lock = LockStateMutex();
+  return {
+      .request = std::move(request),
+      .transcript = transcript_,
+      .base_session_options = SessionOptionsLocked(),
+      .chat_session_options = session_options_,
+      .tool_definitions = ToolDefinitionsLocked(),
+      .model_info = CatalogModel().Info(),
+  };
+}
+
+RequestBudget ChatSession::PreflightRequest(const Request& request) const {
+  return CaptureRequestPreflight(request)->Execute();
+}
+
+std::unique_ptr<Session::RequestPreflightOperation> ChatSession::CaptureRequestPreflight(
+    const Request& request) const {
+  auto snapshot = request.CapturePreflightSnapshot();
+  ValidateRequestItems(snapshot);
+  auto state = CaptureState(std::move(snapshot));
+  return std::make_unique<ChatRequestPreflightOperation>(std::move(state), model_);
+}
+
+void ChatSession::ProcessRequestImpl(const Request& request, Response& response) {
+  auto state = CaptureState(request.CapturePreflightSnapshot());
+  auto prepared_owner =
+      PrepareChatRequest(std::move(state.request), state.transcript, state.base_session_options,
+                         state.chat_session_options, state.tool_definitions, state.model_info, model_);
+  auto& prepared = *prepared_owner;
+
+  if (!prepared.budget.fits) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+             "request requires " + std::to_string(prepared.budget.required_tokens) + " total tokens (" +
+                 std::to_string(prepared.budget.prompt_tokens) + " input + " +
+                 std::to_string(prepared.budget.output_reserve_tokens) +
+                 " output), which exceeds the model's maximum context length of " +
+                 std::to_string(prepared.budget.context_limit_tokens) + " tokens");
+  }
+
+  if (prepared.json_passthrough) {
+    ProcessChatCompletionsJson(prepared, request, response);
+    return;
+  }
+
+  auto& ingest = prepared.ingest;
+  auto& inputs = ingest.messages;
+  auto& media = prepared.media;
+  const bool media_turn = !media.Empty();
+  auto& turn_tool_ctx = prepared.tool_context;
+  auto& effective_options = prepared.options;
+  const auto backend_kind = prepared.backend_kind;
+  const auto& turn_system_prompt = prepared.system_prompt;
 
   int prompt_tokens = 0;
   // Empty until this turn's input is appended to an existing generator. A rebuilt generator bakes the input into its
@@ -645,13 +829,6 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
 
   // The complete authoritative prompt for this turn. Engine uses this to verify that its resident raw tokens are an
   // exact prefix before reusing them; otherwise it replaces the conversation and submits the full prompt.
-  std::vector<TranscriptMessage> all_messages;
-  const auto& committed = transcript_.Messages();
-  all_messages.reserve(committed.size() + inputs.size() + (turn_system_prompt.empty() ? 0u : 1u));
-  all_messages.insert(all_messages.end(), committed.begin(), committed.end());
-  all_messages.insert(all_messages.end(), inputs.begin(), inputs.end());
-  all_messages = WithSystemPrompt(turn_system_prompt, std::move(all_messages));
-
   // Classic Generator cannot append tool exchanges or a changed prefix in isolation. Engine always renders the full
   // transcript and performs token-prefix reconciliation, so it can decide safely whether to reuse or replace state.
   const bool retained_tool_context_changed =
@@ -708,7 +885,7 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
   if (cached_generator_) {
     pre_turn_token_count = cached_generator_->TokenCount();
     try {
-      cached_generator_->AppendMessages(inputs, all_messages, Model(), turn_tool_ctx, effective_options);
+      cached_generator_->AppendPreparedPrompt(inputs, prepared.prompt, Model(), turn_tool_ctx, effective_options);
       prompt_tokens = cached_generator_->TokenCount();
       cached_tool_ctx_ = turn_tool_ctx;
     } catch (const RetainedPromptMismatchError&) {
@@ -727,15 +904,10 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
     if (media_turn) {
       // Media is single-shot: the generator is dropped after the turn because retained text state cannot reconstruct
       // media bytes. The system prefix is projected into the media prompt but never enters the transcript.
-      auto media_messages = std::move(media.messages);
-      if (!turn_system_prompt.empty()) {
-        media_messages.insert(media_messages.begin(), MessageItem(FOUNDRY_LOCAL_ROLE_SYSTEM, turn_system_prompt));
-      }
-
-      generator = OnnxChatGenerator::CreateWithMedia(media_messages, effective_options, Model(), media.images,
-                                                     media.audios, tool_ctx, /*use_full_context*/ false);
+      generator = OnnxChatGenerator::CreatePrepared(std::move(prepared.prompt), effective_options, Model(), tool_ctx,
+                                                    /*use_full_context=*/false);
     } else {
-      generator = CreateTextChatGenerator(all_messages, effective_options, Model(), tool_ctx,
+      generator = CreateTextChatGenerator(std::move(prepared.prompt), effective_options, Model(), tool_ctx,
                                           /*use_full_context=*/true);
     }
 
@@ -748,7 +920,12 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
 
   std::optional<int> host_max_output;
   if (chat_session_internal::ShouldEnforceHostOutputLimit(backend_kind, media_turn)) {
-    host_max_output = ResolveMaxOutputTokens(effective_options, GetDefaultMaxOutputTokens(media_turn));
+    if (!effective_options.max_output_tokens.has_value()) {
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL,
+               "max_output_tokens must be resolved before generation");
+    }
+
+    host_max_output = effective_options.max_output_tokens;
   }
 
   // Generate token-by-token with optional streaming.
@@ -887,6 +1064,8 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
   const bool generated_tool_calls = assistant_message.HasToolCalls();
 
   if (!request.canceled) {
+    auto state_lock = LockStateMutex();
+
     // Reject a generation whose calls cannot be correlated before it reaches the caller — a committed turn must never
     // leave the outstanding-call set inconsistent.
     transcript_.ValidateGeneratedOutput(assistant_message);
@@ -926,8 +1105,11 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
 
   // The reply may only merge into an input message from the last replay segment — this request's own input. Merging
   // into an earlier hop's assistant message would glue two recorded turns together.
-  transcript_.CommitTurn(std::move(inputs), std::move(assistant_message),
-                         {pre_turn_token_count, total_tokens}, ingest.last_segment_start);
+  {
+    auto state_lock = LockStateMutex();
+    transcript_.CommitTurn(std::move(inputs), std::move(assistant_message),
+                           {pre_turn_token_count, total_tokens}, ingest.last_segment_start);
+  }
   turn_committed = true;
 
   if (discard_after_success || media_turn || generated_tool_calls || turn_guard.TurnEnded()) {
@@ -935,71 +1117,20 @@ void ChatSession::ProcessRequestImpl(const Request& request, Response& response)
   }
 }
 
-void ChatSession::ProcessChatCompletionsJson(const std::string& request_json, const Request& original_request,
+void ChatSession::ProcessChatCompletionsJson(PreparedChatRequest& prepared,
+                                             const Request& original_request,
                                              Response& response) {
-  // Consult mutable session state exactly once. JSON requests otherwise derive their complete tool
-  // context from their own payload, so later registration cannot alter this request's interpretation.
-  const auto session_tool_definitions = ToolDefinitions();
-
-  // Parse the OpenAI chat completions request
-  auto req_json = nlohmann::json::parse(request_json);
-  auto req = req_json.get<ChatCompletionRequest>();
-
-  // Apply catalog defaults passed via request options
-  chat_completions::ApplyCatalogDefaults(req, CatalogModel().Info().model_settings);
-
-  std::string model_name = req.model;
+  const std::string& model_name = prepared.json_model_name;
   std::string completion_id = chat_completions::GenerateCompletionId();
   auto now = std::chrono::system_clock::now();
   int64_t created = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
 
-  // Build the internal request from the chat completions request
-  Request internal_request;
-
-  // We don't use history_ for this request as it's for backwards compat and all messages come from the input.
-  chat_completions::BuildRequestItems(req, internal_request);
-  if (internal_request.items.empty()) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-             "the request has nothing to generate from: `messages` carried no content");
-  }
-
-  std::string tools_json = chat_completions::ExtractToolDefinitions(req, internal_request);
-  chat_completions::MapRequestParameters(req, internal_request);
-  chat_completions::MapGuidance(req, internal_request);
-  chat_completions::MapStopSequences(req, internal_request);
-
-  // Merge options from the original request (e.g. tool_call_start/end from model properties)
-  for (const auto& [key, value] : original_request.options) {
-    if (internal_request.options.find(key) == internal_request.options.end()) {
-      internal_request.options[key] = value;
-    }
-  }
-
-  // Build a request-local tool definition. It must never enter the session registry: this payload
-  // is self-contained and concurrent registration must not alter either its prompt or call parsing.
-  const auto request_tool_definitions =
-      chat_session_internal::BuildJsonRequestToolDefinitions(std::move(tools_json),
-                                                             session_tool_definitions);
-
-  const auto tool_ctx = BuildToolCallContext(internal_request, request_tool_definitions);
-
-  // Merge session-level and per-request options once.
-  auto effective_kvp = MergedOptions(internal_request.options);
-  SearchOptions options = SearchOptions::FromParameters(effective_kvp);
-
-  // Collect transcript messages from the internal request for the generator.
-  // The session transcript is not used here — everything comes from the parsed JSON input.
-  // The context above already snapshotted the kinds that shape this prompt, so replayed calls in the payload are
-  // normalized with exactly the kinds the produced calls are read back with.
-  auto messages = BuildTranscriptMessages(internal_request.items, tool_ctx.tool_kinds);
-
-  // The payload is self-contained, so correlate its tool calls and results against an empty transcript. This gives
-  // the same stable errors a session turn would produce for a history the model cannot interpret.
-  const ChatTranscript payload_transcript;
-  payload_transcript.ValidateInputs(messages);
+  auto& tool_ctx = prepared.tool_context;
+  auto& options = prepared.options;
+  auto& messages = prepared.all_messages;
 
   // Create generator
-  auto generator = CreateTextChatGenerator(messages, options, Model(), tool_ctx,
+  auto generator = CreateTextChatGenerator(std::move(prepared.prompt), options, Model(), tool_ctx,
                                            /*use_full_context=*/false);
   int prompt_tokens = generator->PromptTokenCount();
 
@@ -1183,6 +1314,7 @@ void ChatSession::InvalidateCachedGenerator() noexcept {
 }
 
 size_t ChatSession::TurnCount() const {
+  auto state_lock = LockStateMutex();
   return transcript_.TurnCount();
 }
 
@@ -1193,10 +1325,15 @@ void ChatSession::UndoTurns(size_t count) {
     return;
   }
 
-  const bool undo_all = count == transcript_.TurnCount();
+  bool undo_all = false;
+  ChatTranscript::TurnTokens tokens;
+  {
+    auto state_lock = LockStateMutex();
+    undo_all = count == transcript_.TurnCount();
 
-  // The transcript validates `count` and rolls back messages, turn records, and outstanding-call state as one step.
-  auto tokens = transcript_.UndoTurns(count);
+    // The transcript validates `count` and rolls back messages, turn records, and outstanding-call state as one step.
+    tokens = transcript_.UndoTurns(count);
+  }
 
   if (!cached_generator_) {
     return;
@@ -1219,6 +1356,7 @@ void ChatSession::UndoTurns(size_t count) {
 }
 
 size_t ChatSession::MessageCount() const {
+  auto state_lock = LockStateMutex();
   return transcript_.MessageCount();
 }
 

--- a/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/chat_session.h
@@ -4,6 +4,7 @@
 
 #include "inferencing/generative/chat/chat_transcript.h"
 #include "inferencing/generative/chat/reasoning_stream_splitter.h"
+#include "inferencing/generative/chat/request_budget.h"
 #include "inferencing/generative/chat/search_options.h"
 #include "inferencing/generative/chat/stop_strings.h"
 #include "inferencing/generative/toolcalling/tool_call_context.h"
@@ -24,6 +25,8 @@ namespace fl {
 
 class GenAIModelInstance;
 class ChatGenerator;
+struct PreparedChatRequest;
+struct ChatSessionStateSnapshot;
 
 namespace chat_session_internal {
 
@@ -117,6 +120,8 @@ using GeneratedOutputEvent = std::variant<ReasoningStreamSplitter::Segment, Pars
 /// Designed for multi-turn conversations where visible text, reasoning, and tool calls accumulate in event order
 /// and are sent with each generation request (for use with the OpenAI Responses API pattern).
 ///
+class ChatSessionTestAccessor;
+
 /// Retained inference state: compatible turns reuse backend state. Engine backends render the complete authoritative
 /// transcript and reuse resident tokens only when they are an exact prefix; classic Generator backends rebuild for
 /// transcript shapes that cannot be appended independently.
@@ -157,19 +162,24 @@ class ChatSession : public Session {
   /// @param count  Number of turns to undo. Must be <= TurnCount().
   void UndoTurns(size_t count) override;
 
+  /// Prepare and budget a request without admitting it to the request lifecycle or mutating session state.
+  RequestBudget PreflightRequest(const Request& request) const;
+
+  /// Capture mutable request and session inputs for asynchronous preparation. Inline bytes are frozen now;
+  /// URI-backed media is materialized when the operation executes.
+  std::unique_ptr<RequestPreflightOperation> CaptureRequestPreflight(const Request& request) const;
+
  private:
+  friend class ChatSessionTestAccessor;
+
   // populate session_options_
   void SetSessionOptionsImpl(const KeyValuePairs& options) override;
+
+  ChatSessionStateSnapshot CaptureState(Request request) const;
 
   /// Process a request: extracts items and parameters from the generic request, generates a response, and on
   /// success commits the turn to the transcript.
   void ProcessRequestImpl(const Request& request, Response& response) override;
-
-  /// Build tool calling context from request parameters and a snapshot of the session's tool definitions.
-  ///
-  /// The snapshot is supplied by the caller rather than read here so that one turn resolves its replayed calls, its
-  /// prompt, and its produced calls against the same tool set.
-  ToolCallContext BuildToolCallContext(const Request& request, const std::vector<ToolDefinition>& definitions) const;
 
   /// Build final response items from the typed segments and tool calls produced during generation.
   void ProcessGeneratedOutput(std::vector<GeneratedOutputEvent> events,
@@ -188,7 +198,7 @@ class ChatSession : public Session {
   /// request. Parses the JSON, converts to internal items, runs generation, and produces an OPENAI_JSON-tagged
   /// TextItem response with the OpenAI ChatCompletionResponse.
   /// Does not use or update the transcript or the cached generator.
-  void ProcessChatCompletionsJson(const std::string& request_json, const Request& original_request,
+  void ProcessChatCompletionsJson(PreparedChatRequest& preparation, const Request& original_request,
                                   Response& response);
 
   /// Drop the cached generator and its tool context. Called whenever the generator's KV cache can no longer be

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_engine.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_engine.cc
@@ -17,13 +17,10 @@ namespace fl {
 
 namespace {
 
-// Only options the caller expressed are set. Upstream treats an unset turn option as "use the model-configured
-// default for this Turn", so forwarding a Foundry-invented default would silently override model policy — and an
-// explicit do_sample=true is rejected outright when the model's own defaults still resolve the turn to greedy.
+// Sampling fields remain optional so model policy applies when the caller omitted them. The
+// output limit is always resolved by request preparation before the turn reaches Engine.
 void ApplyEngineTurnOptions(const EngineTurnOptionsPlan& plan, OgaTurnOptions& options) {
-  if (plan.max_generated_tokens.has_value()) {
-    options.SetMaxGeneratedTokens(static_cast<uint64_t>(*plan.max_generated_tokens));
-  }
+  options.SetMaxGeneratedTokens(static_cast<uint64_t>(plan.max_generated_tokens));
 
   if (plan.sampling.do_sample.has_value()) {
     options.SetDoSample(*plan.sampling.do_sample);
@@ -170,21 +167,18 @@ uint64_t OnnxChatEngine::BeginTurn(const std::shared_ptr<Conversation>& conversa
 
         auto plan = BuildEngineTurnOptionsPlan(options, tool_ctx, model_.GetGenAIConfig().GetChatBackendKind(),
                                                prompt_opens_reasoning);
-        if (plan.max_generated_tokens.has_value()) {
-          // Validate only the limit the caller requested. When it is absent, leave the turn uncapped and let OGA
-          // enforce the Request's model-context session limit.
-          const uint64_t total_required =
-              static_cast<uint64_t>(existing_tokens) + static_cast<uint64_t>(tokens.size()) +
-              static_cast<uint64_t>(*plan.max_generated_tokens);
-          const uint64_t model_max_tokens = static_cast<uint64_t>(GetModelMaxContextLength(model_.GetGenAIConfig()));
-          if (total_required > model_max_tokens) {
-            FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-                     "request requires " + std::to_string(total_required) + " total tokens (" +
-                         std::to_string(existing_tokens) + " existing + " + std::to_string(tokens.size()) +
-                         " input + " + std::to_string(*plan.max_generated_tokens) +
-                         " output), which exceeds the model's maximum context length of " +
-                         std::to_string(model_max_tokens) + " tokens");
-          }
+        const uint64_t total_required =
+            static_cast<uint64_t>(existing_tokens) + static_cast<uint64_t>(tokens.size()) +
+            static_cast<uint64_t>(plan.max_generated_tokens);
+        const uint64_t model_max_tokens =
+            static_cast<uint64_t>(GetModelMaxContextLength(model_.GetGenAIConfig()));
+        if (total_required > model_max_tokens) {
+          FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+                   "request requires " + std::to_string(total_required) + " total tokens (" +
+                       std::to_string(existing_tokens) + " existing + " + std::to_string(tokens.size()) +
+                       " input + " + std::to_string(plan.max_generated_tokens) +
+                       " output), which exceeds the model's maximum context length of " +
+                       std::to_string(model_max_tokens) + " tokens");
         }
 
         ApplyEngineTurnOptions(plan, *turn_options);

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.cc
@@ -187,13 +187,20 @@ int OnnxChatGenerator::AppendMessages(const std::vector<TranscriptMessage>& new_
     FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "new_messages and full_messages must not be empty");
   }
 
-  // Render and tokenize the authoritative full transcript once. Generated text is not guaranteed to round-trip
-  // through decode/encode to the same token IDs, so resident state is reusable only when it is an exact prefix.
-  std::string prompt = BuildChatPrompt(full_messages, model, tool_ctx.tools_json);
-  auto full_sequences = EncodePrompt(prompt, model);
-  const auto full_count = full_sequences->SequenceCount(0);
-  const auto* full_data = full_sequences->SequenceData(0);
-  const std::span<const int32_t> full_prompt(full_data, full_count);
+  auto prepared = PrepareTextChatPrompt(full_messages, model, tool_ctx);
+  return AppendPreparedPrompt(new_messages, prepared, model, tool_ctx, SearchOptions{});
+}
+
+int OnnxChatGenerator::AppendPreparedPrompt(const std::vector<TranscriptMessage>& new_messages,
+                                            const PreparedChatPrompt& prepared,
+                                            GenAIModelInstance& /*model*/,
+                                            const ToolCallContext& /*tool_ctx*/,
+                                            const SearchOptions& /*options*/) {
+  if (new_messages.empty() || prepared.token_ids.empty()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "new_messages and prepared prompt must not be empty");
+  }
+
+  const std::span<const int32_t> full_prompt(prepared.token_ids);
   const std::span<const int32_t> resident(generator_->GetSequenceData(0), generator_->GetSequenceCount(0));
   const auto suffix_start = chat_internal::FindUnmatchedPromptSuffix(resident, full_prompt);
   if (!suffix_start.has_value()) {
@@ -217,7 +224,10 @@ int OnnxChatGenerator::AppendMessages(const std::vector<TranscriptMessage>& new_
 
   // Re-probe: the appended segment ends with this turn's assistant generation prefix, so it — not the original
   // prompt — determines whether generation resumes inside a template-opened reasoning block.
-  prompt_opens_reasoning_ = DetectPromptOpensReasoning(prompt, full_sequences.get(), reasoning_markers_);
+  auto full_sequences = OgaSequences::Create();
+  full_sequences->Append(prepared.token_ids.data(), prepared.token_ids.size());
+  prompt_opens_reasoning_ =
+      DetectPromptOpensReasoning(prepared.prompt, full_sequences.get(), reasoning_markers_);
 
   return static_cast<int>(suffix.size());
 }
@@ -298,8 +308,7 @@ std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::Create(const std::vector<T
     FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "messages must not be empty");
   }
 
-  std::string prompt = BuildChatPrompt(messages, model, tool_ctx.tools_json);
-  return CreateImpl(prompt, options, model, tool_ctx, use_full_context, /*images=*/{}, /*audios=*/{});
+  return CreatePrepared(PrepareTextChatPrompt(messages, model, tool_ctx), options, model, tool_ctx, use_full_context);
 }
 
 std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateWithMedia(
@@ -310,127 +319,46 @@ std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateWithMedia(
     const std::vector<const AudioItem*>& audios,
     const ToolCallContext& tool_ctx,
     bool use_full_context) {
-  if (messages.empty()) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "messages must not be empty");
-  }
-
-  if (images.empty() && audios.empty()) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-             "CreateWithMedia requires at least one image or audio input");
-  }
-
-  if (!model.IsMultiModal()) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "image or audio input requires a multimodal model");
-  }
-
-  if (!model.GetPreprocessor().HasMultiModalProcessor()) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "model has no multimodal processor available for media input");
-  }
-
-  std::string messages_json = TransformMessagesForMedia(messages);
-  const char* tools_ptr = tool_ctx.tools_json.empty() ? nullptr : tool_ctx.tools_json.c_str();
-  std::string prompt =
-      model.GetPreprocessor().ApplyChatTemplate(messages_json.c_str(), tools_ptr, /*add_generation_prompt=*/true);
-
-  return CreateImpl(prompt, options, model, tool_ctx, use_full_context, images, audios);
+  return CreatePrepared(PrepareMediaChatPrompt(messages, model, images, audios, tool_ctx), options, model, tool_ctx,
+                        use_full_context);
 }
 
-std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateImpl(const std::string& prompt,
+std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreatePrepared(PreparedChatPrompt prepared,
+                                                                     const SearchOptions& options,
+                                                                     GenAIModelInstance& model,
+                                                                     const ToolCallContext& tool_ctx,
+                                                                     bool use_full_context) {
+  return CreateImpl(std::move(prepared), options, model, tool_ctx, use_full_context);
+}
+
+std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateImpl(PreparedChatPrompt prepared,
                                                                  const SearchOptions& options,
                                                                  GenAIModelInstance& model,
                                                                  const ToolCallContext& tool_ctx,
-                                                                 bool use_full_context,
-                                                                 const std::vector<const ImageItem*>& images,
-                                                                 const std::vector<const AudioItem*>& audios) {
-  const bool media_branch = !images.empty() || !audios.empty();
-
-  // 1. Token budgeting.
-  //    Text path: encode the prompt up front so we know its token count.
-  //    Media path: process inputs first and read the expanded input_ids shape.
+                                                                 bool use_full_context) {
+  const bool media_branch = prepared.HasMedia();
   std::unique_ptr<OgaSequences> sequences;
-  int input_token_count = 0;
-
   if (!media_branch) {
-    sequences = EncodePrompt(prompt, model);
-    input_token_count = static_cast<int>(sequences->SequenceCount(0));
+    sequences = OgaSequences::Create();
+    sequences->Append(prepared.token_ids.data(), prepared.token_ids.size());
   }
 
-  // Process media before sizing the generator so max_length includes the
-  // exact token expansion produced by the multimodal processor.
-  std::unique_ptr<OgaNamedTensors> named_tensors;
-  if (media_branch) {
-    std::unique_ptr<OgaImages> oga_images;
-    if (!images.empty()) {
-      std::vector<std::vector<std::uint8_t>> image_bytes;
-      image_bytes.reserve(images.size());
-      std::vector<const void*> buffers;
-      buffers.reserve(images.size());
-      std::vector<size_t> sizes;
-      sizes.reserve(images.size());
-
-      for (const auto* img : images) {
-        if (img == nullptr) {
-          FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "image entry must not be null");
-        }
-
-        image_bytes.push_back(img->ReadBytes());
-        buffers.push_back(image_bytes.back().data());
-        sizes.push_back(image_bytes.back().size());
-      }
-
-      oga_images = OgaImages::Load(buffers.data(), sizes.data(), buffers.size());
-    }
-
-    std::unique_ptr<OgaAudios> oga_audios;
-    if (!audios.empty()) {
-      std::vector<const void*> audio_buffers;
-      audio_buffers.reserve(audios.size());
-      std::vector<size_t> audio_sizes;
-      audio_sizes.reserve(audios.size());
-      for (const auto* audio : audios) {
-        if (audio == nullptr || audio->data == nullptr || audio->data_size == 0) {
-          FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "audio entry must contain bytes");
-        }
-        audio_buffers.push_back(audio->data);
-        audio_sizes.push_back(audio->data_size);
-      }
-
-      oga_audios = OgaAudios::Load(audio_buffers.data(), audio_sizes.data(), audio_buffers.size());
-    }
-
-    named_tensors = model.GetPreprocessor().ProcessMedia(prompt.c_str(), oga_images.get(), oga_audios.get());
-    auto input_ids = named_tensors->Get("input_ids");
-    auto input_shape = input_ids->Shape();
-    if (input_shape.empty() || input_shape.back() <= 0) {
-      FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "multimodal processor returned invalid input_ids");
-    }
-    input_token_count = static_cast<int>(input_shape.back());
-  }
-
-  // 2. Create GeneratorParams from the model
   auto gen_params = OgaGeneratorParams::Create(model.GetOgaModel());
 
-  // 3. Apply search options (temperature, top_p, max_length, etc.) and validate token budget.
-  //    Media inputs use a larger default because preprocessing expands them into tokens.
-  ApplySearchOptions(options, input_token_count, model.GetGenAIConfig(), *gen_params, model.EP(),
-                     use_full_context, GetDefaultMaxOutputTokens(media_branch));
+  ApplySearchOptions(options, prepared.prompt_token_count, model.GetGenAIConfig(), *gen_params, model.EP(),
+                     use_full_context, media_branch);
 
-  // 4. Build guidance from the actual rendered prompt state, then reuse that state to seed stream reasoning.
   auto reasoning_markers = ResolveReasoningMarkers(tool_ctx, model);
-  const bool prompt_opens_reasoning = DetectPromptOpensReasoning(prompt, sequences.get(), reasoning_markers);
+  const bool prompt_opens_reasoning =
+      DetectPromptOpensReasoning(prepared.prompt, sequences.get(), reasoning_markers);
   ApplyGuidanceOptions(tool_ctx, prompt_opens_reasoning, *gen_params);
 
-  // 5. Create the Generator and feed it the prompt.
-  //    Text path: append the encoded token sequences.
-  //    Media path: process inputs via OgaMultiModalProcessor and feed the
-  //    resulting named tensors via SetInputs (which extracts input_ids and
-  //    appends them internally — do NOT also call AppendTokenSequences).
   std::unique_ptr<OgaGenerator> generator;
   try {
     generator = OgaGenerator::Create(model.GetOgaModel(), *gen_params);
 
     if (media_branch) {
-      generator->SetInputs(*named_tensors);
+      generator->SetInputs(*prepared.media_tensors);
     } else {
       generator->AppendTokenSequences(*sequences);
     }
@@ -438,7 +366,6 @@ std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateImpl(const std::stri
     FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, std::string("failed to create generator: ") + e.what());
   }
 
-  // 6. Create tokenizer stream (single-decode path).
   auto stream = model.GetPreprocessor().CreateTokenizerStream();
 
   // `std::make_unique` constructs inside the library helper, which does not have
@@ -447,10 +374,10 @@ std::unique_ptr<OnnxChatGenerator> OnnxChatGenerator::CreateImpl(const std::stri
                                                                   std::move(generator),
                                                                   std::move(stream),
                                                                   model,
-                                                                  input_token_count,
+                                                                  static_cast<int>(prepared.prompt_token_count),
                                                                   std::move(reasoning_markers),
                                                                   prompt_opens_reasoning,
-                                                                  std::move(named_tensors)));
+                                                                  std::move(prepared.media_tensors)));
 }
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_chat_generator.h
@@ -4,6 +4,7 @@
 
 #include "inferencing/generative/chat/chat_generator.h"
 #include "inferencing/generative/chat/chat_template.h"
+#include "inferencing/generative/chat/prepared_chat_prompt.h"
 #include "inferencing/generative/chat/reasoning_stream_splitter.h"
 #include "inferencing/generative/chat/search_options.h"
 #include "inferencing/generative/toolcalling/tool_call_context.h"
@@ -61,6 +62,11 @@ class OnnxChatGenerator : public ChatGenerator {
                      GenAIModelInstance& model,
                      const ToolCallContext& tool_ctx,
                      const SearchOptions& options) override;
+  int AppendPreparedPrompt(const std::vector<TranscriptMessage>& new_messages,
+                           const PreparedChatPrompt& prepared,
+                           GenAIModelInstance& model,
+                           const ToolCallContext& tool_ctx,
+                           const SearchOptions& options) override;
 
   /// Rewind the generator to a previous token position.
   /// Used for error recovery — restores the KV cache to the state before the last turn.
@@ -98,6 +104,13 @@ class OnnxChatGenerator : public ChatGenerator {
       const ToolCallContext& tool_ctx = {},
       bool use_full_context = false);
 
+  /// Create a generator from the exact artifact produced by request preflight preparation.
+  static std::unique_ptr<OnnxChatGenerator> CreatePrepared(PreparedChatPrompt prepared,
+                                                           const SearchOptions& options,
+                                                           GenAIModelInstance& model,
+                                                           const ToolCallContext& tool_ctx,
+                                                           bool use_full_context = false);
+
   // ---- Static helpers exposed for unit testing ----
 
   /// Build the JSON messages array fed to OgaTokenizer::ApplyChatTemplate when
@@ -123,13 +136,11 @@ class OnnxChatGenerator : public ChatGenerator {
   // the two paths project their messages differently: text builds from the transcript, media rewrites MessageItems
   // so the template inserts media sentinels. Both share search-options validation, guidance setup, media tensor
   // preparation, and generator construction.
-  static std::unique_ptr<OnnxChatGenerator> CreateImpl(const std::string& prompt,
+  static std::unique_ptr<OnnxChatGenerator> CreateImpl(PreparedChatPrompt prepared,
                                                        const SearchOptions& options,
                                                        GenAIModelInstance& model,
                                                        const ToolCallContext& tool_ctx,
-                                                       bool use_full_context,
-                                                       const std::vector<const ImageItem*>& images,
-                                                       const std::vector<const AudioItem*>& audios);
+                                                       bool use_full_context);
 
   std::unique_ptr<OgaGeneratorParams> gen_params_;
   std::unique_ptr<OgaGenerator> generator_;

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_engine_chat_stream.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_engine_chat_stream.cc
@@ -137,14 +137,27 @@ int OnnxEngineChatStream::AppendMessages(const std::vector<TranscriptMessage>& n
     FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "new_messages and full_messages must not be empty");
   }
 
-  auto prompt = BuildChatPrompt(full_messages, model, tool_ctx.tools_json);
-  auto sequences = EncodePrompt(prompt, model);
-  const int count = static_cast<int>(sequences->SequenceCount(0));
-  const auto* data = sequences->SequenceData(0);
-  const std::span<const int32_t> full_prompt(data, static_cast<size_t>(count));
+  auto prepared = PrepareTextChatPrompt(full_messages, model, tool_ctx);
+  return AppendPreparedPrompt(new_messages, prepared, model, tool_ctx, options);
+}
+
+int OnnxEngineChatStream::AppendPreparedPrompt(const std::vector<TranscriptMessage>& new_messages,
+                                               const PreparedChatPrompt& prepared,
+                                               GenAIModelInstance& model,
+                                               const ToolCallContext& tool_ctx,
+                                               const SearchOptions& options) {
+  if (new_messages.empty() || prepared.token_ids.empty()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "new_messages and prepared prompt must not be empty");
+  }
+
+  const int count = static_cast<int>(prepared.prompt_token_count);
+  const std::span<const int32_t> full_prompt(prepared.token_ids);
   const auto resident_tokens = engine_.ResidentTokens(conversation_);
   const auto suffix_start = chat_internal::FindUnmatchedPromptSuffix(resident_tokens, full_prompt);
-  const bool prompt_opens_reasoning = DetectPromptOpensReasoning(prompt, *sequences, tool_ctx, model);
+  auto sequences = OgaSequences::Create();
+  sequences->Append(prepared.token_ids.data(), prepared.token_ids.size());
+  const bool prompt_opens_reasoning =
+      DetectPromptOpensReasoning(prepared.prompt, *sequences, tool_ctx, model);
 
   // Keep the previous decoder intact if admission fails. Once admitted, start a fresh stream so partial UTF-8/BPE
   // state from the prior turn cannot affect generated tokens; prompt tokens are never decoded.
@@ -211,10 +224,28 @@ std::unique_ptr<OnnxEngineChatStream> OnnxEngineChatStream::Create(
     FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "model does not own a chat Engine");
   }
 
-  auto prompt = BuildChatPrompt(messages, model, tool_ctx.tools_json);
-  auto sequences = EncodePrompt(prompt, model);
-  const int prompt_token_count = static_cast<int>(sequences->SequenceCount(0));
-  const bool prompt_opens_reasoning = DetectPromptOpensReasoning(prompt, *sequences, tool_ctx, model);
+  return CreatePrepared(PrepareTextChatPrompt(messages, model, tool_ctx), options, model, tool_ctx);
+}
+
+std::unique_ptr<OnnxEngineChatStream> OnnxEngineChatStream::CreatePrepared(
+    PreparedChatPrompt prepared,
+    const SearchOptions& options,
+    GenAIModelInstance& model,
+    const ToolCallContext& tool_ctx) {
+  if (prepared.token_ids.empty()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "prepared prompt must not be empty");
+  }
+
+  auto* engine = model.GetChatEngine();
+  if (!engine) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "model does not own a chat Engine");
+  }
+
+  auto sequences = OgaSequences::Create();
+  sequences->Append(prepared.token_ids.data(), prepared.token_ids.size());
+  const int prompt_token_count = static_cast<int>(prepared.prompt_token_count);
+  const bool prompt_opens_reasoning =
+      DetectPromptOpensReasoning(prepared.prompt, *sequences, tool_ctx, model);
   auto stream = model.GetPreprocessor().CreateTokenizerStream();
   auto conversation = engine->CreateConversation(options, tool_ctx, prompt_token_count);
   try {

--- a/sdk_v2/cpp/src/inferencing/generative/chat/onnx_engine_chat_stream.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/onnx_engine_chat_stream.h
@@ -4,6 +4,7 @@
 
 #include "inferencing/generative/chat/chat_generator.h"
 #include "inferencing/generative/chat/onnx_chat_engine.h"
+#include "inferencing/generative/chat/prepared_chat_prompt.h"
 #include "inferencing/generative/chat/search_options.h"
 #include "inferencing/generative/toolcalling/tool_call_context.h"
 
@@ -15,6 +16,7 @@ struct OgaTokenizerStream;
 
 namespace fl {
 
+class ChatSessionTestAccessor;
 class GenAIModelInstance;
 
 /// ChatGenerator stream for a conversation scheduled by a model-owned ORT GenAI Engine.
@@ -34,6 +36,11 @@ class OnnxEngineChatStream final : public ChatGenerator {
                      GenAIModelInstance& model,
                      const ToolCallContext& tool_ctx,
                      const SearchOptions& options) override;
+  int AppendPreparedPrompt(const std::vector<TranscriptMessage>& new_messages,
+                           const PreparedChatPrompt& prepared,
+                           GenAIModelInstance& model,
+                           const ToolCallContext& tool_ctx,
+                           const SearchOptions& options) override;
   bool PromptOpensReasoning() const override { return prompt_opens_reasoning_; }
   std::optional<ChatTurnUsage> GetTurnUsage() const override;
 
@@ -42,8 +49,14 @@ class OnnxEngineChatStream final : public ChatGenerator {
       const SearchOptions& options,
       GenAIModelInstance& model,
       const ToolCallContext& tool_ctx);
+  static std::unique_ptr<OnnxEngineChatStream> CreatePrepared(PreparedChatPrompt prepared,
+                                                              const SearchOptions& options,
+                                                              GenAIModelInstance& model,
+                                                              const ToolCallContext& tool_ctx);
 
  private:
+  friend class ChatSessionTestAccessor;
+
   OnnxEngineChatStream(OnnxChatEngine& engine,
                        std::shared_ptr<OnnxChatEngine::Conversation> conversation,
                        std::unique_ptr<OgaTokenizerStream> stream,

--- a/sdk_v2/cpp/src/inferencing/generative/chat/prepared_chat_prompt.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/prepared_chat_prompt.cc
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "inferencing/generative/chat/prepared_chat_prompt.h"
+
+#include "exception.h"
+#include "inferencing/generative/chat/chat_template.h"
+#include "inferencing/generative/chat/onnx_chat_generator.h"
+#include "inferencing/generative/genai_model_instance.h"
+#include "inferencing/generative/toolcalling/tool_call_context.h"
+#include "items/audio_item.h"
+#include "items/image_item.h"
+
+#include <ort_genai.h>
+
+namespace fl {
+
+PreparedChatPrompt::PreparedChatPrompt() = default;
+PreparedChatPrompt::~PreparedChatPrompt() = default;
+PreparedChatPrompt::PreparedChatPrompt(PreparedChatPrompt&&) noexcept = default;
+PreparedChatPrompt& PreparedChatPrompt::operator=(PreparedChatPrompt&&) noexcept = default;
+
+PreparedChatPrompt PrepareTextChatPrompt(const std::vector<TranscriptMessage>& messages,
+                                         GenAIModelInstance& model,
+                                         const ToolCallContext& tool_ctx) {
+  if (messages.empty()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "messages must not be empty");
+  }
+
+  PreparedChatPrompt prepared;
+  prepared.prompt = BuildChatPrompt(messages, model, tool_ctx.tools_json);
+  auto sequences = EncodePrompt(prepared.prompt, model);
+  const auto count = sequences->SequenceCount(0);
+  const auto* data = sequences->SequenceData(0);
+  prepared.token_ids.assign(data, data + count);
+  prepared.prompt_token_count = static_cast<int64_t>(count);
+  return prepared;
+}
+
+PreparedChatPrompt PrepareMediaChatPrompt(const std::vector<MessageItem>& messages,
+                                          GenAIModelInstance& model,
+                                          const std::vector<const ImageItem*>& images,
+                                          const std::vector<const AudioItem*>& audios,
+                                          const ToolCallContext& tool_ctx) {
+  if (messages.empty()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "messages must not be empty");
+  }
+  if (images.empty() && audios.empty()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "media preparation requires image or audio input");
+  }
+  if (!model.IsMultiModal()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "image or audio input requires a multimodal model");
+  }
+  if (!model.GetPreprocessor().HasMultiModalProcessor()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "model has no multimodal processor available for media input");
+  }
+
+  PreparedChatPrompt prepared;
+  const auto messages_json = OnnxChatGenerator::TransformMessagesForMedia(messages);
+  const char* tools = tool_ctx.tools_json.empty() ? nullptr : tool_ctx.tools_json.c_str();
+  prepared.prompt = model.GetPreprocessor().ApplyChatTemplate(messages_json.c_str(), tools, true);
+
+  std::unique_ptr<OgaImages> oga_images;
+  std::vector<std::vector<uint8_t>> image_bytes;
+  if (!images.empty()) {
+    image_bytes.reserve(images.size());
+    std::vector<const void*> buffers;
+    std::vector<size_t> sizes;
+    buffers.reserve(images.size());
+    sizes.reserve(images.size());
+
+    for (const auto* image : images) {
+      if (image == nullptr) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "image entry must not be null");
+      }
+
+      image_bytes.push_back(image->ReadBytes());
+      const auto& bytes = image_bytes.back();
+      buffers.push_back(bytes.data());
+      sizes.push_back(bytes.size());
+    }
+
+    oga_images = OgaImages::Load(buffers.data(), sizes.data(), buffers.size());
+  }
+
+  std::unique_ptr<OgaAudios> oga_audios;
+  if (!audios.empty()) {
+    std::vector<std::vector<uint8_t>> audio_bytes;
+    audio_bytes.reserve(audios.size());
+    std::vector<const void*> buffers;
+    std::vector<size_t> sizes;
+    buffers.reserve(audios.size());
+    sizes.reserve(audios.size());
+
+    for (const auto* audio : audios) {
+      if (audio == nullptr) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "audio entry must not be null");
+      }
+
+      audio_bytes.push_back(audio->ReadBytes());
+      const auto& bytes = audio_bytes.back();
+      buffers.push_back(bytes.data());
+      sizes.push_back(bytes.size());
+    }
+
+    oga_audios = OgaAudios::Load(buffers.data(), sizes.data(), buffers.size());
+  }
+
+  prepared.media_tensors =
+      model.GetPreprocessor().ProcessMedia(prepared.prompt.c_str(), oga_images.get(), oga_audios.get());
+  auto input_ids = prepared.media_tensors->Get("input_ids");
+  const auto shape = input_ids->Shape();
+  if (shape.empty() || shape.back() <= 0) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "multimodal processor returned invalid input_ids");
+  }
+
+  prepared.prompt_token_count = shape.back();
+  return prepared;
+}
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/chat/prepared_chat_prompt.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/prepared_chat_prompt.h
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+struct OgaNamedTensors;
+
+namespace fl {
+
+class AudioItem;
+class GenAIModelInstance;
+class ImageItem;
+class MessageItem;
+struct ToolCallContext;
+struct TranscriptMessage;
+
+/// Fully rendered and tokenized model input. Construction performs no generation or conversation mutation.
+struct PreparedChatPrompt {
+  PreparedChatPrompt();
+  ~PreparedChatPrompt();
+  PreparedChatPrompt(PreparedChatPrompt&&) noexcept;
+  PreparedChatPrompt& operator=(PreparedChatPrompt&&) noexcept;
+
+  PreparedChatPrompt(const PreparedChatPrompt&) = delete;
+  PreparedChatPrompt& operator=(const PreparedChatPrompt&) = delete;
+
+  std::string prompt;
+  std::vector<int32_t> token_ids;
+  std::unique_ptr<OgaNamedTensors> media_tensors;
+  int64_t prompt_token_count = 0;
+
+  bool HasMedia() const noexcept {
+    return media_tensors != nullptr;
+  }
+};
+
+PreparedChatPrompt PrepareTextChatPrompt(const std::vector<TranscriptMessage>& messages,
+                                         GenAIModelInstance& model,
+                                         const ToolCallContext& tool_ctx);
+
+PreparedChatPrompt PrepareMediaChatPrompt(const std::vector<MessageItem>& messages,
+                                          GenAIModelInstance& model,
+                                          const std::vector<const ImageItem*>& images,
+                                          const std::vector<const AudioItem*>& audios,
+                                          const ToolCallContext& tool_ctx);
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/chat/request_budget.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/request_budget.cc
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "inferencing/generative/chat/request_budget.h"
+
+#include "exception.h"
+
+#include <limits>
+
+namespace fl {
+
+RequestBudget ComputeRequestBudget(int64_t prompt_tokens,
+                                   int64_t output_reserve_tokens,
+                                   int64_t context_limit_tokens) {
+  if (prompt_tokens < 0) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "prompt token count must not be negative");
+  }
+  if (output_reserve_tokens < 1) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "max_output_tokens must be >= 1");
+  }
+  if (context_limit_tokens < 1) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "model context length must be a positive integer");
+  }
+  if (prompt_tokens > (std::numeric_limits<int64_t>::max)() - output_reserve_tokens) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "request token budget overflow");
+  }
+
+  const int64_t required_tokens = prompt_tokens + output_reserve_tokens;
+  const bool fits = required_tokens <= context_limit_tokens;
+  return RequestBudget{
+      .prompt_tokens = prompt_tokens,
+      .output_reserve_tokens = output_reserve_tokens,
+      .required_tokens = required_tokens,
+      .context_limit_tokens = context_limit_tokens,
+      .fits = fits,
+      .deficit_tokens = fits ? 0 : required_tokens - context_limit_tokens,
+  };
+}
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/chat/request_budget.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/request_budget.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include <cstdint>
+
+namespace fl {
+
+struct RequestBudget {
+  int64_t prompt_tokens = 0;
+  int64_t output_reserve_tokens = 0;
+  int64_t required_tokens = 0;
+  int64_t context_limit_tokens = 0;
+  bool fits = false;
+  int64_t deficit_tokens = 0;
+};
+
+/// Compute a request budget with checked signed arithmetic.
+RequestBudget ComputeRequestBudget(int64_t prompt_tokens,
+                                   int64_t output_reserve_tokens,
+                                   int64_t context_limit_tokens);
+
+}  // namespace fl

--- a/sdk_v2/cpp/src/inferencing/generative/chat/search_options.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/search_options.cc
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 namespace fl {
 
@@ -48,26 +49,48 @@ void ValidatePenalties(const SearchOptions& options) {
 
 }  // namespace
 
-int ResolveMaxOutputTokens(const SearchOptions& options, int default_max_output_tokens) {
-  const int max_output = options.max_output_tokens.value_or(default_max_output_tokens);
-  if (max_output < 1) {
+int ResolveOutputLimit(const SearchOptions& options, bool has_media) {
+  if (options.max_output_tokens.has_value()) {
+    if (*options.max_output_tokens < 1) {
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "max_output_tokens must be >= 1");
+    }
+
+    return *options.max_output_tokens;
+  }
+
+  // GenAIConfig currently exposes only total-context limits. There is no package generation
+  // default to consult between the request and the host fallback.
+  return has_media ? kDefaultChatMediaMaxOutputTokens : kDefaultChatTextMaxOutputTokens;
+}
+
+namespace {
+
+int RequireResolvedMaxOutputTokens(const SearchOptions& options) {
+  if (!options.max_output_tokens.has_value()) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL,
+             "max_output_tokens must be resolved before backend submission");
+  }
+
+  if (*options.max_output_tokens < 1) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "max_output_tokens must be >= 1");
   }
 
-  return max_output;
+  return *options.max_output_tokens;
 }
 
-int GetModelMaxContextLength(const GenAIConfig& config) {
-  int model_max_length = 0;
-  if (config.search.has_value()) {
-    model_max_length = config.search->max_length;
+}  // namespace
+
+int64_t GetModelMaxContextLength(const GenAIConfig& config) {
+  if (config.model.has_value() && config.model->context_length > 0) {
+    return config.model->context_length;
   }
 
-  if (model_max_length <= 0) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL, "model genai_config.json is missing search.max_length");
+  if (config.search.has_value() && config.search->max_length > 0) {
+    return config.search->max_length;
   }
 
-  return model_max_length;
+  FL_THROW(FOUNDRY_LOCAL_ERROR_INTERNAL,
+           "model genai_config.json must define a positive model.context_length or search.max_length");
 }
 
 std::optional<TurnGuidanceOptions> ResolveTurnGuidanceOptions(const ToolCallContext& tool_ctx,
@@ -172,10 +195,7 @@ EngineTurnOptionsPlan BuildEngineTurnOptionsPlan(const SearchOptions& options,
   }
 
   EngineTurnOptionsPlan plan;
-  if (options.max_output_tokens.has_value() && *options.max_output_tokens < 1) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "max_output_tokens must be >= 1");
-  }
-  plan.max_generated_tokens = options.max_output_tokens;
+  plan.max_generated_tokens = RequireResolvedMaxOutputTokens(options);
   plan.sampling = ResolveSamplingPlan(options);
 
   // Negative seeds preserve classic ORT GenAI's nondeterministic behavior and require no per-turn seed support.
@@ -210,25 +230,27 @@ void ApplyGuidanceOptions(const ToolCallContext& tool_ctx,
   }
 }
 
-int ApplySearchOptions(const SearchOptions& options,
-                       int input_token_count,
-                       const GenAIConfig& config,
-                       OgaGeneratorParams& gen_params,
-                       ExecutionProvider ep,
-                       bool use_full_context,
-                       int default_max_output_tokens) {
+int64_t ApplySearchOptions(const SearchOptions& options,
+                           int64_t input_token_count,
+                           const GenAIConfig& config,
+                           OgaGeneratorParams& gen_params,
+                           ExecutionProvider ep,
+                           bool use_full_context,
+                           bool has_media) {
   ValidatePenalties(options);
 
-  const int model_max_length = GetModelMaxContextLength(config);
+  const int64_t model_max_length = GetModelMaxContextLength(config);
 
-  // genai_config.json's search.max_length (read above) is the source of truth for the total input+output budget.
-  // The catalog's maxOutputTokens is informational metadata only and is intentionally NOT used to clamp generation:
-  // it is commonly a conservative 2048 that would wrongly cap larger contexts (e.g. the 3072 vision default). A
-  // user-supplied max_output_tokens is honored as-is and only rejected if input+output exceeds max_length below.
-  const int max_output = ResolveMaxOutputTokens(options, default_max_output_tokens);
+  // Prepared chat requests already carry an explicit resolved value. Direct internal callers
+  // use the same canonical resolver rather than a backend-specific fallback.
+  const int max_output = ResolveOutputLimit(options, has_media);
 
   // Validate token budget: input + output must not exceed model's max_length
-  int total_required = input_token_count + max_output;
+  if (input_token_count > (std::numeric_limits<int64_t>::max)() - max_output) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "request token budget overflow");
+  }
+
+  const int64_t total_required = input_token_count + max_output;
   if (total_required > model_max_length) {
     FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
              "request requires " + std::to_string(total_required) + " total tokens (" +
@@ -240,9 +262,8 @@ int ApplySearchOptions(const SearchOptions& options,
   // max_length in ORT GenAI is the total (input + output) budget.
   // For continuous decoding (cached generators), use the model's full context window
   // so the sequence can grow across turns.
-  int effective_max_length = use_full_context
-                                 ? model_max_length
-                                 : std::min(model_max_length, total_required);
+  const int64_t effective_max_length =
+      use_full_context ? model_max_length : std::min(model_max_length, total_required);
   gen_params.SetSearchOption("max_length", static_cast<double>(effective_max_length));
 
   // One shared normalization for every backend: the same combination is forwarded to a classic generator, to an
@@ -312,7 +333,11 @@ SearchOptions SearchOptions::FromParameters(const KeyValuePairs& params) {
   auto try_float = [&](const std::string& key) -> std::optional<float> {
     auto it = params.find(key);
     if (it != params.end()) {
-      return std::stof(it->second);
+      try {
+        return std::stof(it->second);
+      } catch (const std::exception&) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, key + " must be a valid number");
+      }
     }
 
     return std::nullopt;
@@ -321,7 +346,11 @@ SearchOptions SearchOptions::FromParameters(const KeyValuePairs& params) {
   auto try_int = [&](const std::string& key) -> std::optional<int> {
     auto it = params.find(key);
     if (it != params.end()) {
-      return std::stoi(it->second);
+      try {
+        return std::stoi(it->second);
+      } catch (const std::exception&) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, key + " must be a valid integer");
+      }
     }
 
     return std::nullopt;

--- a/sdk_v2/cpp/src/inferencing/generative/chat/search_options.h
+++ b/sdk_v2/cpp/src/inferencing/generative/chat/search_options.h
@@ -45,10 +45,10 @@ struct SamplingPlan {
 };
 
 /// Per-turn Engine settings for the newer ORT GenAI `OgaTurnOptions` surface.
-/// Only fields upstream actually implements are represented; anything absent stays at the model's own default for
-/// that turn (upstream: "an unset option means use the model-configured default for this Turn").
+/// The output limit is mandatory after request preparation. Optional sampling fields stay at the
+/// model's own default for that turn when absent.
 struct EngineTurnOptionsPlan {
-  std::optional<int> max_generated_tokens;
+  int max_generated_tokens = 0;
   SamplingPlan sampling;
   std::optional<int> seed;
   std::vector<std::string> stop_sequences;
@@ -94,17 +94,16 @@ struct SearchOptions {
 inline constexpr int kDefaultChatTextMaxOutputTokens = 2048;
 inline constexpr int kDefaultChatMediaMaxOutputTokens = 3072;
 
-/// Return the host default for classic Generator and media turns. Engine text turns remain unset unless specified.
-constexpr int GetDefaultMaxOutputTokens(bool has_media) noexcept {
-  return has_media ? kDefaultChatMediaMaxOutputTokens : kDefaultChatTextMaxOutputTokens;
-}
+/// Resolve the request output limit from the package schema and host fallback policy.
+///
+/// The current GenAIConfig schema has no distinct package generation default:
+/// model.context_length and search.max_length are total-context limits. Neither participates
+/// in this resolution. If a distinct generation field is added later, it belongs between the
+/// explicit request value and the text/media fallback here.
+int ResolveOutputLimit(const SearchOptions& options, bool has_media);
 
-/// Return the explicit or caller-selected default output-token limit.
-int ResolveMaxOutputTokens(const SearchOptions& options,
-                           int default_max_output_tokens = kDefaultChatTextMaxOutputTokens);
-
-/// Return the model's total context window from genai_config.json.
-int GetModelMaxContextLength(const GenAIConfig& config);
+/// Return positive model.context_length, falling back to positive search.max_length for legacy artifacts.
+int64_t GetModelMaxContextLength(const GenAIConfig& config);
 
 /// Resolve the guidance configuration that should apply to a single tool-only turn.
 std::optional<TurnGuidanceOptions> ResolveTurnGuidanceOptions(const ToolCallContext& tool_ctx,
@@ -121,7 +120,8 @@ bool ShouldForwardStopSequencesToEngine(ChatBackendKind backend_kind);
 bool SupportsPerTurnSeed(ChatBackendKind backend_kind);
 
 /// Resolve SearchOptions + ToolCallContext into the per-turn Engine settings used by newer OGA headers.
-/// Throws fl::Exception when the request asks for something this backend cannot honor per turn.
+/// max_output_tokens must already have been resolved during request preparation.
+/// Throws fl::Exception when the request is unresolved or asks for something this backend cannot honor per turn.
 EngineTurnOptionsPlan BuildEngineTurnOptionsPlan(const SearchOptions& options,
                                                  const ToolCallContext& tool_ctx,
                                                  ChatBackendKind backend_kind,
@@ -134,7 +134,7 @@ EngineTurnOptionsPlan BuildEngineTurnOptionsPlan(const SearchOptions& options,
 ///
 /// @param options            Search options extracted from the request
 /// @param input_token_count  Number of tokens in the encoded prompt
-/// @param config             Model's GenAI config (for search.max_length)
+/// @param config             Model's GenAI config (model.context_length, then search.max_length fallback)
 /// @param gen_params         ORT GenAI generator params to configure
 /// @param ep                 Resolved execution provider. Used to enable chunked prefill by default
 ///                           on providers that benefit from it (CUDA, NvTensorRtRtx, WebGPU, CPU).
@@ -143,15 +143,14 @@ EngineTurnOptionsPlan BuildEngineTurnOptionsPlan(const SearchOptions& options,
 ///                           ORT GenAI determines whether the model consumes this option.
 /// @param use_full_context   When true, set max_length to the model's full context window
 ///                           instead of input+output. Used for continuous decoding (cached generators).
-/// @param default_max_output_tokens  Default applied when the request does not specify
-///                                   max_output_tokens. C# uses 2048 for text, 3072 for vision.
-int ApplySearchOptions(const SearchOptions& options,
-                       int input_token_count,
-                       const GenAIConfig& config,
-                       OgaGeneratorParams& gen_params,
-                       ExecutionProvider ep,
-                       bool use_full_context = false,
-                       int default_max_output_tokens = kDefaultChatTextMaxOutputTokens);
+/// @param has_media          Whether to use the media fallback when called outside prepared-request submission.
+int64_t ApplySearchOptions(const SearchOptions& options,
+                           int64_t input_token_count,
+                           const GenAIConfig& config,
+                           OgaGeneratorParams& gen_params,
+                           ExecutionProvider ep,
+                           bool use_full_context = false,
+                           bool has_media = false);
 
 /// Applies request-level grammar guidance to generator parameters when the tool context requires tool-only output.
 void ApplyGuidanceOptions(const ToolCallContext& tool_ctx,

--- a/sdk_v2/cpp/src/inferencing/generative/genai_config.cc
+++ b/sdk_v2/cpp/src/inferencing/generative/genai_config.cc
@@ -119,7 +119,7 @@ GenAIConfig GenAIConfig::LoadFromFile(const std::string& path) {
     OnnxModel model;
 
     if (jm.contains("context_length") && jm["context_length"].is_number()) {
-      model.context_length = jm["context_length"].get<int>();
+      model.context_length = jm["context_length"].get<int64_t>();
     }
 
     if (jm.contains("type") && jm["type"].is_string()) {
@@ -173,7 +173,7 @@ GenAIConfig GenAIConfig::LoadFromFile(const std::string& path) {
     Search search;
 
     if (js.contains("max_length") && js["max_length"].is_number()) {
-      search.max_length = js["max_length"].get<int>();
+      search.max_length = js["max_length"].get<int64_t>();
     }
 
     config.search = std::move(search);

--- a/sdk_v2/cpp/src/inferencing/generative/genai_config.h
+++ b/sdk_v2/cpp/src/inferencing/generative/genai_config.h
@@ -19,7 +19,7 @@ enum class ChatBackendKind {
 /// Maps the C# GenAIConfig / OnnxModel / OnnxDecoder types.
 struct GenAIConfig {
   struct OnnxModel {
-    int context_length = 0;
+    int64_t context_length = 0;
     std::string type;
     std::map<std::string, std::string> prompt_templates;
 
@@ -39,7 +39,7 @@ struct GenAIConfig {
   };
 
   struct Search {
-    int max_length = 0;
+    int64_t max_length = 0;
   };
 
   struct Engine {

--- a/sdk_v2/cpp/src/inferencing/session/request.h
+++ b/sdk_v2/cpp/src/inferencing/session/request.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "exception.h"
 #include "items/item.h"
 #include "util/key_value_pairs.h"
 
@@ -65,6 +66,30 @@ struct Request {
 
   Request(const Request&) = delete;
   Request& operator=(const Request&) = delete;
+
+  /// Deep-copy all in-memory state read by chat request preparation.
+  ///
+  /// Request and session mutations are frozen here, including inline media
+  /// bytes. URI-backed media retains only its URI and descriptors; external
+  /// content is read by the preflight worker at Execute and is not
+  /// transactionally frozen with the captured request.
+  Request CapturePreflightSnapshot() const {
+    Request snapshot;
+    snapshot.options = options;
+    snapshot.item_segment_starts = item_segment_starts;
+    snapshot.items.reserve(items.size());
+
+    for (const auto* item : items) {
+      if (item == nullptr) {
+        FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+                 "request preflight snapshot cannot contain a null item");
+      }
+
+      snapshot.AddOwnedItem(CloneChatRequestItem(*item));
+    }
+
+    return snapshot;
+  }
 
   /// Add a pre-allocated owned item.
   void AddOwnedItem(std::unique_ptr<Item> item) {

--- a/sdk_v2/cpp/src/inferencing/session/session.cc
+++ b/sdk_v2/cpp/src/inferencing/session/session.cc
@@ -87,7 +87,15 @@ void Session::UndoTurns(size_t /*count*/) {
 }
 
 void Session::AddToolDefinition(ToolDefinition tool_def) {
+  auto lock = LockStateMutex();
   tool_registry_.Add(std::move(tool_def));
+}
+
+void Session::SetSessionOptions(const KeyValuePairs& options) {
+  auto request_lock = LockRequestMutex();
+  auto state_lock = LockStateMutex();
+  session_options_ = options;
+  SetSessionOptionsImpl(session_options_);
 }
 
 void Session::ValidateRequestItems(const Request& request) const {
@@ -145,6 +153,8 @@ void Session::ProcessRequest(const Request& request, Response& response) {
     lock.lock();
   }
 
+  ValidateRequestItems(request);
+
   {
     std::lock_guard<std::mutex> active_lock(*active_requests_mutex_);
     active_requests_.insert(&request);
@@ -171,8 +181,6 @@ void Session::ProcessRequest(const Request& request, Response& response) {
   tracker.SetModelId(CatalogModel().Id());
 
   try {
-    ValidateRequestItems(request);
-
     ProcessRequestImpl(request, response);
 
     tracker.SetStatus(ActionStatus::kSuccess);

--- a/sdk_v2/cpp/src/inferencing/session/session.h
+++ b/sdk_v2/cpp/src/inferencing/session/session.h
@@ -24,6 +24,7 @@ namespace fl {
 class ILogger;     // forward declaration
 class ITelemetry;  // forward declaration
 class Model;       // forward declaration
+struct RequestBudget;
 
 /// Base class for model inference sessions.
 /// Manages lifecycle, request dispatch, streaming callbacks, and tool definitions.
@@ -34,6 +35,25 @@ class Model;       // forward declaration
 ///   - Future: predictive inference, realtime audio, multi-modal
 class Session {
  public:
+#if defined(_WIN32)
+  class RequestPreflightOperation {
+#else
+  class __attribute__((visibility("hidden"))) RequestPreflightOperation {
+#endif
+   public:
+    virtual ~RequestPreflightOperation() = default;
+
+    RequestPreflightOperation(const RequestPreflightOperation&) = delete;
+    RequestPreflightOperation& operator=(const RequestPreflightOperation&) = delete;
+    RequestPreflightOperation(RequestPreflightOperation&&) = delete;
+    RequestPreflightOperation& operator=(RequestPreflightOperation&&) = delete;
+
+    virtual RequestBudget Execute() = 0;
+
+   protected:
+    RequestPreflightOperation() = default;
+  };
+
   virtual ~Session();
 
   Session(Session&&) = default;
@@ -69,6 +89,7 @@ class Session {
   /// Remove a previously-added tool definition by name.
   /// Returns true if a matching tool was found and removed, false otherwise.
   bool RemoveToolDefinition(const std::string& tool_name) {
+    auto lock = LockStateMutex();
     return tool_registry_.Remove(tool_name);
   }
 
@@ -77,6 +98,7 @@ class Session {
   /// A request takes this once, before generation, so the calls it replays, the prompt it builds,
   /// and the calls it produces are all resolved against the same tool set.
   std::vector<ToolDefinition> ToolDefinitions() const {
+    auto lock = LockStateMutex();
     return tool_registry_.Definitions();
   }
 
@@ -84,7 +106,14 @@ class Session {
   /// requests (e.g. via Responses API `previous_response_id`) and the new request brings its
   /// own tools — the request-is-self-contained model means stale tools must not leak across turns.
   void ClearToolDefinitions() {
+    auto lock = LockStateMutex();
     tool_registry_.Clear();
+  }
+
+  /// Validate, normalize, and atomically replace all definitions.
+  void SetToolDefinitions(std::vector<ToolDefinition> tool_definitions) {
+    auto lock = LockStateMutex();
+    tool_registry_.Replace(std::move(tool_definitions));
   }
 
   /// Get the number of completed turns. Only meaningful for chat sessions.
@@ -95,10 +124,7 @@ class Session {
   virtual void UndoTurns(size_t count);
 
   /// Session-level parameters overlaid onto each request.
-  void SetSessionOptions(const KeyValuePairs& options) {
-    session_options_ = options;
-    SetSessionOptionsImpl(session_options_);
-  }
+  void SetSessionOptions(const KeyValuePairs& options);
 
   using StreamingCallbackFn = std::function<int(flStreamingCallbackData, void*)>;
   void SetStreamingCallback(StreamingCallbackFn callback, void* user_data = nullptr) {
@@ -149,14 +175,22 @@ class Session {
 
   const KeyValuePairs& SessionOptions() const { return session_options_; }
 
-  /// Serialize a state mutation with ProcessRequest for session types that maintain mutable turn state.
+  /// Serialize request execution/admission for session types that maintain ordered mutable inference state.
   std::unique_lock<std::mutex> LockRequestMutex() const { return std::unique_lock<std::mutex>(*request_mutex_); }
 
- private:
+  /// Protect short-lived snapshots and mutations of session state. When both locks are needed, request_mutex_
+  /// must be acquired first so preflight capture never blocks behind inference or creates a lock inversion.
+  std::unique_lock<std::mutex> LockStateMutex() const { return std::unique_lock<std::mutex>(*state_mutex_); }
+
+  const KeyValuePairs& SessionOptionsLocked() const { return session_options_; }
+
+  std::vector<ToolDefinition> ToolDefinitionsLocked() const { return tool_registry_.Definitions(); }
+
   /// Reject items (and message content parts) whose type the model's task does not advertise as an
   /// input. Currently applies to chat tasks only.
   void ValidateRequestItems(const Request& request) const;
 
+ private:
   const fl::Model& catalog_model_;
   ILogger& logger_;
   ITelemetry& telemetry_;
@@ -166,6 +200,7 @@ class Session {
   void* callback_user_data_ = nullptr;
   const bool allow_concurrent_requests_;
   mutable std::unique_ptr<std::mutex> request_mutex_ = std::make_unique<std::mutex>();
+  mutable std::unique_ptr<std::mutex> state_mutex_ = std::make_unique<std::mutex>();
 
   // In-flight requests tracked so Cancel() can flip their cancel flags from another thread. Guarded
   // by its own mutex (not request_mutex_) because concurrent sessions (e.g. audio) may hold several

--- a/sdk_v2/cpp/src/inferencing/session/tool_registry.cc
+++ b/sdk_v2/cpp/src/inferencing/session/tool_registry.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <iterator>
 #include <utility>
 
 namespace fl {
@@ -24,6 +25,40 @@ constexpr uint32_t kToolDefinitionKindVersion = 2;
 static_assert(offsetof(flToolDefinition, kind) == offsetof(flToolDefinition, json_schema) + sizeof(const char*),
               "flToolDefinition::kind must be appended directly after the version 1 prefix");
 static_assert(sizeof(flToolKind) == sizeof(uint32_t), "flToolKind must be a fixed-width 32-bit ABI type");
+
+void NormalizeToolDefinition(ToolDefinition& tool_def) {
+  if (tool_def.kind == ToolKind::kCustom) {
+    if (tool_def.name.empty()) {
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "a custom tool definition requires a name");
+    }
+
+    if (!tool_def.json_schema.empty()) {
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "custom tool '", tool_def.name,
+               "' must not supply a json_schema; the schema is synthesized");
+    }
+
+    tool_def.json_schema = kCustomToolInputSchema;
+  } else if (!nlohmann::json::accept(tool_def.json_schema)) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+             "ToolDefinition.json_schema is not valid JSON for tool: " + tool_def.name);
+  }
+}
+
+void ValidateUniqueToolNames(const std::vector<ToolDefinition>& definitions) {
+  for (auto current = definitions.begin(); current != definitions.end(); ++current) {
+    if (current->name.empty()) {
+      continue;
+    }
+
+    const auto duplicate = std::find_if(
+        std::next(current), definitions.end(),
+        [&](const ToolDefinition& candidate) { return candidate.name == current->name; });
+    if (duplicate != definitions.end()) {
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "a tool named '", current->name,
+               "' is already registered; remove it before registering it again");
+    }
+  }
+}
 
 }  // namespace
 
@@ -75,21 +110,7 @@ void ValidateToolCallText(std::string_view text, std::string_view field) {
 
 void ToolRegistry::Add(ToolDefinition tool_def) {
   // Validate and normalize before taking the lock — none of it touches shared state.
-  if (tool_def.kind == ToolKind::kCustom) {
-    if (tool_def.name.empty()) {
-      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "a custom tool definition requires a name");
-    }
-
-    if (!tool_def.json_schema.empty()) {
-      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "custom tool '", tool_def.name,
-               "' must not supply a json_schema; the schema is synthesized");
-    }
-
-    tool_def.json_schema = kCustomToolInputSchema;
-  } else if (!nlohmann::json::accept(tool_def.json_schema)) {
-    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-             "ToolDefinition.json_schema is not valid JSON for tool: " + tool_def.name);
-  }
+  NormalizeToolDefinition(tool_def);
 
   std::lock_guard<std::mutex> lock(mutex_);
 
@@ -129,6 +150,16 @@ bool ToolRegistry::Remove(const std::string& name) {
 void ToolRegistry::Clear() {
   std::lock_guard<std::mutex> lock(mutex_);
   definitions_.clear();
+}
+
+void ToolRegistry::Replace(std::vector<ToolDefinition> tool_definitions) {
+  for (auto& definition : tool_definitions) {
+    NormalizeToolDefinition(definition);
+  }
+  ValidateUniqueToolNames(tool_definitions);
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  definitions_ = std::move(tool_definitions);
 }
 
 std::vector<ToolDefinition> ToolRegistry::Definitions() const {

--- a/sdk_v2/cpp/src/inferencing/session/tool_registry.h
+++ b/sdk_v2/cpp/src/inferencing/session/tool_registry.h
@@ -79,6 +79,9 @@ class ToolRegistry {
   /// brings its own tools.
   void Clear();
 
+  /// Validate, normalize, and atomically replace every definition.
+  void Replace(std::vector<ToolDefinition> tool_definitions);
+
   /// Snapshot of the registered definitions, in registration order.
   std::vector<ToolDefinition> Definitions() const;
 

--- a/sdk_v2/cpp/src/items/audio_item.h
+++ b/sdk_v2/cpp/src/items/audio_item.h
@@ -90,6 +90,9 @@ struct AudioItem : Item {
     out.deleter_user_data = nullptr;
   }
 
+  /// Return owned or borrowed bytes, reading a URI only when no bytes are present.
+  std::vector<std::uint8_t> ReadBytes() const;
+
  private:
   // Optional owning storage when the item was constructed with a vector of
   // bytes. The `data` pointer is set to point into this buffer at construction.

--- a/sdk_v2/cpp/src/items/image_item.cc
+++ b/sdk_v2/cpp/src/items/image_item.cc
@@ -3,13 +3,7 @@
 
 #include "items/image_item.h"
 
-#include "exception.h"
 #include "util/file_uri.h"
-
-#include <fstream>
-#include <ios>
-#include <string>
-#include <string_view>
 
 namespace fl {
 
@@ -20,32 +14,7 @@ std::vector<std::uint8_t> ImageItem::ReadBytes() const {
   }
 
   if (!uri.empty()) {
-    // Strip optional `file://` scheme prefix and percent-decode so URIs like
-    // `file:///C:/My%20Image.png` work the same as a plain path.
-    std::string path = PathFromFileUri(uri);
-
-    std::ifstream in(path, std::ios::binary);
-    if (!in) {
-      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-               std::string("failed to open image file: ") + path);
-    }
-
-    in.seekg(0, std::ios::end);
-    auto size = in.tellg();
-    in.seekg(0, std::ios::beg);
-
-    if (size <= 0) {
-      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-               std::string("image file is empty: ") + path);
-    }
-
-    std::vector<std::uint8_t> bytes(static_cast<size_t>(size));
-    if (!in.read(reinterpret_cast<char*>(bytes.data()), size)) {
-      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
-               std::string("failed to read image file: ") + path);
-    }
-
-    return bytes;
+    return ReadFileUriBytes(uri, "image");
   }
 
   FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,

--- a/sdk_v2/cpp/src/items/item.cc
+++ b/sdk_v2/cpp/src/items/item.cc
@@ -13,8 +13,90 @@
 #include "items/text_item.h"
 #include "items/tool_call_item.h"
 #include "items/tool_result_item.h"
+#include "exception.h"
+#include "util/file_uri.h"
 
+#include <cstdint>
 namespace fl {
+namespace {
+
+std::unique_ptr<Item> CloneChatRequestItemImpl(const Item& item) {
+  switch (item.type) {
+    case FOUNDRY_LOCAL_ITEM_TEXT: {
+      const auto& text = static_cast<const TextItem&>(item);
+      return std::make_unique<TextItem>(text.text, text.text_type);
+    }
+    case FOUNDRY_LOCAL_ITEM_MESSAGE: {
+      const auto& message = static_cast<const MessageItem&>(item);
+      auto clone = std::make_unique<MessageItem>();
+      clone->role = message.role;
+      clone->name = message.name;
+      clone->content.reserve(message.content.size());
+      for (const auto& part : message.content) {
+        if (part.view != nullptr) {
+          clone->content.push_back(
+              MessagePart::Own(CloneChatRequestItemImpl(*part.view)));
+        }
+      }
+
+      return clone;
+    }
+    case FOUNDRY_LOCAL_ITEM_TOOL_CALL:
+      return std::make_unique<ToolCallItem>(static_cast<const ToolCallItem&>(item));
+    case FOUNDRY_LOCAL_ITEM_TOOL_RESULT:
+      return std::make_unique<ToolResultItem>(static_cast<const ToolResultItem&>(item));
+    case FOUNDRY_LOCAL_ITEM_IMAGE: {
+      const auto& image = static_cast<const ImageItem&>(item);
+      if (image.data != nullptr && image.data_size > 0) {
+        const auto* bytes = static_cast<const std::uint8_t*>(image.data);
+        auto clone = std::make_unique<ImageItem>(
+            std::vector<std::uint8_t>(bytes, bytes + image.data_size), image.format);
+        clone->uri = image.uri;
+        return clone;
+      }
+
+      return std::make_unique<ImageItem>(image.uri, image.format);
+    }
+    case FOUNDRY_LOCAL_ITEM_AUDIO: {
+      const auto& audio = static_cast<const AudioItem&>(item);
+      std::unique_ptr<AudioItem> clone;
+      if (audio.data != nullptr && audio.data_size > 0) {
+        const auto* bytes = static_cast<const std::uint8_t*>(audio.data);
+        clone = std::make_unique<AudioItem>(
+            std::vector<std::uint8_t>(bytes, bytes + audio.data_size), audio.format);
+        clone->uri = audio.uri;
+      } else {
+        clone = std::make_unique<AudioItem>(audio.uri, audio.format);
+      }
+
+      clone->sample_rate = audio.sample_rate;
+      clone->channels = audio.channels;
+      return clone;
+    }
+    case FOUNDRY_LOCAL_ITEM_QUEUE:
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+               "ItemQueue cannot be captured for request preflight");
+    default:
+      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT,
+               "unsupported item type for chat request preflight snapshot: " +
+                   std::string(Item::TypeName(item.type)));
+  }
+}
+
+}  // namespace
+
+std::vector<std::uint8_t> AudioItem::ReadBytes() const {
+  if (data != nullptr && data_size > 0) {
+    const auto* bytes = static_cast<const std::uint8_t*>(data);
+    return {bytes, bytes + data_size};
+  }
+
+  if (!uri.empty()) {
+    return ReadFileUriBytes(uri, "audio");
+  }
+
+  FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "AudioItem must carry either bytes or a readable uri");
+}
 
 // flItem / flItemQueue are opaque ABI handle types — they are NOT base classes of fl::Item / fl::ItemQueue.
 // The bit pattern of `this` is what the C ABI sees, but the C++ static type system has no relationship
@@ -80,6 +162,10 @@ std::string_view Item::TypeName(flItemType type) noexcept {
     default:
       return "UNKNOWN";
   }
+}
+
+std::unique_ptr<Item> CloneChatRequestItem(const Item& item) {
+  return CloneChatRequestItemImpl(item);
 }
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/items/item.h
+++ b/sdk_v2/cpp/src/items/item.h
@@ -64,4 +64,10 @@ struct Item {
   mutable std::unique_ptr<KeyValuePairs> metadata;
 };
 
+/// Deep-copy an item accepted by chat request preparation.
+///
+/// The returned item owns all nested content and byte-backed media. ItemQueue is
+/// deliberately rejected without inspecting or consuming its contents.
+std::unique_ptr<Item> CloneChatRequestItem(const Item& item);
+
 }  // namespace fl

--- a/sdk_v2/cpp/src/items/message_item.cc
+++ b/sdk_v2/cpp/src/items/message_item.cc
@@ -2,14 +2,8 @@
 // Licensed under the MIT License.
 #include "items/message_item.h"
 
-#include <cstdint>
-#include <cstring>
-
 #include "c_api_types.h"
 #include "exception.h"
-#include "items/audio_item.h"
-#include "items/image_item.h"
-#include "items/text_item.h"
 
 namespace fl {
 
@@ -20,7 +14,7 @@ MessageItem::MessageItem(const MessageItem& other)
     if (!part.view) {
       continue;
     }
-    content.push_back(MessagePart::Own(CloneApiPart(*part.view)));
+    content.push_back(MessagePart::Own(CloneChatRequestItem(*part.view)));
   }
 }
 
@@ -38,7 +32,7 @@ MessageItem& MessageItem::operator=(const MessageItem& other) {
     if (!part.view) {
       continue;
     }
-    content.push_back(MessagePart::Own(CloneApiPart(*part.view)));
+    content.push_back(MessagePart::Own(CloneChatRequestItem(*part.view)));
   }
 
   api_part_ptrs_.clear();
@@ -85,7 +79,7 @@ void MessageItem::SetMessageData(const flMessageData& new_data) {
     // Request construction, language bindings) drops the source parts
     // immediately, leaving the message dangling. Cloning at the C ABI ingress
     // makes the contract symmetric with every other typed item.
-    content.push_back(MessagePart::Own(CloneApiPart(*part_item)));
+    content.push_back(MessagePart::Own(CloneChatRequestItem(*part_item)));
   }
 }
 
@@ -102,49 +96,6 @@ void MessageItem::GetApiData(flMessageData& out) const {
 
   out.content_items = api_part_ptrs_.empty() ? nullptr : api_part_ptrs_.data();
   out.content_items_count = api_part_ptrs_.size();
-}
-
-std::unique_ptr<Item> MessageItem::CloneApiPart(const Item& src) {
-  switch (src.type) {
-    case FOUNDRY_LOCAL_ITEM_TEXT: {
-      const auto& t = static_cast<const TextItem&>(src);
-      return std::make_unique<TextItem>(t.text, t.text_type);
-    }
-    case FOUNDRY_LOCAL_ITEM_IMAGE: {
-      const auto& img = static_cast<const ImageItem&>(src);
-      // Bytes-based: deep-copy into independently-owned storage so the clone
-      // has no dependency on the source buffer's lifetime.
-      if (img.data && img.data_size > 0) {
-        const auto* bytes = static_cast<const std::uint8_t*>(img.data);
-        std::vector<std::uint8_t> owned(bytes, bytes + img.data_size);
-        auto clone = std::make_unique<ImageItem>(std::move(owned), img.format);
-        clone->uri = img.uri;
-        return clone;
-      }
-      // URI-only (or empty).
-      auto clone = std::make_unique<ImageItem>(img.uri, img.format);
-      return clone;
-    }
-    case FOUNDRY_LOCAL_ITEM_AUDIO: {
-      const auto& aud = static_cast<const AudioItem&>(src);
-      if (aud.data && aud.data_size > 0) {
-        const auto* bytes = static_cast<const std::uint8_t*>(aud.data);
-        std::vector<std::uint8_t> owned(bytes, bytes + aud.data_size);
-        auto clone = std::make_unique<AudioItem>(std::move(owned), aud.format);
-        clone->uri = aud.uri;
-        clone->sample_rate = aud.sample_rate;
-        clone->channels = aud.channels;
-        return clone;
-      }
-
-      auto clone = std::make_unique<AudioItem>(aud.uri, aud.format);
-      clone->sample_rate = aud.sample_rate;
-      clone->channels = aud.channels;
-      return clone;
-    }
-    default:
-      FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "unsupported item type for message content part");
-  }
 }
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/items/message_item.h
+++ b/sdk_v2/cpp/src/items/message_item.h
@@ -128,13 +128,6 @@ struct MessageItem : Item {
   // Storage for pointers returned by GetApiData. Mutable so a const message
   // can serve API-level reads.
   mutable std::vector<const flItem*> api_part_ptrs_;
-
-  // Clone a part item into a self-owned unique_ptr. For IMAGE/AUDIO parts,
-  // byte buffers are deep-copied into independently-owned storage so the
-  // clone has no dependency on the source's lifetime. Implementation lives
-  // out-of-line (see message_item.cc) to avoid pulling every concrete item
-  // header into this one.
-  static std::unique_ptr<Item> CloneApiPart(const Item& src);
 };
 
 }  // namespace fl

--- a/sdk_v2/cpp/src/node_private_api.h
+++ b/sdk_v2/cpp/src/node_private_api.h
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+// This header is private to the in-repo Node addon. It is not installed with the public C/C++ SDK.
+#include <foundry_local/foundry_local_c.h>
+#include <foundry_local/foundry_local_cpp.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <utility>
+
+#define FOUNDRY_LOCAL_NODE_PRIVATE_API_VERSION 1
+
+struct flRequestPreflightOperation;
+
+struct flNodePrivateApi {
+  FL_API_STATUS(Session_CaptureRequestPreflight, _In_ const flSession* session, _In_ const flRequest* request,
+                _Outptr_ flRequestPreflightOperation** out_operation);
+  FL_API_STATUS(RequestPreflightOperation_Execute, _Inout_ flRequestPreflightOperation* operation,
+                _Inout_ flRequestPreflight* out_preflight);
+  FL_TYPE_RELEASE(RequestPreflightOperation);
+};
+
+static_assert(sizeof(flNodePrivateApi) == 3 * sizeof(void*), "Node private API layout changed");
+
+/// Private lockstep entry point for the in-repo Node addon. Both the version and table size must match exactly.
+extern "C" FL_EXPORT const flNodePrivateApi* FL_API_CALL FoundryLocalGetNodePrivateApi(
+    uint32_t version, uint32_t size) FL_NO_EXCEPTION;
+
+namespace foundry_local::detail {
+
+class NodeAddonAccess {
+ public:
+  static const flSession* SessionHandle(const ChatSession& session) noexcept {
+    return session.handle_.get();
+  }
+};
+
+class RequestPreflightOperation {
+ public:
+  RequestPreflightOperation(RequestPreflightOperation&& other) noexcept
+      : api_(std::exchange(other.api_, nullptr)),
+        operation_(std::exchange(other.operation_, nullptr)) {}
+
+  RequestPreflightOperation& operator=(RequestPreflightOperation&& other) noexcept {
+    if (this != &other) {
+      Reset();
+      api_ = std::exchange(other.api_, nullptr);
+      operation_ = std::exchange(other.operation_, nullptr);
+    }
+
+    return *this;
+  }
+
+  RequestPreflightOperation(const RequestPreflightOperation&) = delete;
+  RequestPreflightOperation& operator=(const RequestPreflightOperation&) = delete;
+
+  ~RequestPreflightOperation() {
+    Reset();
+  }
+
+  RequestPreflight Execute() {
+    flRequestPreflight preflight{};
+    preflight.version = FOUNDRY_LOCAL_API_VERSION;
+    Check(api_->RequestPreflightOperation_Execute(operation_, &preflight));
+
+    return {
+        preflight.prompt_tokens,
+        preflight.output_reserve_tokens,
+        preflight.required_tokens,
+        preflight.context_limit_tokens,
+        preflight.fits != 0,
+        preflight.deficit_tokens,
+    };
+  }
+
+ private:
+  friend RequestPreflightOperation CaptureRequestPreflight(const ChatSession& session, const Request& request);
+
+  RequestPreflightOperation(const flNodePrivateApi& api, flRequestPreflightOperation* operation) noexcept
+      : api_(&api), operation_(operation) {}
+
+  void Reset() noexcept {
+    if (api_ != nullptr) {
+      api_->RequestPreflightOperation_Release(operation_);
+    }
+
+    api_ = nullptr;
+    operation_ = nullptr;
+  }
+
+  const flNodePrivateApi* api_ = nullptr;
+  flRequestPreflightOperation* operation_ = nullptr;
+};
+
+inline RequestPreflightOperation CaptureRequestPreflight(const ChatSession& session, const Request& request) {
+  static_assert(sizeof(flNodePrivateApi) <= std::numeric_limits<uint32_t>::max(),
+                "flNodePrivateApi size must fit its private ABI parameter");
+  const auto* api =
+      FoundryLocalGetNodePrivateApi(FOUNDRY_LOCAL_NODE_PRIVATE_API_VERSION,
+                                    static_cast<uint32_t>(sizeof(flNodePrivateApi)));
+  if (api == nullptr) {
+    throw Error("Foundry Local Node private API mismatch", FOUNDRY_LOCAL_ERROR_INVALID_USAGE);
+  }
+
+  flRequestPreflightOperation* operation = nullptr;
+  Check(api->Session_CaptureRequestPreflight(
+      NodeAddonAccess::SessionHandle(session), request.native_handle(), &operation));
+  return RequestPreflightOperation(*api, operation);
+}
+
+}  // namespace foundry_local::detail

--- a/sdk_v2/cpp/src/service/responses_handler.cc
+++ b/sdk_v2/cpp/src/service/responses_handler.cc
@@ -334,12 +334,13 @@ std::shared_ptr<HttpRequestHandler::OutgoingResponse> ResponsesHandler::handle(
 
     // Sessions can be reused via previous_response_id; clear any stale tool defs from the prior
     // turn before applying this request's tools so the request stays self-contained.
-    session->ClearToolDefinitions();
+    std::vector<fl::ToolDefinition> tool_definitions;
     if (!tools_json.empty()) {
       // Unnamed and function-shaped: a whole pre-serialized tools array rather than a registrable
       // tool. It is not name-indexed, so no generated call resolves against it.
-      session->AddToolDefinition({{}, {}, std::move(tools_json), fl::ToolKind::kFunction});
+      tool_definitions.push_back({{}, {}, std::move(tools_json), fl::ToolKind::kFunction});
     }
+    session->SetToolDefinitions(std::move(tool_definitions));
 
     if (params.stream) {
       ctx_.logger.Log(LogLevel::Debug,

--- a/sdk_v2/cpp/src/util/file_uri.h
+++ b/sdk_v2/cpp/src/util/file_uri.h
@@ -2,9 +2,15 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "exception.h"
+
 #include <cctype>
+#include <cstdint>
+#include <fstream>
+#include <ios>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace fl {
 
@@ -39,6 +45,27 @@ inline std::string PathFromFileUri(std::string_view uri) {
   }
 
   return out;
+}
+
+inline std::vector<std::uint8_t> ReadFileUriBytes(std::string_view uri, std::string_view media_kind) {
+  const auto path = PathFromFileUri(uri);
+  std::ifstream input(path, std::ios::binary | std::ios::ate);
+  if (!input) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "failed to open ", media_kind, " file: ", path);
+  }
+
+  const auto size = input.tellg();
+  if (size <= 0) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, media_kind, " file is empty: ", path);
+  }
+
+  input.seekg(0, std::ios::beg);
+  std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
+  if (!input.read(reinterpret_cast<char*>(bytes.data()), size)) {
+    FL_THROW(FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT, "failed to read ", media_kind, " file: ", path);
+  }
+
+  return bytes;
 }
 
 }  // namespace fl

--- a/sdk_v2/cpp/test/CMakeLists.txt
+++ b/sdk_v2/cpp/test/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(foundry_local_tests
     internal_api/catalog_cache_test.cc
     internal_api/chat/chat_generator_test.cc
     internal_api/chat/reasoning_stream_splitter_test.cc
+    internal_api/chat/request_budget_test.cc
     internal_api/chat/chat_session_test.cc
     internal_api/chat/chat_template_test.cc
     internal_api/chat/chat_transcript_test.cc

--- a/sdk_v2/cpp/test/internal_api/c_api_test.cc
+++ b/sdk_v2/cpp/test/internal_api/c_api_test.cc
@@ -1,14 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "internal_api/c_api_test_helpers.h"
+#include "c_api_types.h"
 #include "items/tool_call_item.h"
+#include "node_private_api.h"
 #include "utils/temp_path.h"
 
+#include <cstddef>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <memory>
 #include <set>
@@ -23,6 +27,17 @@ using fl::test::CreateTestConfig;
 using fl::test::GetApi;
 using fl::test::IsOk;
 using fl::test::StatusGuard;
+
+template <typename T>
+concept HasPreflightRequest = requires(const T& session, const foundry_local::Request& request) {
+  session.PreflightRequest(request);
+};
+
+static_assert(HasPreflightRequest<foundry_local::ChatSession>);
+static_assert(!HasPreflightRequest<foundry_local::Session>);
+static_assert(sizeof(flNodePrivateApi) <= std::numeric_limits<uint32_t>::max());
+
+constexpr auto kNodePrivateApiSize = static_cast<uint32_t>(sizeof(flNodePrivateApi));
 
 // ========================================================================
 // Exports & Version
@@ -54,6 +69,90 @@ TEST(CApiTest, SupportedVersionsReturnSameExpandedApiTables) {
   EXPECT_EQ(v1->GetModelApi(), v2->GetModelApi());
   EXPECT_NE(v1->GetCatalogApi()->RegisterModel, nullptr);
   EXPECT_NE(v1->GetModelApi()->CreateModelInfo, nullptr);
+}
+
+TEST(CApiTest, RequestPreflightVersionRangeAcceptsV2) {
+  EXPECT_FALSE(fl::detail::IsRequestPreflightVersionSupported(1));
+  EXPECT_TRUE(fl::detail::IsRequestPreflightVersionSupported(2));
+  EXPECT_FALSE(fl::detail::IsRequestPreflightVersionSupported(3));
+}
+
+TEST(CApiTest, RequestPreflightVersionRangeCanValidateAFutureCurrentVersion) {
+  constexpr uint32_t future_current_version = FOUNDRY_LOCAL_API_VERSION + 1;
+  EXPECT_TRUE(fl::detail::IsRequestPreflightVersionSupported(
+      future_current_version, future_current_version));
+  EXPECT_FALSE(fl::detail::IsRequestPreflightVersionSupported(
+      future_current_version + 1, future_current_version));
+}
+
+TEST(CApiTest, InferenceApiV2AppendsOnlyPreflightAtOffset22) {
+  EXPECT_EQ(FOUNDRY_LOCAL_API_VERSION, 2);
+  EXPECT_EQ(FOUNDRY_LOCAL_REQUEST_PREFLIGHT_MIN_VERSION, 2);
+  EXPECT_EQ(offsetof(flInferenceApi, Session_UndoTurns), 21 * sizeof(void*));
+  EXPECT_EQ(offsetof(flInferenceApi, Session_PreflightRequest), 22 * sizeof(void*));
+  EXPECT_EQ(sizeof(flInferenceApi), 23 * sizeof(void*));
+
+  const auto* api_v2 = FoundryLocalGetApi(2);
+  ASSERT_NE(api_v2, nullptr);
+  const auto* inference = api_v2->GetInferenceApi();
+  ASSERT_NE(inference, nullptr);
+  EXPECT_NE(inference->Session_PreflightRequest, nullptr);
+}
+
+TEST(CApiTest, RequestPreflightV2LayoutIsFrozenWithoutAvailableTokens) {
+  EXPECT_EQ(offsetof(flRequestPreflight, version), 0u);
+  EXPECT_EQ(offsetof(flRequestPreflight, prompt_tokens), 8u);
+  EXPECT_EQ(offsetof(flRequestPreflight, output_reserve_tokens), 16u);
+  EXPECT_EQ(offsetof(flRequestPreflight, required_tokens), 24u);
+  EXPECT_EQ(offsetof(flRequestPreflight, context_limit_tokens), 32u);
+  EXPECT_EQ(offsetof(flRequestPreflight, fits), 40u);
+  EXPECT_EQ(offsetof(flRequestPreflight, deficit_tokens), 48u);
+  EXPECT_EQ(sizeof(flRequestPreflight), 56u);
+
+  EXPECT_EQ(offsetof(foundry_local::RequestPreflight, prompt_tokens), 0u);
+  EXPECT_EQ(offsetof(foundry_local::RequestPreflight, output_reserve_tokens), 8u);
+  EXPECT_EQ(offsetof(foundry_local::RequestPreflight, required_tokens), 16u);
+  EXPECT_EQ(offsetof(foundry_local::RequestPreflight, context_limit_tokens), 24u);
+  EXPECT_EQ(offsetof(foundry_local::RequestPreflight, fits), 32u);
+  EXPECT_EQ(offsetof(foundry_local::RequestPreflight, deficit_tokens), 40u);
+  EXPECT_EQ(sizeof(foundry_local::RequestPreflight), 48u);
+}
+
+TEST(CApiTest, NodePrivateApiRequiresExactVersionAndSize) {
+  EXPECT_EQ(FoundryLocalGetNodePrivateApi(
+                FOUNDRY_LOCAL_NODE_PRIVATE_API_VERSION - 1, kNodePrivateApiSize),
+            nullptr);
+  EXPECT_EQ(FoundryLocalGetNodePrivateApi(
+                FOUNDRY_LOCAL_NODE_PRIVATE_API_VERSION + 1, kNodePrivateApiSize),
+            nullptr);
+  EXPECT_EQ(FoundryLocalGetNodePrivateApi(
+                FOUNDRY_LOCAL_NODE_PRIVATE_API_VERSION, kNodePrivateApiSize - 1),
+            nullptr);
+  EXPECT_EQ(FoundryLocalGetNodePrivateApi(
+                FOUNDRY_LOCAL_NODE_PRIVATE_API_VERSION, kNodePrivateApiSize + 1),
+            nullptr);
+
+  const auto* private_api = FoundryLocalGetNodePrivateApi(
+      FOUNDRY_LOCAL_NODE_PRIVATE_API_VERSION, kNodePrivateApiSize);
+  ASSERT_NE(private_api, nullptr);
+  EXPECT_NE(private_api->Session_CaptureRequestPreflight, nullptr);
+  EXPECT_NE(private_api->RequestPreflightOperation_Execute, nullptr);
+  EXPECT_NE(private_api->RequestPreflightOperation_Release, nullptr);
+}
+
+TEST(CApiTest, NodePrivateCaptureNullsOutputBeforeReturningAnError) {
+  const auto* api = GetApi();
+  const auto* private_api = FoundryLocalGetNodePrivateApi(
+      FOUNDRY_LOCAL_NODE_PRIVATE_API_VERSION, kNodePrivateApiSize);
+  ASSERT_NE(private_api, nullptr);
+
+  auto* operation = reinterpret_cast<flRequestPreflightOperation*>(static_cast<uintptr_t>(1));
+  StatusGuard status{private_api->Session_CaptureRequestPreflight(nullptr, nullptr, &operation), api};
+  ASSERT_NE(status.s, nullptr);
+  EXPECT_EQ(api->Status_GetErrorCode(status.s), FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT);
+  EXPECT_EQ(operation, nullptr);
+
+  private_api->RequestPreflightOperation_Release(nullptr);
 }
 
 TEST(CApiTest, VersionReturnsNonNull) {

--- a/sdk_v2/cpp/test/internal_api/chat/chat_session_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat/chat_session_test.cc
@@ -6,6 +6,7 @@
 
 #include "inferencing/generative/chat/chat_session.h"
 #include "inferencing/generative/chat/chat_template.h"
+#include "c_api_types.h"
 #include "exception.h"
 #include "inferencing/model_load_manager.h"
 #include "inferencing/generative/chat/search_options.h"
@@ -13,6 +14,7 @@
 #include "inferencing/session/tool_registry.h"
 #include "items/audio_item.h"
 #include "items/image_item.h"
+#include "items/item_queue.h"
 #include "items/text_item.h"
 #include "items/tool_call_item.h"
 #include "items/tool_result_item.h"
@@ -20,16 +22,21 @@
 #include "logger.h"
 #include "model.h"
 #include "internal_api/null_session_manager.h"
+#include "internal_api/c_api_test_helpers.h"
 #include "internal_api/test_helpers.h"
 #include "internal_api/test_model_cache.h"
 #include "utils/string_utils.h"
 #include "utils/temp_path.h"
+#include "node_private_api.h"
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
+#include <limits>
 #include <algorithm>
 #include <chrono>
+#include <filesystem>
+#include <fstream>
 #include <future>
 #include <memory>
 #include <string>
@@ -403,6 +410,12 @@ class ChatSessionTest : public ::testing::Test {
 
   GenAIModelInstance& GetModel() { return *model_; }
   const Model& GetCatalogModel() { return catalog_model_; }
+  Model MakeCatalogModelWithMaxTokensSetting() {
+    ModelInfo info;
+    info.task = "chat-completion";
+    info.model_settings.Add("max_tokens", "1024");
+    return Model::FromModelInfo(std::move(info), "", svc_.download_manager, svc_.model_load_manager);
+  }
 
   static inline std::unique_ptr<StderrLogger> logger_;
   static inline std::unique_ptr<test::CpuOnlyEpDetector> ep_detector_;
@@ -457,6 +470,293 @@ std::string GetAssistantText(const Response& response) {
 // ===========================================================================
 // Session::Run (integration — requires loaded model)
 // ===========================================================================
+
+TEST_F(ChatSessionTest, RebuiltRequestIsPreflightedImmediatelyBeforeSubmitWithPromptCountParity) {
+  ChatSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  Request candidate;
+  candidate.AddOwnedItem(MakeMessage(FOUNDRY_LOCAL_ROLE_USER, "Count this prepared prompt."));
+  candidate.options.Add("max_output_tokens", "8");
+  candidate.options.Add("temperature", "0");
+
+  const auto candidate_preflight = session.PreflightRequest(candidate);
+  EXPECT_GT(candidate_preflight.prompt_tokens, 0);
+  EXPECT_EQ(candidate_preflight.output_reserve_tokens, 8);
+  EXPECT_EQ(candidate_preflight.required_tokens, candidate_preflight.prompt_tokens + 8);
+  EXPECT_EQ(session.TurnCount(), 0u);
+  EXPECT_EQ(session.MessageCount(), 0u);
+
+  Request final_request;
+  final_request.AddOwnedItem(MakeMessage(FOUNDRY_LOCAL_ROLE_USER, "Count this prepared prompt."));
+  final_request.options.Add("max_output_tokens", "8");
+  final_request.options.Add("temperature", "0");
+  const auto final_preflight = session.PreflightRequest(final_request);
+
+  const auto* api = fl::test::GetApi();
+  flRequestPreflight c_preflight{};
+  c_preflight.version = FOUNDRY_LOCAL_REQUEST_PREFLIGHT_MIN_VERSION;
+  ASSERT_FL_OK(api, api->GetInferenceApi()->Session_PreflightRequest(
+                        AsHandle<flSession>(&session), AsHandle<flRequest>(&final_request), &c_preflight));
+  EXPECT_EQ(c_preflight.prompt_tokens, final_preflight.prompt_tokens);
+  EXPECT_EQ(c_preflight.output_reserve_tokens, final_preflight.output_reserve_tokens);
+  EXPECT_EQ(c_preflight.required_tokens, final_preflight.required_tokens);
+  EXPECT_EQ(c_preflight.context_limit_tokens, final_preflight.context_limit_tokens);
+  EXPECT_EQ(c_preflight.fits != 0, final_preflight.fits);
+  EXPECT_EQ(c_preflight.deficit_tokens, final_preflight.deficit_tokens);
+
+  Response response;
+  session.ProcessRequest(final_request, response);
+  EXPECT_EQ(final_preflight.prompt_tokens, candidate_preflight.prompt_tokens);
+  EXPECT_EQ(response.usage.prompt_tokens, final_preflight.prompt_tokens);
+}
+
+TEST_F(ChatSessionTest, CapturedPreflightIsolatedFromLaterRequestAndSessionMutations) {
+  ChatSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  KeyValuePairs initial_session_options;
+  initial_session_options.Add("max_output_tokens", "7");
+  session.SetSessionOptions(initial_session_options);
+  session.AddToolDefinition(
+      {"lookup", "Look up a value", R"({"type":"object","properties":{"key":{"type":"string"}}})"});
+
+  Request request;
+  request.AddOwnedItem(MakeMessage(FOUNDRY_LOCAL_ROLE_USER, "Original captured text."));
+  request.options.Add("temperature", "0");
+
+  const auto expected = session.PreflightRequest(request);
+  auto operation = session.CaptureRequestPreflight(request);
+
+  auto& message = static_cast<MessageItem&>(*request.items.front());
+  auto& text = static_cast<TextItem&>(*message.content.front().owned);
+  text.text = "A substantially different request after capture.";
+  request.options.Add("max_output_tokens", "11");
+
+  KeyValuePairs changed_session_options;
+  changed_session_options.Add("max_output_tokens", "13");
+  session.SetSessionOptions(changed_session_options);
+  session.SetToolDefinitions({
+      {"replacement", "A different tool", R"({"type":"object","properties":{}})"},
+  });
+
+  Request transcript_request;
+  transcript_request.AddOwnedItem(MakeMessage(
+      FOUNDRY_LOCAL_ROLE_USER, "Reply with the single word ok."));
+  transcript_request.options.Add("max_output_tokens", "4");
+  transcript_request.options.Add("temperature", "0");
+  transcript_request.options.Add(FOUNDRY_LOCAL_PARAM_TOOL_CHOICE, "none");
+  Response transcript_response;
+  session.ProcessRequest(transcript_request, transcript_response);
+
+  const auto captured = operation->Execute();
+  EXPECT_EQ(captured.prompt_tokens, expected.prompt_tokens);
+  EXPECT_EQ(captured.output_reserve_tokens, 7);
+  EXPECT_EQ(captured.required_tokens, expected.required_tokens);
+  EXPECT_EQ(captured.context_limit_tokens, expected.context_limit_tokens);
+  EXPECT_EQ(captured.fits, expected.fits);
+  EXPECT_EQ(captured.deficit_tokens, expected.deficit_tokens);
+
+  const auto after_mutations = session.PreflightRequest(request);
+  EXPECT_EQ(after_mutations.output_reserve_tokens, 11);
+  EXPECT_NE(after_mutations.prompt_tokens, captured.prompt_tokens);
+}
+
+TEST_F(ChatSessionTest, CapturedPreflightOperationAllowsOnlyOneExecutionAttempt) {
+  ChatSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  Request request;
+  request.AddOwnedItem(MakeMessage(FOUNDRY_LOCAL_ROLE_USER, "Count this once."));
+  request.options.Add("max_output_tokens", "4");
+
+  const auto* api = fl::test::GetApi();
+  static_assert(sizeof(flNodePrivateApi) <= std::numeric_limits<uint32_t>::max());
+  const auto* private_api = FoundryLocalGetNodePrivateApi(
+      FOUNDRY_LOCAL_NODE_PRIVATE_API_VERSION, static_cast<uint32_t>(sizeof(flNodePrivateApi)));
+  ASSERT_NE(private_api, nullptr);
+
+  flRequestPreflightOperation* operation = nullptr;
+  ASSERT_FL_OK(api, private_api->Session_CaptureRequestPreflight(
+                        AsHandle<flSession>(&session), AsHandle<flRequest>(&request), &operation));
+  ASSERT_NE(operation, nullptr);
+
+  flRequestPreflight unsupported{};
+  unsupported.version = FOUNDRY_LOCAL_REQUEST_PREFLIGHT_MIN_VERSION - 1;
+  fl::test::StatusGuard unsupported_status{
+      private_api->RequestPreflightOperation_Execute(operation, &unsupported), api};
+  ASSERT_NE(unsupported_status.s, nullptr);
+  EXPECT_EQ(api->Status_GetErrorCode(unsupported_status.s), FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT);
+
+  flRequestPreflight result{};
+  result.version = FOUNDRY_LOCAL_REQUEST_PREFLIGHT_MIN_VERSION;
+  ASSERT_FL_OK(api, private_api->RequestPreflightOperation_Execute(operation, &result));
+  EXPECT_GT(result.prompt_tokens, 0);
+
+  fl::test::StatusGuard repeated_status{
+      private_api->RequestPreflightOperation_Execute(operation, &result), api};
+  ASSERT_NE(repeated_status.s, nullptr);
+  EXPECT_EQ(api->Status_GetErrorCode(repeated_status.s), FOUNDRY_LOCAL_ERROR_INVALID_USAGE);
+  private_api->RequestPreflightOperation_Release(operation);
+}
+
+TEST_F(ChatSessionTest, CapturedPreflightForTextOnlyModelRejectsMediaBeforeReadingBackingFile) {
+  auto temp = fl::test::TempPath::CreateTempFile("foundry_local_preflight_text_model_image_");
+  const auto& path = temp.path();
+  {
+    const std::vector<std::uint8_t> initial_bytes = {1, 2, 3};
+    std::ofstream output(path, std::ios::binary);
+    ASSERT_TRUE(output);
+    output.write(reinterpret_cast<const char*>(initial_bytes.data()),
+                 static_cast<std::streamsize>(initial_bytes.size()));
+    ASSERT_TRUE(output);
+  }
+
+  ModelInfo vision_info;
+  vision_info.task = "vision-language-chat";
+  auto vision_catalog = Model::FromModelInfo(
+      std::move(vision_info), "", svc_.download_manager, svc_.model_load_manager);
+  ChatSession session(vision_catalog, GetModel(), *logger_, null_telemetry_);
+  std::vector<std::unique_ptr<Item>> parts;
+  parts.push_back(std::make_unique<ImageItem>(path.string(), "png"));
+  Request request;
+  request.AddOwnedItem(std::make_unique<MessageItem>(
+      FOUNDRY_LOCAL_ROLE_USER, std::move(parts)));
+
+  auto operation = session.CaptureRequestPreflight(request);
+  ASSERT_TRUE(std::filesystem::remove(path));
+
+  // Model/request capability checks are intentionally cheaper than media I/O. Although the catalog metadata lets
+  // capture accept this image request, the loaded fixture is text-only, so execution must reject its real capability
+  // before ImageItem::ReadBytes can report that the backing file was removed.
+  try {
+    operation->Execute();
+    FAIL() << "Expected the text-only model to reject image input";
+  } catch (const fl::Exception& ex) {
+    EXPECT_EQ(ex.code(), FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT);
+    const std::string expected = "image or audio input requires a multimodal model";
+    const std::string actual = ex.what();
+    ASSERT_GE(actual.size(), expected.size());
+    EXPECT_EQ(actual.substr(actual.size() - expected.size()), expected);
+  }
+}
+
+TEST_F(ChatSessionTest, CapturingItemQueueRejectsWithoutConsumingIt) {
+  ChatSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  auto queue = std::make_unique<ItemQueue>();
+  queue->Push(std::make_unique<TextItem>("queued"));
+  auto* queue_view = queue.get();
+
+  Request request;
+  request.AddOwnedItem(std::move(queue));
+
+  EXPECT_THROW(session.CaptureRequestPreflight(request), fl::Exception);
+  EXPECT_EQ(queue_view->Size(), 1u);
+}
+
+TEST_F(ChatSessionTest, OmittedTypedLimitRepreflightOfRebuiltCandidatePreservesBudgetAndState) {
+  ChatSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  Request candidate;
+  candidate.AddOwnedItem(MakeMessage(FOUNDRY_LOCAL_ROLE_USER, "first"));
+  const auto candidate_preflight = session.PreflightRequest(candidate);
+
+  Request rebuilt;
+  rebuilt.AddOwnedItem(MakeMessage(FOUNDRY_LOCAL_ROLE_USER, "first"));
+  const auto rebuilt_preflight = session.PreflightRequest(rebuilt);
+
+  EXPECT_GT(candidate_preflight.prompt_tokens, 0);
+  EXPECT_EQ(candidate_preflight.output_reserve_tokens, 2048);
+  EXPECT_EQ(rebuilt_preflight.prompt_tokens, candidate_preflight.prompt_tokens);
+  EXPECT_EQ(rebuilt_preflight.output_reserve_tokens, candidate_preflight.output_reserve_tokens);
+  EXPECT_EQ(rebuilt_preflight.required_tokens, candidate_preflight.required_tokens);
+  EXPECT_EQ(session.TurnCount(), 0u);
+  EXPECT_EQ(session.MessageCount(), 0u);
+}
+
+TEST_F(ChatSessionTest, CatalogMaxTokensDoesNotChangeOmittedTypedOrOpenAIJsonPreflightLimits) {
+  auto catalog_model = MakeCatalogModelWithMaxTokensSetting();
+  ChatSession session(catalog_model, GetModel(), *logger_, null_telemetry_);
+  Request typed_request;
+  typed_request.AddOwnedItem(MakeMessage(
+      FOUNDRY_LOCAL_ROLE_USER, "Prepare this typed request without generation."));
+
+  const nlohmann::json request_json = {
+      {"model", GetModel().ModelId()},
+      {"messages", nlohmann::json::array({
+                       {{"role", "user"}, {"content", "Prepare this request without generation."}},
+                   })},
+      {"temperature", 0},
+  };
+
+  Request openai_request;
+  openai_request.AddOwnedItem(std::make_unique<TextItem>(
+      request_json.dump(), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+
+  // The tiny test model has a 512-token context, so submitting this 2048-token fallback
+  // to generation would be rejected. Preflight exercises the shared prepared-request seam
+  // without generating the fallback-sized completion.
+  const auto typed_preflight = session.PreflightRequest(typed_request);
+  const auto openai_preflight = session.PreflightRequest(openai_request);
+
+  EXPECT_EQ(typed_preflight.output_reserve_tokens, 2048);
+  EXPECT_EQ(openai_preflight.output_reserve_tokens, typed_preflight.output_reserve_tokens);
+  EXPECT_EQ(openai_preflight.required_tokens, openai_preflight.prompt_tokens + 2048);
+  EXPECT_FALSE(openai_preflight.fits);
+  EXPECT_EQ(session.TurnCount(), 0u);
+  EXPECT_EQ(session.MessageCount(), 0u);
+}
+
+TEST_F(ChatSessionTest, SessionOutputLimitWinsWhenOpenAIJsonOmitsWireLimit) {
+  auto catalog_model = MakeCatalogModelWithMaxTokensSetting();
+  ChatSession session(catalog_model, GetModel(), *logger_, null_telemetry_);
+  const nlohmann::json request_json = {
+      {"model", GetModel().ModelId()},
+      {"messages", nlohmann::json::array({
+                       {{"role", "user"}, {"content", "Prepare this request without generation."}},
+                   })},
+  };
+
+  Request request;
+  request.AddOwnedItem(std::make_unique<TextItem>(
+      request_json.dump(), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+  request.options.Add("max_output_tokens", "17");
+
+  const auto preflight = session.PreflightRequest(request);
+
+  EXPECT_EQ(preflight.output_reserve_tokens, 17);
+  EXPECT_EQ(preflight.required_tokens, preflight.prompt_tokens + 17);
+  EXPECT_EQ(session.TurnCount(), 0u);
+  EXPECT_EQ(session.MessageCount(), 0u);
+}
+
+TEST_F(ChatSessionTest, OpenAIJsonPreflightUsesConvertedRequestWithoutMutatingSessionTools) {
+  ChatSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);
+  nlohmann::json request_json = {
+      {"model", GetModel().ModelId()},
+      {"messages", nlohmann::json::array({
+                       {{"role", "user"}, {"content", "Look up the current value."}},
+                   })},
+      {"max_completion_tokens", 16},
+      {"temperature", 0.25},
+      {"tools", nlohmann::json::array({
+                    {{"type", "function"},
+                     {"function",
+                      {{"name", "lookup"},
+                       {"description", "Look up a value"},
+                       {"parameters",
+                        {{"type", "object"},
+                         {"properties", {{"key", {{"type", "string"}}}}},
+                         {"required", nlohmann::json::array({"key"})}}}}}},
+                })},
+      {"tool_choice", "auto"}};
+
+  Request request;
+  request.AddOwnedItem(std::make_unique<TextItem>(
+      request_json.dump(), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+
+  const auto preflight = session.PreflightRequest(request);
+
+  EXPECT_GT(preflight.prompt_tokens, 0);
+  EXPECT_EQ(preflight.output_reserve_tokens, 16);
+  EXPECT_EQ(preflight.required_tokens, preflight.prompt_tokens + 16);
+  EXPECT_TRUE(session.ToolDefinitions().empty());
+  EXPECT_EQ(session.TurnCount(), 0u);
+  EXPECT_EQ(session.MessageCount(), 0u);
+}
 
 TEST_F(ChatSessionTest, RunBasic) {
   ChatSession session(GetCatalogModel(), GetModel(), *logger_, null_telemetry_);

--- a/sdk_v2/cpp/test/internal_api/chat/dynamic_engine_chat_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat/dynamic_engine_chat_test.cc
@@ -6,11 +6,15 @@
 #include "inferencing/generative/chat/onnx_chat_engine.h"
 #include "inferencing/generative/chat/onnx_engine_chat_stream.h"
 #include "inferencing/model_load_manager.h"
+#include "configuration.h"
 #include "internal_api/test_helpers.h"
 #include "internal_api/test_model_cache.h"
 #include "items/text_item.h"
+#include "manager.h"
 #include "model.h"
 #include "telemetry/telemetry_logger.h"
+#include "utils/safe_getenv.h"
+#include "utils/temp_path.h"
 
 #include <gtest/gtest.h>
 #include <ort_genai.h>
@@ -24,11 +28,28 @@
 #include <optional>
 #include <span>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using namespace std::chrono_literals;
 
 namespace fl {
+
+class ChatSessionTestAccessor {
+ public:
+  static const ChatGenerator* CachedGenerator(const ChatSession& session) {
+    return session.cached_generator_.get();
+  }
+
+  static const OnnxEngineChatStream* CachedEngineStream(const ChatSession& session) {
+    return dynamic_cast<const OnnxEngineChatStream*>(session.cached_generator_.get());
+  }
+
+  static std::vector<int32_t> ResidentTokens(const OnnxEngineChatStream& stream) {
+    return stream.engine_.ResidentTokens(stream.conversation_);
+  }
+};
+
 namespace {
 
 constexpr const char* kDynamicEngineModelId = "tiny-paged-attention";
@@ -177,6 +198,38 @@ class DynamicEngineChatTest : public ::testing::Test {
   static inline GenAIModelInstance* model_ = nullptr;
   TelemetryLogger telemetry_{"dynamic-engine-test", test::NullLog()};
 };
+
+TEST_F(DynamicEngineChatTest, PreflightDoesNotMutateRetainedGeneratorEngineKvOrTranscriptState) {
+  ChatSession session(CatalogModel(), ModelInstance(), *logger_, telemetry_);
+  auto warm_request = MakeRequest("Retain this exact paged-attention state.", 5);
+  Response warm_response;
+  session.ProcessRequest(warm_request, warm_response);
+
+  const auto* generator_before = ChatSessionTestAccessor::CachedGenerator(session);
+  const auto* stream_before = ChatSessionTestAccessor::CachedEngineStream(session);
+  ASSERT_NE(generator_before, nullptr);
+  ASSERT_NE(stream_before, nullptr);
+  const auto resident_tokens_before = ChatSessionTestAccessor::ResidentTokens(*stream_before);
+  const auto token_count_before = generator_before->TokenCount();
+  const auto transcript_before = BuildChatPrompt(session.Transcript().Messages(), ModelInstance());
+  const auto turn_count_before = session.TurnCount();
+  const auto message_count_before = session.MessageCount();
+
+  auto candidate = MakeRequest("This request must remain hypothetical.", 7);
+  candidate.options.Add(kSystemPromptOption, "Use a different instruction.");
+  const auto preflight = session.PreflightRequest(candidate);
+
+  EXPECT_GT(preflight.prompt_tokens, 0);
+  EXPECT_EQ(preflight.output_reserve_tokens, 7);
+  EXPECT_EQ(ChatSessionTestAccessor::CachedGenerator(session), generator_before);
+  const auto* stream_after = ChatSessionTestAccessor::CachedEngineStream(session);
+  ASSERT_EQ(stream_after, stream_before);
+  EXPECT_EQ(ChatSessionTestAccessor::ResidentTokens(*stream_after), resident_tokens_before);
+  EXPECT_EQ(generator_before->TokenCount(), token_count_before);
+  EXPECT_EQ(BuildChatPrompt(session.Transcript().Messages(), ModelInstance()), transcript_before);
+  EXPECT_EQ(session.TurnCount(), turn_count_before);
+  EXPECT_EQ(session.MessageCount(), message_count_before);
+}
 
 TEST_F(DynamicEngineChatTest, RetainedContinuationReportsFreshPromptUsageParity) {
   ChatSession session(CatalogModel(), ModelInstance(), *logger_, telemetry_);
@@ -521,6 +574,220 @@ TEST_F(DynamicEngineChatTest, UnloadsAfterSessionsClose) {
   }
 
   EXPECT_TRUE(load_manager.UnloadModel(kUnloadModelId));
+}
+
+TEST(QualifiedQwenPreflightTest, RealCudaEnginePreflightMatchesGenerationAndPreservesWarmState) {
+  constexpr const char* kModelPathEnv = "FOUNDRY_QUALIFIED_QWEN_MODEL_PATH";
+  constexpr const char* kCudaLibraryEnv = "FOUNDRY_LOCAL_CUDA_EP_LIBRARY";
+  constexpr const char* kModelId = "qualified-qwen-generic-gpu";
+
+  const auto model_path = test::SafeGetEnv(kModelPathEnv);
+  const auto cuda_library = test::SafeGetEnv(kCudaLibraryEnv);
+  if (model_path.empty() || cuda_library.empty()) {
+    GTEST_SKIP() << "Qualified Qwen preflight requires both " << kModelPathEnv << " and " << kCudaLibraryEnv;
+  }
+
+  ASSERT_TRUE(std::filesystem::is_directory(model_path))
+      << kModelPathEnv << " must point directly to the model directory: " << model_path;
+  ASSERT_TRUE(std::filesystem::is_regular_file(cuda_library))
+      << kCudaLibraryEnv << " must point to the qualified CUDA EP library: " << cuda_library;
+
+  auto temp_root = test::TempPath::CreateTempDir("fl_qualified_qwen_preflight_");
+  const auto app_dir = temp_root.path() / "app";
+  const auto cache_dir = temp_root.path() / "cache";
+  const auto logs_dir = temp_root.path() / "logs";
+  ASSERT_TRUE(std::filesystem::create_directories(app_dir));
+  ASSERT_TRUE(std::filesystem::create_directories(cache_dir));
+  ASSERT_TRUE(std::filesystem::create_directories(logs_dir));
+
+  Configuration config;
+  config.app_name = "qualified-qwen-preflight-test";
+  config.app_data_dir = app_dir.string();
+  config.model_cache_dir = cache_dir.string();
+  config.logs_dir = logs_dir.string();
+  config.disable_nonessential_telemetry = true;
+
+  Manager* manager = nullptr;
+  ASSERT_NO_THROW(manager = &Manager::Create(config));
+  ASSERT_NE(manager, nullptr);
+
+  struct ManagerDestroyGuard {
+    ~ManagerDestroyGuard() { Manager::Destroy(); }
+  } manager_destroy_guard;
+
+  std::vector<std::string> requested_eps = {"CUDAExecutionProvider"};
+  const auto ep_result = manager->DownloadAndRegisterEps(&requested_eps, {});
+  ASSERT_TRUE(ep_result.success) << ep_result.status;
+  EXPECT_FALSE(ep_result.cancelled);
+  EXPECT_TRUE(ep_result.failed_eps.empty());
+  ASSERT_EQ(ep_result.registered_eps.size(), 1u);
+  EXPECT_EQ(ep_result.registered_eps[0], "CUDAExecutionProvider");
+
+  auto& load_manager = manager->GetModelLoadManager();
+  const auto load_result = load_manager.LoadModel(model_path, kModelId, ExecutionProvider::kCUDA);
+  ASSERT_EQ(load_result.status, ModelLoadManager::LoadStatus::kSuccess);
+  ASSERT_NE(load_result.model, nullptr);
+  ASSERT_EQ(load_result.model->EP(), ExecutionProvider::kCUDA);
+  ASSERT_EQ(load_result.model->GetGenAIConfig().GetChatBackendKind(), ChatBackendKind::kEngine);
+  ASSERT_NE(load_result.model->GetChatEngine(), nullptr);
+
+  ModelInfo info;
+  info.model_id = kModelId;
+  info.task = "chat-completion";
+  info.device_type = DeviceType::kGPU;
+  info.execution_provider = "CUDAExecutionProvider";
+  info.model_settings.Add("max_tokens", "1024");
+  auto catalog_model = Model::FromModelInfo(std::move(info), model_path, manager->GetDownloadManager(), load_manager);
+
+  {
+    ChatSession session(catalog_model, *load_result.model, manager->GetLogger(), manager->GetTelemetry());
+
+    auto warm_request = MakeRequest("Reply with one short word.", 4);
+    const auto warm_preflight = session.PreflightRequest(warm_request);
+    Response warm_response;
+    session.ProcessRequest(warm_request, warm_response);
+
+    EXPECT_GT(warm_preflight.prompt_tokens, 0);
+    EXPECT_EQ(warm_preflight.output_reserve_tokens, 4);
+    EXPECT_EQ(warm_response.usage.prompt_tokens, warm_preflight.prompt_tokens);
+    EXPECT_GE(warm_response.usage.completion_tokens, 1);
+    EXPECT_LE(warm_response.usage.completion_tokens, 4);
+
+    const auto* generator_before = ChatSessionTestAccessor::CachedGenerator(session);
+    const auto* stream_before = ChatSessionTestAccessor::CachedEngineStream(session);
+    ASSERT_NE(generator_before, nullptr);
+    ASSERT_NE(stream_before, nullptr);
+    const auto resident_tokens_before = ChatSessionTestAccessor::ResidentTokens(*stream_before);
+    const auto generator_tokens_before = generator_before->TokenCount();
+    const auto transcript_before = BuildChatPrompt(session.Transcript().Messages(), *load_result.model);
+    const auto turn_count_before = session.TurnCount();
+    const auto message_count_before = session.MessageCount();
+
+    KeyValuePairs original_session_options;
+    original_session_options.Add(kSystemPromptOption, "Use the original captured session instruction.");
+    session.SetSessionOptions(original_session_options);
+    session.SetToolDefinitions({
+        {"original_lookup", "Look up the original value",
+         R"({"type":"object","properties":{"key":{"type":"string"}}})"},
+    });
+
+    Request original_candidate;
+    original_candidate.AddOwnedItem(UserMessage("Original captured Qwen prompt."));
+    original_candidate.options.Add("max_output_tokens", "8");
+    original_candidate.options.Add("temperature", "0");
+    original_candidate.options.Add(FOUNDRY_LOCAL_PARAM_TOOL_CHOICE, "none");
+    const auto original_preflight = session.PreflightRequest(original_candidate);
+
+    Request captured_candidate;
+    auto original_item = UserMessage("Original captured Qwen prompt.");
+    auto* original_message = static_cast<MessageItem*>(original_item.get());
+    captured_candidate.AddOwnedItem(std::move(original_item));
+    captured_candidate.options.Add("max_output_tokens", "8");
+    captured_candidate.options.Add("temperature", "0");
+    captured_candidate.options.Add(FOUNDRY_LOCAL_PARAM_TOOL_CHOICE, "none");
+    auto captured_operation = session.CaptureRequestPreflight(captured_candidate);
+
+    auto& original_text = static_cast<TextItem&>(*original_message->content.front().owned);
+    original_text.text = "Changed Qwen prompt after capture with substantially different text.";
+    captured_candidate.AddOwnedItem(UserMessage("Additional request item added after capture."));
+    captured_candidate.options.Add("max_output_tokens", "17");
+
+    KeyValuePairs changed_session_options;
+    changed_session_options.Add(kSystemPromptOption, "Use the changed session instruction.");
+    changed_session_options.Add("max_output_tokens", "23");
+    session.SetSessionOptions(changed_session_options);
+    session.SetToolDefinitions({
+        {"replacement_search", "Search for a replacement value",
+         R"({"type":"object","properties":{"query":{"type":"string"}},"required":["query"]})"},
+    });
+
+    const auto captured_preflight = captured_operation->Execute();
+    EXPECT_EQ(captured_preflight.prompt_tokens, original_preflight.prompt_tokens);
+    EXPECT_EQ(captured_preflight.output_reserve_tokens, 8);
+    EXPECT_EQ(captured_preflight.required_tokens, captured_preflight.prompt_tokens + 8);
+
+    const auto changed_preflight = session.PreflightRequest(captured_candidate);
+    EXPECT_EQ(changed_preflight.output_reserve_tokens, 17);
+    EXPECT_EQ(changed_preflight.required_tokens, changed_preflight.prompt_tokens + 17);
+    EXPECT_NE(changed_preflight.prompt_tokens, captured_preflight.prompt_tokens);
+
+    KeyValuePairs reset_session_options;
+    session.SetSessionOptions(reset_session_options);
+    session.ClearToolDefinitions();
+
+    Request candidate;
+    candidate.AddOwnedItem(UserMessage("Describe the retained answer briefly."));
+    const auto first_preflight = session.PreflightRequest(candidate);
+
+    Request rebuilt_candidate;
+    rebuilt_candidate.AddOwnedItem(UserMessage("Describe the retained answer briefly."));
+    const auto rebuilt_preflight = session.PreflightRequest(rebuilt_candidate);
+
+    EXPECT_EQ(first_preflight.output_reserve_tokens, 2048);
+    EXPECT_EQ(first_preflight.required_tokens, first_preflight.prompt_tokens + 2048);
+    EXPECT_EQ(rebuilt_preflight.prompt_tokens, first_preflight.prompt_tokens);
+    EXPECT_EQ(rebuilt_preflight.output_reserve_tokens, first_preflight.output_reserve_tokens);
+    EXPECT_EQ(rebuilt_preflight.required_tokens, first_preflight.required_tokens);
+
+    EXPECT_EQ(ChatSessionTestAccessor::CachedGenerator(session), generator_before);
+    const auto* stream_after = ChatSessionTestAccessor::CachedEngineStream(session);
+    ASSERT_EQ(stream_after, stream_before);
+    EXPECT_EQ(ChatSessionTestAccessor::ResidentTokens(*stream_after), resident_tokens_before);
+    EXPECT_EQ(generator_before->TokenCount(), generator_tokens_before);
+    EXPECT_EQ(BuildChatPrompt(session.Transcript().Messages(), *load_result.model), transcript_before);
+    EXPECT_EQ(session.TurnCount(), turn_count_before);
+    EXPECT_EQ(session.MessageCount(), message_count_before);
+  }
+
+  {
+    ChatSession session(catalog_model, *load_result.model, manager->GetLogger(), manager->GetTelemetry());
+    Request candidate;
+    candidate.AddOwnedItem(UserMessage("Reply with exactly one word: OK."));
+    candidate.options.Add("temperature", "0");
+    const auto candidate_preflight = session.PreflightRequest(candidate);
+
+    Request final_request;
+    final_request.AddOwnedItem(UserMessage("Reply with exactly one word: OK."));
+    final_request.options.Add("temperature", "0");
+    const auto final_preflight = session.PreflightRequest(final_request);
+
+    Response response;
+    ASSERT_NO_THROW(session.ProcessRequest(final_request, response));
+    EXPECT_EQ(candidate_preflight.prompt_tokens, final_preflight.prompt_tokens);
+    EXPECT_EQ(final_preflight.output_reserve_tokens, 2048);
+    EXPECT_EQ(final_preflight.required_tokens, final_preflight.prompt_tokens + 2048);
+    EXPECT_FALSE(response.items.empty());
+    EXPECT_EQ(response.usage.prompt_tokens, final_preflight.prompt_tokens);
+    EXPECT_GT(response.usage.completion_tokens, 0);
+    EXPECT_LE(response.usage.completion_tokens, 2048);
+  }
+
+  {
+    ChatSession session(catalog_model, *load_result.model, manager->GetLogger(), manager->GetTelemetry());
+    constexpr std::string_view request_json =
+        R"({"model":"qualified-qwen-generic-gpu","messages":[{"role":"user","content":"Reply with exactly one word: OK."}],"temperature":0,"stop":["\n"]})";
+    Request candidate;
+    candidate.AddOwnedItem(std::make_unique<TextItem>(
+        std::string(request_json), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+    const auto candidate_preflight = session.PreflightRequest(candidate);
+
+    Request final_request;
+    final_request.AddOwnedItem(std::make_unique<TextItem>(
+        std::string(request_json), FOUNDRY_LOCAL_TEXT_ITEM_TYPE_OPENAI_JSON));
+    const auto final_preflight = session.PreflightRequest(final_request);
+
+    Response response;
+    ASSERT_NO_THROW(session.ProcessRequest(final_request, response));
+    EXPECT_EQ(candidate_preflight.prompt_tokens, final_preflight.prompt_tokens);
+    EXPECT_EQ(final_preflight.output_reserve_tokens, 2048);
+    EXPECT_EQ(final_preflight.required_tokens, final_preflight.prompt_tokens + 2048);
+    EXPECT_FALSE(response.items.empty());
+    EXPECT_EQ(response.usage.prompt_tokens, final_preflight.prompt_tokens);
+    EXPECT_GT(response.usage.completion_tokens, 0);
+    EXPECT_LE(response.usage.completion_tokens, 2048);
+  }
+
+  EXPECT_TRUE(load_manager.UnloadModel(kModelId));
 }
 
 }  // namespace

--- a/sdk_v2/cpp/test/internal_api/chat/request_budget_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat/request_budget_test.cc
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "inferencing/generative/chat/request_budget.h"
+
+#include "exception.h"
+#include "inferencing/generative/chat/search_options.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+namespace fl {
+namespace {
+
+TEST(RequestBudgetTest, ExactBoundariesAtNinetyNinetyNineOneHundredAndOneHundredOne) {
+  const auto ninety = ComputeRequestBudget(90, 10, 100);
+  EXPECT_EQ(ninety.required_tokens, 100);
+  EXPECT_TRUE(ninety.fits);
+  EXPECT_EQ(ninety.deficit_tokens, 0);
+
+  const auto ninety_nine = ComputeRequestBudget(99, 1, 100);
+  EXPECT_EQ(ninety_nine.required_tokens, 100);
+  EXPECT_TRUE(ninety_nine.fits);
+
+  const auto one_hundred = ComputeRequestBudget(100, 1, 100);
+  EXPECT_EQ(one_hundred.required_tokens, 101);
+  EXPECT_FALSE(one_hundred.fits);
+  EXPECT_EQ(one_hundred.deficit_tokens, 1);
+
+  const auto one_hundred_one = ComputeRequestBudget(101, 1, 100);
+  EXPECT_EQ(one_hundred_one.required_tokens, 102);
+  EXPECT_FALSE(one_hundred_one.fits);
+  EXPECT_EQ(one_hundred_one.deficit_tokens, 2);
+}
+
+TEST(RequestBudgetTest, RejectsInvalidOutputReserveAndCheckedAdditionOverflow) {
+  EXPECT_THROW(ComputeRequestBudget(1, 0, 100), Exception);
+  EXPECT_THROW(ComputeRequestBudget((std::numeric_limits<int64_t>::max)(), 1, 100), Exception);
+}
+
+TEST(RequestBudgetTest, ResolvedTextFallbackFitsExactlyAndRejectsOneTokenOver) {
+  const auto output_limit = ResolveOutputLimit(SearchOptions{}, false);
+
+  const auto exact = ComputeRequestBudget(2048, output_limit, 4096);
+  EXPECT_EQ(exact.required_tokens, 4096);
+  EXPECT_TRUE(exact.fits);
+
+  const auto one_over = ComputeRequestBudget(2049, output_limit, 4096);
+  EXPECT_EQ(one_over.required_tokens, 4097);
+  EXPECT_FALSE(one_over.fits);
+  EXPECT_EQ(one_over.deficit_tokens, 1);
+}
+
+TEST(RequestBudgetTest, PositiveModelContextLengthWinsWithPositiveSearchFallback) {
+  GenAIConfig config;
+  config.model.emplace();
+  config.model->context_length = 4096;
+  config.search.emplace();
+  config.search->max_length = 2048;
+  EXPECT_EQ(GetModelMaxContextLength(config), 4096);
+
+  config.model->context_length = 0;
+  EXPECT_EQ(GetModelMaxContextLength(config), 2048);
+
+  config.search->max_length = 0;
+  EXPECT_THROW(GetModelMaxContextLength(config), Exception);
+}
+
+}  // namespace
+}  // namespace fl

--- a/sdk_v2/cpp/test/internal_api/chat/search_options_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat/search_options_test.cc
@@ -26,6 +26,15 @@
 
 using namespace fl;
 
+namespace {
+
+SearchOptions ResolveTextOutputLimit(SearchOptions options = {}) {
+  options.max_output_tokens = ResolveOutputLimit(options, false);
+  return options;
+}
+
+}  // namespace
+
 TEST(SearchOptionsParsingTest, TemperatureOutsideSupportedRangeThrows) {
   for (const char* temperature : {"-1", "2.1", "nan"}) {
     KeyValuePairs params;
@@ -35,19 +44,23 @@ TEST(SearchOptionsParsingTest, TemperatureOutsideSupportedRangeThrows) {
   }
 }
 
-TEST(SearchOptionsParsingTest, OmittedOutputLimitUsesTextAndMediaDefaults) {
-  SearchOptions defaults;
-  EXPECT_EQ(GetDefaultMaxOutputTokens(/*has_media=*/false), 2048);
-  EXPECT_EQ(GetDefaultMaxOutputTokens(/*has_media=*/true), 3072);
-  EXPECT_EQ(ResolveMaxOutputTokens(defaults, GetDefaultMaxOutputTokens(/*has_media=*/false)), 2048);
-  EXPECT_EQ(ResolveMaxOutputTokens(defaults, GetDefaultMaxOutputTokens(/*has_media=*/true)), 3072);
+TEST(OutputLimitResolutionTest, AbsentCurrentSchemaGenerationDefaultUsesTextAndMediaFallbacks) {
+  const SearchOptions options;
+
+  const auto text = ResolveOutputLimit(options, false);
+  EXPECT_EQ(text, 2048);
+
+  const auto media = ResolveOutputLimit(options, true);
+  EXPECT_EQ(media, 3072);
 }
 
-TEST(SearchOptionsParsingTest, ExplicitOutputLimitOverridesTurnDefault) {
-  SearchOptions explicit_limit;
-  explicit_limit.max_output_tokens = 64;
-  EXPECT_EQ(ResolveMaxOutputTokens(explicit_limit, GetDefaultMaxOutputTokens(/*has_media=*/false)), 64);
-  EXPECT_EQ(ResolveMaxOutputTokens(explicit_limit, GetDefaultMaxOutputTokens(/*has_media=*/true)), 64);
+TEST(OutputLimitResolutionTest, ExplicitPositiveRequestLimitWinsForTextAndMedia) {
+  SearchOptions options;
+  options.max_output_tokens = 64;
+
+  for (bool has_media : {false, true}) {
+    EXPECT_EQ(ResolveOutputLimit(options, has_media), 64);
+  }
 }
 
 TEST(SearchOptionsParsingTest, RetainedGenerationSettingsAreBackendAware) {
@@ -212,10 +225,18 @@ TEST(SamplingPlanTest, OutOfRangeScalarsAreRejected) {
   EXPECT_THROW(ResolveSamplingPlan(negative_top_k), fl::Exception);
 }
 
-TEST(EngineTurnOptionsPlanTest, LeavesMaxOutputAndSamplingUnsetWhenCallerOmitsThem) {
+TEST(EngineTurnOptionsPlanTest, RejectsAnUnresolvedOutputLimitBeforeBackendSubmission) {
+  EXPECT_THROW(
+      BuildEngineTurnOptionsPlan(SearchOptions{}, ToolCallContext{}, ChatBackendKind::kEngine, false),
+      fl::Exception);
+}
+
+TEST(EngineTurnOptionsPlanTest, ProductionFacingPlanCarriesCanonicalResolvedFallback) {
+  const auto options = ResolveTextOutputLimit();
   const auto plan =
-      BuildEngineTurnOptionsPlan(SearchOptions{}, ToolCallContext{}, ChatBackendKind::kEngine, false);
-  EXPECT_FALSE(plan.max_generated_tokens.has_value());
+      BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine, false);
+
+  EXPECT_EQ(plan.max_generated_tokens, 2048);
   EXPECT_FALSE(plan.sampling.do_sample.has_value());
   EXPECT_FALSE(plan.sampling.temperature.has_value());
   EXPECT_FALSE(plan.seed.has_value());
@@ -245,8 +266,7 @@ TEST(EngineTurnOptionsPlanTest, CarriesStopStringsSeedAndGuidanceOnDynamicBacken
   tool_ctx.guidance_data = R"({"type":"object"})";
 
   const auto plan = BuildEngineTurnOptionsPlan(options, tool_ctx, ChatBackendKind::kEngine, false);
-  ASSERT_TRUE(plan.max_generated_tokens.has_value());
-  EXPECT_EQ(*plan.max_generated_tokens, 64);
+  EXPECT_EQ(plan.max_generated_tokens, 64);
   ASSERT_TRUE(plan.seed.has_value());
   EXPECT_EQ(*plan.seed, 42);
   EXPECT_EQ(plan.stop_sequences, (std::vector<std::string>{"END", "STOP"}));
@@ -260,6 +280,7 @@ TEST(EngineTurnOptionsPlanTest, NegativeSeedIsOmitted) {
   for (int seed : {-1, -2, std::numeric_limits<int>::min()}) {
     SearchOptions options;
     options.seed = seed;
+    options = ResolveTextOutputLimit(std::move(options));
 
     const auto plan =
         BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine, false);
@@ -270,6 +291,7 @@ TEST(EngineTurnOptionsPlanTest, NegativeSeedIsOmitted) {
 TEST(EngineTurnOptionsPlanTest, ZeroSeedIsForwarded) {
   SearchOptions options;
   options.seed = 0;
+  options = ResolveTextOutputLimit(std::move(options));
 
   const auto plan =
       BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine, false);
@@ -283,7 +305,7 @@ TEST(EngineTurnOptionsPlanTest, UserGuidanceAppliesWithoutToolOnlyMode) {
   tool_ctx.guidance_data = R"({"type":"object","required":["answer"]})";
 
   const auto plan =
-      BuildEngineTurnOptionsPlan(SearchOptions{}, tool_ctx, ChatBackendKind::kEngine, false);
+      BuildEngineTurnOptionsPlan(ResolveTextOutputLimit(), tool_ctx, ChatBackendKind::kEngine, false);
 
   ASSERT_TRUE(plan.guidance.has_value());
   EXPECT_EQ(plan.guidance->type, "json_schema");
@@ -301,10 +323,11 @@ TEST(EngineTurnOptionsPlanTest, PromptOpenedReasoningOmitsTheGrammarOpener) {
   tool_ctx.reasoning_start_token_id = 248058;
   tool_ctx.reasoning_end_token_id = 248059;
 
+  const auto options = ResolveTextOutputLimit();
   const auto closed_plan =
-      BuildEngineTurnOptionsPlan(SearchOptions{}, tool_ctx, ChatBackendKind::kEngine, false);
+      BuildEngineTurnOptionsPlan(options, tool_ctx, ChatBackendKind::kEngine, false);
   const auto open_plan =
-      BuildEngineTurnOptionsPlan(SearchOptions{}, tool_ctx, ChatBackendKind::kEngine, true);
+      BuildEngineTurnOptionsPlan(options, tool_ctx, ChatBackendKind::kEngine, true);
 
   ASSERT_TRUE(closed_plan.guidance.has_value());
   ASSERT_TRUE(open_plan.guidance.has_value());
@@ -319,6 +342,7 @@ TEST(EngineTurnOptionsPlanTest, NeutralPenaltiesDoNotOverrideModelDefaults) {
   SearchOptions options;
   options.frequency_penalty = 0.0f;
   options.presence_penalty = 0.0f;
+  options = ResolveTextOutputLimit(std::move(options));
 
   EXPECT_NO_THROW(
       BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine, false));
@@ -331,6 +355,7 @@ TEST(EngineTurnOptionsPlanTest, RejectsNonzeroPenalties) {
     SearchOptions options;
     options.frequency_penalty = frequency;
     options.presence_penalty = presence;
+    options = ResolveTextOutputLimit(std::move(options));
 
     EXPECT_THROW(BuildEngineTurnOptionsPlan(options, ToolCallContext{}, ChatBackendKind::kEngine, false),
                  fl::Exception);
@@ -340,11 +365,13 @@ TEST(EngineTurnOptionsPlanTest, RejectsNonzeroPenalties) {
 TEST(EngineTurnOptionsPlanTest, RejectsTrueEarlyStoppingAndAcceptsNeutralFalse) {
   SearchOptions enabled;
   enabled.early_stopping = true;
+  enabled = ResolveTextOutputLimit(std::move(enabled));
   EXPECT_THROW(BuildEngineTurnOptionsPlan(enabled, ToolCallContext{}, ChatBackendKind::kEngine, false),
                fl::Exception);
 
   SearchOptions disabled;
   disabled.early_stopping = false;
+  disabled = ResolveTextOutputLimit(std::move(disabled));
   EXPECT_NO_THROW(
       BuildEngineTurnOptionsPlan(disabled, ToolCallContext{}, ChatBackendKind::kEngine, false));
 }

--- a/sdk_v2/cpp/test/internal_api/chat_completions_converter_test.cc
+++ b/sdk_v2/cpp/test/internal_api/chat_completions_converter_test.cc
@@ -109,7 +109,7 @@ TEST(ChatCompletionsConverterTest, ApplyCatalogDefaults_DoesNotOverrideExisting)
   EXPECT_FLOAT_EQ(*req.top_p, 0.5f);
 }
 
-TEST(ChatCompletionsConverterTest, ApplyCatalogDefaults_AppliesMaxTokens) {
+TEST(ChatCompletionsConverterTest, ApplyCatalogDefaults_IgnoresCatalogMaxTokensAsAnOutputLimit) {
   ChatCompletionRequest req;
 
   KeyValuePairs settings;
@@ -117,8 +117,26 @@ TEST(ChatCompletionsConverterTest, ApplyCatalogDefaults_AppliesMaxTokens) {
 
   ApplyCatalogDefaults(req, settings);
 
-  ASSERT_TRUE(req.max_tokens.has_value());
-  EXPECT_EQ(*req.max_tokens, 1024);
+  EXPECT_FALSE(req.max_tokens.has_value());
+  EXPECT_FALSE(req.max_completion_tokens.has_value());
+}
+
+TEST(ChatCompletionsConverterTest, ApplyCatalogDefaults_PreservesExplicitWireOutputLimits) {
+  ChatCompletionRequest req;
+  req.max_completion_tokens = 64;
+  req.max_tokens = 32;
+
+  KeyValuePairs settings;
+  settings.Add("max_tokens", "1024");
+
+  ApplyCatalogDefaults(req, settings);
+
+  EXPECT_EQ(req.max_completion_tokens, 64);
+  EXPECT_EQ(req.max_tokens, 32);
+
+  Request session_request;
+  MapRequestParameters(req, session_request);
+  EXPECT_STREQ(session_request.options.Find("max_output_tokens"), "64");
 }
 
 TEST(ChatCompletionsConverterTest, ApplyCatalogDefaults_AppliesMetadata) {

--- a/sdk_v2/cpp/test/internal_api/item_test.cc
+++ b/sdk_v2/cpp/test/internal_api/item_test.cc
@@ -17,6 +17,7 @@
 #include "items/tool_result_item.h"
 #include "inferencing/session/session.h"
 #include "exception.h"
+#include "utils/temp_path.h"
 
 #include <foundry_local/foundry_local_cpp.h>
 #include <gtest/gtest.h>
@@ -37,6 +38,156 @@ TEST(ItemTypeNameTest, ReturnsSymbolicNames) {
   EXPECT_EQ(Item::TypeName(FOUNDRY_LOCAL_ITEM_IMAGE), "IMAGE");
   EXPECT_EQ(Item::TypeName(FOUNDRY_LOCAL_ITEM_AUDIO), "AUDIO");
   EXPECT_EQ(Item::TypeName(static_cast<flItemType>(-1)), "UNKNOWN");
+}
+
+TEST(RequestPreflightSnapshotTest, DeepCopiesNestedImageBytes) {
+  std::vector<std::uint8_t> source = {1, 2, 3, 4};
+  std::vector<std::unique_ptr<Item>> parts;
+  parts.push_back(std::make_unique<ImageItem>(source.data(), source.size(), "png"));
+
+  Request request;
+  request.AddOwnedItem(std::make_unique<MessageItem>(
+      FOUNDRY_LOCAL_ROLE_USER, std::move(parts)));
+  auto snapshot = request.CapturePreflightSnapshot();
+
+  source.assign(source.size(), 9);
+
+  const auto& message = static_cast<const MessageItem&>(*snapshot.items.front());
+  const auto& image = static_cast<const ImageItem&>(*message.content.front().view);
+  ASSERT_EQ(image.data_size, 4u);
+  const auto* bytes = static_cast<const std::uint8_t*>(image.data);
+  EXPECT_EQ(std::vector<std::uint8_t>(bytes, bytes + image.data_size),
+            (std::vector<std::uint8_t>{1, 2, 3, 4}));
+}
+
+TEST(RequestPreflightSnapshotTest, CapturePreservesMissingMediaUrisWithoutReadingFiles) {
+  const auto image_path = std::filesystem::temp_directory_path() /
+                          "foundry_local_missing_preflight_snapshot_image.bin";
+  const auto audio_path = std::filesystem::temp_directory_path() /
+                          "foundry_local_missing_preflight_snapshot_audio.bin";
+  std::filesystem::remove(image_path);
+  std::filesystem::remove(audio_path);
+
+  std::vector<std::unique_ptr<Item>> parts;
+  parts.push_back(std::make_unique<ImageItem>(image_path.string(), "png"));
+  auto audio = std::make_unique<AudioItem>(audio_path.string(), "wav");
+  audio->sample_rate = 16'000;
+  audio->channels = 2;
+  parts.push_back(std::move(audio));
+
+  Request request;
+  request.AddOwnedItem(std::make_unique<MessageItem>(
+      FOUNDRY_LOCAL_ROLE_USER, std::move(parts)));
+
+  auto snapshot = request.CapturePreflightSnapshot();
+
+  const auto& message = static_cast<const MessageItem&>(*snapshot.items.front());
+  const auto& image = static_cast<const ImageItem&>(*message.content.front().view);
+  const auto& captured_audio =
+      static_cast<const AudioItem&>(*message.content.back().view);
+  EXPECT_EQ(image.data, nullptr);
+  EXPECT_EQ(image.data_size, 0u);
+  EXPECT_EQ(image.format, "png");
+  EXPECT_EQ(image.uri, image_path.string());
+  EXPECT_EQ(captured_audio.data, nullptr);
+  EXPECT_EQ(captured_audio.data_size, 0u);
+  EXPECT_EQ(captured_audio.format, "wav");
+  EXPECT_EQ(captured_audio.sample_rate, 16'000);
+  EXPECT_EQ(captured_audio.channels, 2);
+  EXPECT_EQ(captured_audio.uri, audio_path.string());
+}
+
+TEST(RequestPreflightSnapshotTest, UriBackedSnapshotReadsFileStateAtUseTime) {
+  const auto path = std::filesystem::temp_directory_path() /
+                    "foundry_local_changed_preflight_snapshot_image.bin";
+  const std::vector<std::uint8_t> captured_file_bytes = {1, 2, 3};
+  const std::vector<std::uint8_t> execution_file_bytes = {8, 9, 10, 11};
+  {
+    std::ofstream output(path, std::ios::binary);
+    ASSERT_TRUE(output);
+    output.write(reinterpret_cast<const char*>(captured_file_bytes.data()),
+                 static_cast<std::streamsize>(captured_file_bytes.size()));
+    ASSERT_TRUE(output);
+  }
+
+  Request request;
+  request.AddOwnedItem(std::make_unique<ImageItem>(path.string(), "png"));
+  auto snapshot = request.CapturePreflightSnapshot();
+
+  {
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(output);
+    output.write(reinterpret_cast<const char*>(execution_file_bytes.data()),
+                 static_cast<std::streamsize>(execution_file_bytes.size()));
+    ASSERT_TRUE(output);
+  }
+
+  const auto& image = static_cast<const ImageItem&>(*snapshot.items.front());
+  EXPECT_EQ(image.ReadBytes(), execution_file_bytes);
+  EXPECT_EQ(image.uri, path.string());
+  EXPECT_EQ(image.format, "png");
+
+  ASSERT_TRUE(std::filesystem::remove(path));
+}
+
+TEST(RequestPreflightSnapshotTest, UriBackedSnapshotObservesFileRemovalAtReadBytes) {
+  auto image_temp = fl::test::TempPath::CreateTempFile("foundry_local_preflight_removed_image_");
+  auto audio_temp = fl::test::TempPath::CreateTempFile("foundry_local_preflight_removed_audio_");
+  {
+    std::ofstream image_output(image_temp.path(), std::ios::binary);
+    ASSERT_TRUE(image_output);
+    image_output.put('\x01');
+    ASSERT_TRUE(image_output);
+
+    std::ofstream audio_output(audio_temp.path(), std::ios::binary);
+    ASSERT_TRUE(audio_output);
+    audio_output.put('\x02');
+    ASSERT_TRUE(audio_output);
+  }
+
+  Request request;
+  request.AddOwnedItem(std::make_unique<ImageItem>(image_temp.string(), "png"));
+  request.AddOwnedItem(std::make_unique<AudioItem>(audio_temp.string(), "wav"));
+  auto snapshot = request.CapturePreflightSnapshot();
+
+  ASSERT_TRUE(std::filesystem::remove(image_temp.path()));
+  ASSERT_TRUE(std::filesystem::remove(audio_temp.path()));
+
+  const auto& image = static_cast<const ImageItem&>(*snapshot.items.front());
+  try {
+    image.ReadBytes();
+    FAIL() << "Expected ImageItem::ReadBytes to observe backing file removal";
+  } catch (const fl::Exception& ex) {
+    EXPECT_EQ(ex.code(), FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT);
+    EXPECT_NE(std::string(ex.what()).find("failed to open image file: " + image_temp.string()), std::string::npos);
+  }
+
+  const auto& audio = static_cast<const AudioItem&>(*snapshot.items.back());
+  try {
+    audio.ReadBytes();
+    FAIL() << "Expected AudioItem::ReadBytes to observe backing file removal";
+  } catch (const fl::Exception& ex) {
+    EXPECT_EQ(ex.code(), FOUNDRY_LOCAL_ERROR_INVALID_ARGUMENT);
+    EXPECT_NE(std::string(ex.what()).find("failed to open audio file: " + audio_temp.string()), std::string::npos);
+  }
+}
+
+TEST(MessageItemCloneTest, UriBackedImageCloneDoesNotReadBackingFile) {
+  const auto missing_path = std::filesystem::temp_directory_path() /
+                            "foundry_local_missing_message_clone_image.bin";
+  std::filesystem::remove(missing_path);
+
+  std::vector<std::unique_ptr<Item>> parts;
+  parts.push_back(std::make_unique<ImageItem>(missing_path.string(), "jpeg"));
+  const MessageItem source(FOUNDRY_LOCAL_ROLE_USER, std::move(parts));
+
+  const MessageItem clone(source);
+
+  const auto& image = static_cast<const ImageItem&>(*clone.content.front().view);
+  EXPECT_EQ(image.data, nullptr);
+  EXPECT_EQ(image.data_size, 0u);
+  EXPECT_EQ(image.format, "jpeg");
+  EXPECT_EQ(image.uri, missing_path.string());
 }
 
 // ========================================================================

--- a/sdk_v2/cpp/test/internal_api/session_manager_test.cc
+++ b/sdk_v2/cpp/test/internal_api/session_manager_test.cc
@@ -4,6 +4,7 @@
 
 #include "inferencing/session/session_manager.h"
 #include "inferencing/session/session_registration.h"
+#include "c_api_types.h"
 #include "inferencing/generative/chat/chat_session.h"
 #include "inferencing/model_load_manager.h"
 #include "inferencing/generative/openresponses/response_store.h"
@@ -12,6 +13,7 @@
 #include "logger.h"
 #include "model.h"
 #include "internal_api/test_helpers.h"
+#include "internal_api/c_api_test_helpers.h"
 #include "internal_api/test_model_cache.h"
 
 #include <gtest/gtest.h>
@@ -430,6 +432,28 @@ class BlockingCancelSession : public Session {
   std::atomic<bool> in_flight_{false};
 };
 
+class NonChatPreflightSession final : public Session {
+ public:
+  NonChatPreflightSession(const Model& model, ILogger& logger, ITelemetry& telemetry)
+      : Session(model, logger, telemetry) {}
+
+  SessionType Type() const override { return SessionType::kAudio; }
+
+ protected:
+  void ProcessRequestImpl(const Request& /*request*/, Response& /*response*/) override {}
+};
+
+class RequestLockHoldingChatSession final : public ChatSession {
+ public:
+  using ChatSession::ChatSession;
+
+  void HoldRequestExecution(std::promise<void>& active, const std::shared_future<void>& release) const {
+    auto request_lock = LockRequestMutex();
+    active.set_value();
+    release.wait();
+  }
+};
+
 /// Spin until `pred` is true or the timeout elapses. Returns pred's final value.
 template <typename Pred>
 bool WaitUntil(Pred pred, std::chrono::milliseconds timeout) {
@@ -446,6 +470,61 @@ bool WaitUntil(Pred pred, std::chrono::milliseconds timeout) {
 }
 
 }  // namespace
+
+class SessionPreflightSynchronizationTest : public SessionManagerTest {};
+
+TEST_F(SessionPreflightSynchronizationTest, CaptureDoesNotWaitForActiveRequestExecution) {
+  RequestLockHoldingChatSession session(GetCatalogModel(), GetModel(), GetLogger(), null_telemetry_);
+  Request request;
+
+  std::promise<void> active_promise;
+  auto active = active_promise.get_future();
+  std::promise<void> release_promise;
+  auto release = release_promise.get_future().share();
+  auto execution = std::async(std::launch::async, [&] {
+    session.HoldRequestExecution(active_promise, release);
+  });
+
+  if (active.wait_for(std::chrono::seconds(1)) != std::future_status::ready) {
+    release_promise.set_value();
+    execution.wait();
+    FAIL() << "request execution did not acquire the session request lock";
+    return;
+  }
+
+  auto capture = std::async(std::launch::async, [&] {
+    return session.CaptureRequestPreflight(request);
+  });
+  const auto capture_status = capture.wait_for(std::chrono::milliseconds(250));
+
+  release_promise.set_value();
+  EXPECT_EQ(execution.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+  execution.get();
+
+  EXPECT_EQ(capture_status, std::future_status::ready)
+      << "production ChatSession::CaptureRequestPreflight waited for request_mutex_";
+  ASSERT_EQ(capture.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+  auto operation = capture.get();
+  EXPECT_NE(operation, nullptr);
+}
+
+TEST(SessionPreflightTest, PublicCAbiRejectsNonChatSessionAsInvalidUsage) {
+  fl::test::FakeServiceBindings svc;
+  Model catalog_model = Model::FromModelInfo(ModelInfo{}, "", svc.download_manager, svc.model_load_manager);
+  TelemetryLogger telemetry{"test", fl::test::NullLog()};
+  NonChatPreflightSession session(catalog_model, fl::test::NullLog(), telemetry);
+  Request request;
+  flRequestPreflight preflight{};
+  preflight.version = FOUNDRY_LOCAL_REQUEST_PREFLIGHT_MIN_VERSION;
+
+  const auto* api = fl::test::GetApi();
+  fl::test::StatusGuard status{
+      api->GetInferenceApi()->Session_PreflightRequest(
+          AsHandle<flSession>(&session), AsHandle<flRequest>(&request), &preflight),
+      api};
+  ASSERT_NE(status.s, nullptr);
+  EXPECT_EQ(api->Status_GetErrorCode(status.s), FOUNDRY_LOCAL_ERROR_INVALID_USAGE);
+}
 
 TEST(SessionManagerCancelTest, CancelAllCancelsInFlightRequestsOnEverySession) {
   fl::test::FakeServiceBindings svc;

--- a/sdk_v2/js/README.md
+++ b/sdk_v2/js/README.md
@@ -257,6 +257,38 @@ int main() {
 }
 ```
 
+`ChatSession.preflightRequest()` is asynchronous. Invocation captures immutable request/session state, including
+copies of inline media, before prompt rendering, URI I/O, media preprocessing, and tokenization run off-thread:
+
+```ts
+const budget = await session.preflightRequest(request);
+console.log({
+  promptTokens: budget.promptTokens,
+  outputReserveTokens: budget.outputReserveTokens,
+  requiredTokens: budget.requiredTokens,
+  contextLimitTokens: budget.contextLimitTokens,
+  fits: budget.fits,
+  deficitTokens: budget.deficitTokens,
+});
+
+// Preflight the final request again immediately before submitting it after
+// any mutation or context compaction.
+request.addItem(Item.userMessage("Keep the answer to one sentence."));
+const finalBudget = await session.preflightRequest(request);
+
+if (finalBudget.fits) {
+  const response = await session.processRequest(request);
+  // ...
+}
+```
+
+URI capture freezes the URI string, not its external content; worker-side read and preparation failures reject the
+promise. Mutating the request or session after invocation does not change the captured work.
+
+There is no server-side digest enforcement. Toolkit integrations should compact private context, rebuild the exact
+private `Request`, then use `await Promise.resolve(session.preflightRequest(request))` immediately before
+`processRequest()`. This transitional form supports older synchronous and current asynchronous implementations.
+
 Build it against:
 
 - Header: `sdk_v2/cpp/include/foundry_local_cpp.h`

--- a/sdk_v2/js/binding.gyp
+++ b/sdk_v2/js/binding.gyp
@@ -16,7 +16,8 @@
             ],
             "include_dirs": [
                 "<!@(node -p \"require('node-addon-api').include\")",
-                "../cpp/include"
+                "../cpp/include",
+                "../cpp/src"
             ],
             "defines": [
                 "NAPI_VERSION=8",

--- a/sdk_v2/js/native/src/session.cc
+++ b/sdk_v2/js/native/src/session.cc
@@ -6,6 +6,7 @@
 #include "errors.h"
 #include "items.h"
 #include "model.h"
+#include "node_private_api.h"
 #include "promise_worker.h"
 #include "request.h"
 #include "request_options.h"
@@ -67,9 +68,10 @@ void ThrowFoundryLocalError(Napi::Env env, int code, const std::string& msg) {
   err.ThrowAsJavaScriptException();
 }
 
-foundry_local::Request* UnwrapRequest(Napi::Env env, const Napi::Value& v) {
+foundry_local::Request* UnwrapRequest(Napi::Env env, const Napi::Value& v,
+                                      const char* method = "processRequest") {
   if (!v.IsObject()) {
-    Napi::TypeError::New(env, "processRequest(request): expected a Request instance")
+    Napi::TypeError::New(env, std::string(method) + "(request): expected a Request instance")
         .ThrowAsJavaScriptException();
     return nullptr;
   }
@@ -80,17 +82,55 @@ foundry_local::Request* UnwrapRequest(Napi::Env env, const Napi::Value& v) {
     return nullptr;
   }
   if (!obj.InstanceOf(data->request_ctor.Value())) {
-    Napi::TypeError::New(env, "processRequest(request): argument is not a Request instance")
+    Napi::TypeError::New(env, std::string(method) + "(request): argument is not a Request instance")
         .ThrowAsJavaScriptException();
     return nullptr;
   }
   Request* req = Napi::ObjectWrap<Request>::Unwrap(obj);
   if (req == nullptr || req->native() == nullptr) {
-    Napi::TypeError::New(env, "processRequest(request): Request is not initialized")
+    Napi::TypeError::New(env, std::string(method) + "(request): Request is not initialized")
         .ThrowAsJavaScriptException();
     return nullptr;
   }
   return req->native();
+}
+
+Napi::Value RequestPreflightToJs(Napi::Env env, const foundry_local::RequestPreflight& preflight) {
+  Napi::Object out = Napi::Object::New(env);
+  out.Set("promptTokens", Napi::Number::New(env, static_cast<double>(preflight.prompt_tokens)));
+  out.Set("outputReserveTokens",
+          Napi::Number::New(env, static_cast<double>(preflight.output_reserve_tokens)));
+  out.Set("requiredTokens", Napi::Number::New(env, static_cast<double>(preflight.required_tokens)));
+  out.Set("contextLimitTokens",
+          Napi::Number::New(env, static_cast<double>(preflight.context_limit_tokens)));
+  out.Set("fits", Napi::Boolean::New(env, preflight.fits));
+  out.Set("deficitTokens", Napi::Number::New(env, static_cast<double>(preflight.deficit_tokens)));
+  return out;
+}
+
+Napi::Value PreflightRequestOn(Napi::Env env, foundry_local::ChatSession* sess,
+                               const Napi::Value& request_arg,
+                               Napi::ObjectReference manager_ref) {
+  foundry_local::Request* req = UnwrapRequest(env, request_arg, "preflightRequest");
+  if (req == nullptr) return env.Undefined();  // pending exception
+
+  using Result = foundry_local::RequestPreflight;
+  using PrivatePreflight = foundry_local::detail::RequestPreflightOperation;
+  std::shared_ptr<PrivatePreflight> preflight;
+  CallCheckedVoid(env, [&]() {
+    preflight =
+        std::make_shared<PrivatePreflight>(foundry_local::detail::CaptureRequestPreflight(*sess, *req));
+  });
+  if (env.IsExceptionPending()) return env.Undefined();
+
+  // PromiseWorker stores a copyable std::function. Shared ownership keeps the private move-only RAII snapshot alive
+  // through worker execution, including after the JS session is disposed.
+  return PromiseWorker<Result>::Run(
+      env, [preflight = std::move(preflight)]() -> Result { return preflight->Execute(); },
+      [](Napi::Env env, Result& preflight) -> Napi::Value {
+        return RequestPreflightToJs(env, preflight);
+      },
+      std::move(manager_ref));
 }
 
 // Process a Request on the worker thread, converting to JS in the resolver.
@@ -291,6 +331,7 @@ Napi::Value ProcessStreamingRequestOn(Napi::Env env, SessT* sess, const Napi::Ca
 Napi::Function ChatSession::Init(Napi::Env env) {
   return DefineClass(env, "ChatSession",
                      {
+                         InstanceMethod("preflightRequest", &ChatSession::PreflightRequest),
                          InstanceMethod("processRequest", &ChatSession::ProcessRequest),
                          InstanceMethod("processStreamingRequest", &ChatSession::ProcessStreamingRequest),
                          InstanceMethod("setOptions", &ChatSession::SetOptions),
@@ -340,6 +381,17 @@ bool ChatSession::ThrowIfDisposed(Napi::Env env) {
     return true;
   }
   return false;
+}
+
+Napi::Value ChatSession::PreflightRequest(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (ThrowIfDisposed(env)) return env.Undefined();
+  if (info.Length() < 1) {
+    Napi::TypeError::New(env, "preflightRequest(request: Request)").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  Napi::ObjectReference owner = Napi::Reference<Napi::Object>::New(manager_.Value(), 1);
+  return PreflightRequestOn(env, impl_.get(), info[0], std::move(owner));
 }
 
 Napi::Value ChatSession::ProcessRequest(const Napi::CallbackInfo& info) {

--- a/sdk_v2/js/native/src/session.h
+++ b/sdk_v2/js/native/src/session.h
@@ -7,6 +7,7 @@
 //   * new ChatSession(model) — sync construction; underlying
 //     flSession_Create is fast.
 //   * session.processRequest(request) -> Promise<Response>  (PromiseWorker<Response>)
+//   * session.preflightRequest(request) -> Promise<RequestPreflight>
 //   * session.processStreamingRequest(request, onItem) -> Promise<Response> — streaming bridge via
 //     Napi::ThreadSafeFunction; resolves with the terminal Response after every item callback drains.
 //     The JS layer wraps this in an AsyncIterable whose `.response` promise carries the resolved value.
@@ -40,6 +41,7 @@ class ChatSession : public Napi::ObjectWrap<ChatSession> {
 
  private:
   Napi::Value ProcessRequest(const Napi::CallbackInfo& info);
+  Napi::Value PreflightRequest(const Napi::CallbackInfo& info);
   Napi::Value ProcessStreamingRequest(const Napi::CallbackInfo& info);
   Napi::Value SetOptions(const Napi::CallbackInfo& info);
   Napi::Value AddToolDefinition(const Napi::CallbackInfo& info);

--- a/sdk_v2/js/src/detail/native.ts
+++ b/sdk_v2/js/src/detail/native.ts
@@ -153,6 +153,20 @@ export interface NativeRequest {
   getItem(index: number): unknown;
 }
 
+/**
+ * Plain-object result returned by the asynchronous native request preflight
+ * check. Capture copies request/session state and inline bytes synchronously;
+ * its worker resolves URI-backed media and performs preparation.
+ */
+export interface NativeRequestPreflight {
+  promptTokens: number;
+  outputReserveTokens: number;
+  requiredTokens: number;
+  contextLimitTokens: number;
+  fits: boolean;
+  deficitTokens: number;
+}
+
 export interface NativeItemQueueCtor {
   new (): NativeItemQueue;
 }
@@ -175,6 +189,7 @@ export interface NativeSession {
 }
 
 export interface NativeChatSession extends NativeSession {
+  preflightRequest(request: NativeRequest): Promise<NativeRequestPreflight>;
   addToolDefinition(
     definition:
       | {

--- a/sdk_v2/js/src/index.ts
+++ b/sdk_v2/js/src/index.ts
@@ -58,6 +58,7 @@ export {
   type ToolKind,
   type StreamOptions,
   type StreamingResponse,
+  type RequestPreflight,
 } from "./session.js";
 export { Request, type RequestOptions, type RequestToolChoice, type SearchOptions } from "./request.js";
 export type { Response, FinishReason, TokenUsage } from "./response.js";

--- a/sdk_v2/js/src/session.ts
+++ b/sdk_v2/js/src/session.ts
@@ -60,6 +60,33 @@ function rejectEmbeddedNul(value: unknown, argumentName: string): void {
   }
 }
 
+/**
+ * Token-budget estimate for a chat request, computed without running generation or mutating session history.
+ * {@link ChatSession.preflightRequest} always returns a promise; request-preparation failures reject it.
+ */
+export interface RequestPreflight {
+  /** Tokens consumed by the fully rendered prompt. */
+  readonly promptTokens: number;
+  /**
+   * Tokens reserved for generated output.
+   *
+   * An explicit positive request limit is used when present. The current
+   * package schema exposes no distinct generation-default field, so an
+   * omitted limit uses the bounded server fallback: 2048 tokens for text and
+   * 3072 for media. If a positive package generation default becomes
+   * supported, it will take precedence over that fallback.
+   */
+  readonly outputReserveTokens: number;
+  /** Total prompt and output-reserve tokens required by the request. */
+  readonly requiredTokens: number;
+  /** Model context-window limit used for the estimate. */
+  readonly contextLimitTokens: number;
+  /** Whether the complete request fits in the available context window. */
+  readonly fits: boolean;
+  /** Additional tokens required when `fits` is false; otherwise zero. */
+  readonly deficitTokens: number;
+}
+
 function modelToNativeChatSession(model: IModel): NativeChatSession {
   if (!(model instanceof Model)) {
     throw new TypeError("ChatSession: expected a Model as the first argument");
@@ -364,6 +391,21 @@ export class ChatSession extends Session {
   // `ChatSession` always constructs a `NativeChatSession`.
   get #nativeChat(): NativeChatSession {
     return this.native as NativeChatSession;
+  }
+
+  /**
+   * Estimate the context-window budget without generation or history mutation.
+   *
+   * Invocation synchronously captures immutable request and chat-session state, including copies of inline media.
+   * Prompt rendering, tokenization, URI reads, and media preprocessing run on a worker thread. URI strings are
+   * captured, but their external content is read later and is not transactionally frozen.
+   *
+   * After request mutation or context compaction, rebuild and preflight the exact request again immediately before
+   * submission. The server does not enforce a preflight identity.
+   */
+  async preflightRequest(request: Request): Promise<RequestPreflight> {
+    const nativeReq = unwrapNativeRequest(request);
+    return await this.#nativeChat.preflightRequest(nativeReq);
   }
 
   /**

--- a/sdk_v2/js/test/chat-session.test.ts
+++ b/sdk_v2/js/test/chat-session.test.ts
@@ -1,11 +1,17 @@
 // Non-streaming ChatSession tests against a real loaded chat model.
 // Gated by FOUNDRY_TEST_DATA_DIR. Streaming + AbortSignal coverage lives in
 // streaming.test.ts.
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+
+import { ItemQueue } from "../src/item-queue.js";
 import { Item } from "../src/items.js";
 import { Request } from "../src/request.js";
-import { ChatSession, Session } from "../src/session.js";
+import type { RequestPreflight } from "../src/session.js";
+import { ChatSession } from "../src/session.js";
 
 function extractText(item: Item): string {
   if (item.type === "text") return item.text;
@@ -61,6 +67,169 @@ describe.skipIf(!haveTestModelCache)("ChatSession (real model, non-streaming)", 
   });
 
   it(
+    "preflightRequest() returns a stable budget without changing conversation history",
+    async () => {
+      if (session === undefined) throw new Error("fixture missing");
+      const req = new Request()
+        .addItem(Item.systemMessage("You are concise."))
+        .addItem(Item.userMessage("Capital of France?"))
+        .setOptions({ search: { maxOutputTokens: 32, temperature: 0 } });
+      const turnsBefore = session.turnCount;
+
+      const result = await session.preflightRequest(req);
+      const repeated = await session.preflightRequest(req);
+
+      expect(result).toEqual(repeated);
+      expect(session.turnCount).toBe(turnsBefore);
+      expect(Number.isInteger(result.promptTokens)).toBe(true);
+      expect(result.promptTokens).toBeGreaterThan(0);
+      expect(Number.isInteger(result.outputReserveTokens)).toBe(true);
+      expect(result.outputReserveTokens).toBe(32);
+      expect(result.requiredTokens).toBe(result.promptTokens + result.outputReserveTokens);
+      expect(result.contextLimitTokens).toBeGreaterThan(0);
+      expect(result.deficitTokens).toBeGreaterThanOrEqual(0);
+      expect(result.fits).toBe(result.deficitTokens === 0);
+      expect(Object.keys(result).sort()).toEqual([
+        "contextLimitTokens",
+        "deficitTokens",
+        "fits",
+        "outputReserveTokens",
+        "promptTokens",
+        "requiredTokens",
+      ]);
+    },
+    2 * 60_000,
+  );
+
+  it(
+    "preflightRequest() isolates in-flight work from later request and chat-session mutations",
+    async () => {
+      if (session === undefined) throw new Error("fixture missing");
+      let settled = false;
+      const request = new Request()
+        .addItem(Item.userMessage("Count the tokens in this request."))
+        .setOptions({ search: { maxOutputTokens: 8, temperature: 0 } });
+      const pending = session.preflightRequest(request);
+      pending.finally(() => {
+        settled = true;
+      });
+
+      request
+        .addItem(
+          Item.userMessage(
+            "This deliberately longer follow-up is added only after the first invocation and must increase the next count.",
+          ),
+        )
+        .setOptions({ search: { maxOutputTokens: 17, temperature: 0 } });
+      session.setOptions({ search: { temperature: 0.25 } }).addToolDefinition({
+        name: "snapshot_state_probe",
+        description: "A deterministic tool definition added only after the first preflight invocation.",
+        jsonSchema: JSON.stringify({
+          type: "object",
+          properties: {
+            value: { type: "string", description: "A value used to verify snapshot isolation." },
+          },
+          required: ["value"],
+        }),
+      });
+
+      expect(pending).toBeInstanceOf(Promise);
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      const original = await pending;
+      const mutated = await session.preflightRequest(request);
+
+      expect(original.outputReserveTokens).toBe(8);
+      expect(mutated.outputReserveTokens).toBe(17);
+      expect(mutated.promptTokens).toBeGreaterThan(original.promptTokens);
+    },
+    2 * 60_000,
+  );
+
+  it(
+    "preflightRequest() rejects asynchronously when the request cannot be preflighted",
+    async () => {
+      if (session === undefined) throw new Error("fixture missing");
+      using queue = new ItemQueue();
+      queue.push(Item.text("queued input cannot be preflighted"));
+      const request = new Request().addItem(queue);
+      const activeSession = session;
+
+      let pending: Promise<RequestPreflight> | undefined;
+      expect(() => {
+        pending = activeSession.preflightRequest(request);
+      }).not.toThrow();
+
+      expect(pending).toBeInstanceOf(Promise);
+      if (pending === undefined) throw new Error("preflightRequest did not return");
+      await expect(pending).rejects.toMatchObject({
+        name: "FoundryLocalError",
+      });
+      expect(queue.size).toBe(1);
+    },
+    2 * 60_000,
+  );
+
+  it(
+    "preflightRequest() reads URI content asynchronously and reports failures",
+    async ({ skip }) => {
+      if (fixture === undefined) throw new Error("fixture missing");
+      const visionModel = (await fixture.catalog.getModels()).find(
+        (model) => model.info.task === "vision-language-chat" && model.isCached,
+      );
+      if (visionModel === undefined) {
+        skip("URI preflight requires a cached vision-language-chat model");
+        return;
+      }
+      await visionModel.load();
+      using visionSession = new ChatSession(visionModel);
+      const missingImage = join(tmpdir(), `foundry-local-js-preflight-missing-${process.pid}-${Date.now()}.png`);
+      rmSync(missingImage, { force: true });
+      const request = new Request().addItem(
+        Item.userMessage([Item.text("Describe this image."), Item.imageFromUri(missingImage, "png")]),
+      );
+
+      let pending: Promise<RequestPreflight> | undefined;
+      expect(() => {
+        pending = visionSession.preflightRequest(request);
+      }).not.toThrow();
+
+      expect(pending).toBeInstanceOf(Promise);
+      if (pending === undefined) throw new Error("preflightRequest did not return");
+      try {
+        await pending;
+        throw new Error("preflightRequest unexpectedly succeeded");
+      } catch (error) {
+        expect(error).toMatchObject({ name: "FoundryLocalError" });
+        expect(error).toBeInstanceOf(Error);
+        if (!(error instanceof Error)) throw error;
+        expect(error.message).toMatch(/open image file/i);
+      }
+    },
+    2 * 60_000,
+  );
+
+  it(
+    "preflightRequest() completes after its session is disposed",
+    async () => {
+      if (fixture === undefined) throw new Error("fixture missing");
+      const oneShot = new ChatSession(fixture.model);
+      const request = new Request()
+        .addItem(Item.userMessage("Count the tokens in this request."))
+        .setOptions({ search: { maxOutputTokens: 8 } });
+
+      const pending = oneShot.preflightRequest(request);
+      oneShot.dispose();
+
+      expect(oneShot.disposed).toBe(true);
+      await expect(pending).resolves.toMatchObject({
+        outputReserveTokens: 8,
+      });
+    },
+    2 * 60_000,
+  );
+
+  it(
     "processRequest() resolves with a Response that contains at least one output item",
     async () => {
       if (session === undefined) throw new Error("fixture missing");
@@ -110,12 +279,13 @@ describe.skipIf(!haveTestModelCache)("ChatSession (real model, non-streaming)", 
     2 * 60_000,
   );
 
-  it("dispose() flips the disposed flag and is idempotent", () => {
+  it("dispose() flips the disposed flag and is idempotent", async () => {
     if (fixture === undefined) throw new Error("fixture missing");
     const oneShot = new ChatSession(fixture.model);
     expect(oneShot.disposed).toBe(false);
     oneShot.dispose();
     expect(oneShot.disposed).toBe(true);
+    await expect(oneShot.preflightRequest(new Request())).rejects.toThrow(/disposed/);
     expect(() => oneShot.dispose()).not.toThrow();
   });
 });
@@ -195,5 +365,19 @@ describe("ChatSession constructor type guard", () => {
   it("throws TypeError when constructed with a non-Model argument", () => {
     expect(() => new ChatSession({} as never)).toThrow(TypeError);
     expect(() => new ChatSession({} as never)).toThrow(/Model/);
+  });
+});
+
+describe("ChatSession.preflightRequest types", () => {
+  it("exposes the asynchronous, strongly typed public result", () => {
+    expectTypeOf<ChatSession["preflightRequest"]>().returns.toEqualTypeOf<Promise<RequestPreflight>>();
+    expectTypeOf<RequestPreflight>().toEqualTypeOf<{
+      readonly promptTokens: number;
+      readonly outputReserveTokens: number;
+      readonly requiredTokens: number;
+      readonly contextLimitTokens: number;
+      readonly fits: boolean;
+      readonly deficitTokens: number;
+    }>();
   });
 });


### PR DESCRIPTION
## Summary

- Add an exact request preflight API for chat requests in C, C++, and JavaScript.
- Report prompt tokens, reserved output tokens, required tokens, the model context limit, whether the request fits, and the token deficit.
- Use the same prompt rendering, tools, tokenizer, and output limit resolution as generation.
- Keep the public Foundry Local API at version 2 for the next minor release.
- Run JavaScript preflight asynchronously without blocking the extension host.
- Capture request and session state before asynchronous work so later mutations do not change the result.
- Keep URI file access, media preparation, prompt rendering, and tokenization off the JavaScript thread.
- Use `model.context_length` as the context limit, with the existing legacy fallback.
- Apply bounded output defaults when clients omit a limit: 2,048 tokens for text and 3,072 tokens for media.

## Why

Toolkit needs an exact token count before generation so it can compact long coding conversations and retry safely.

The same budget checks also prevent oversized requests and unbounded output when clients such as GitHub Copilot BYOK omit an output limit.